### PR TITLE
 feat(CrazyGames): add presence for new site

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,7 +154,7 @@ A list of fields and their rules are listed below:
 
 ### **`description`**
 
-- **All** activities are **required** to have an English description regardless of the website's prefered language.
+- **All** activities are **required** to have an English description regardless of the website's preferred language.
 - Do **not** try and translate the description yourself unless you know that language, translators will modify your `metadata.json` and change the descriptions if necessary.
 
 ### **`url`**
@@ -225,7 +225,7 @@ Here is a list of rules you must follow when writing your `presence.ts` file:
 - **Always** use `document.location` to get current location information rather than `window.location` or `location`.
 - All assets **must** have a resolution of `512x512` pixels. You can upsize it using a tool like [waifu2x](http://waifu2x.udp.jp/).
 - **Never** use custom functions when [native variants are available](https://docs.premid.app/dev/presence#files-explained); this makes sure fixes on the extension level also apply to your activities. You're free to use whatever you need if you do not find them listed in the docs.
-- It is **forbidden** to code activities for a site without adding support to its primary language (for e.g., a YouTube activity coded with support only for Portueguese and Japanese, but not English itself.)
+- It is **forbidden** to code activities for a site without adding support to its primary language (for e.g., a YouTube activity coded with support only for Portuguese and Japanese, but not English itself.)
 - The `smallImageKey` and `smallImageText` fields are intended to provide additional/secondary context (such as `playing/paused` for video sites, `browsing` for regular sites, and other cases) not to promote Discord profiles or anything unrelated to PreMiD.
 - When accessing cookies for stored data, please prefix the key with `PMD_`.
 - You may only make HTTP/HTTPS requests to `premid.app` or the activity website API. If you are using external domains, you will be required to explain why it is necessary. The only allowed API to make requests is the [`Fetch API`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -3,7 +3,7 @@
 
 ## Acknowledgements
 - [ ] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
-- [ ] I linted the code by running `yarn format`
+- [ ] I linted the code by running `npm run lint`
 - [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
 
 ## Screenshots

--- a/websites/C/CrazyGames/metadata.json
+++ b/websites/C/CrazyGames/metadata.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "1348276520342257797",
+    "name": "Seth_CrazyGames"
+  },
+  "service": "CrazyGames",
+  "altnames": [
+    "1001juegos",
+    "1001 juegos"
+  ],
+  "description": {
+    "ar": "العب ألعاب إنترنت مجانية على كريزي جيمز، المكان الأفضل للعب ألعاب متصفح عالية الجودة. نقوم بإضافة ألعاب جديدة يوميًا. استمتع!",
+    "cs": "Zahrajte si zdarma online hry na CrazyGames, cože je to nejlepší místo pro hraní vysoce kvalitních her v prohlížeči. Každý den přidáváme nové hry. Bavte se!",
+    "da": "Spil gratis online spil på CrazyGames, det bedste sted at spille browserspil af høj kvalitet på! Vi tilføjer nye spil hver dag. Hav det sjovt!",
+    "de": "Spiele kostenlose online Spiele auf CrazyGames, der beste Ort um hochqualitative Browserspiele zu spielen. Wir fügen täglich neue Spiele hinzu. Viel Spaß!",
+    "el": "Παίξε δωρεάν online παιχνίδια στο CrazyGames, το καλύτερο μέρος για να παίξεις παιχνίδια υψηλής ποιότητας στον περιηγητή σας. Προσθέτουμε νέα παιχνίδια κάθε μέρα. Καλά να περάσεις!",
+    "en": "Play free online games at CrazyGames, the best place to play high-quality browser games. We add new games every day. Have fun!",
+    "es": "Juega a juegos gratis en línea en 1001 Juegos, el mejor sitio para jugar a juegos de navegador de calidad. Añadimos juegos nuevos cada día. ¡Que te diviertas!",
+    "fi": "Pelaa ilmaisia online-pelejä CrazyGamesillä, paras paikka pelata korkealaatuisia selainpelejä. Lisäämme uusia pelejä joka päivä. Pidä hauskaa!",
+    "fr": "Joue gratuitement en ligne sur CrazyGames, le meilleur endroit pour trouver des jeux sur navigateur de haute qualité. Nous ajoutons de nouveaux jeux tous les jours. Amuse-toi bien !",
+    "hu": "Játsz ingyenes online játékokat CrazyGames-en, a legkirályabb böngészős játékok tárházában. Minden nap új játékok kerülnek fel az oldalra! Jó szórakozást!",
+    "id": "Mainkan game online gratis di CrazyGames, tempat terbaik untuk bermain game peramban berkualitas tinggi. Ada game baru setiap harinya. Selamat bermain!",
+    "it": "Gioca giochi gratis su CrazyGames.com, il posto migliore per giocare i migliori giochi nel browser! Aggiungiamo tutti i giorni nuovi giochi!",
+    "ko": "고품질 브라우저 게임을 플레이하기에 최고의 플랫폼인 CrazyGames에서 무료 온라인 게임을 플레이하세요. 매일 새로운 게임이 추가됩니다. 즐겨보세요!",
+    "nl": "Speel de beste gratis online spelletjes op CrazyGames. Hier vind je duizenden games voor je computer, smartphone, of tablet! Speel je favoriete spellen gewoon meteen, zonder download of installatie.",
+    "pl": "Graj w darmowe gry online na CrazyGames, najlepszym miejscu do grania w wysokiej jakości gry przeglądarkowe. Codziennie dodajemy nowe gry. Baw się dobrze!",
+    "pt": "Com 5000+ Jogos Online Gratuitos, a CrazyGames é o Melhor Lugar Para Jogar Instantaneamente Sozinho ou com Seus Amigos, Sem Downloads e com Todos os Seus Dispositivos",
+    "ro": "Joacă jocuri online gratuite pe CrazyGames, cel mai bun loc pentru a juca jocuri browser de înaltă calitate. Adăugăm jocuri noi în fiecare zi. Distracție plăcută!",
+    "ru": "Играйте в бесплатные онлайн-игры на CrazyGames, лучшее место с качественными браузерными играми. Мы добавляем новые игры каждый день. Развлекайтесь!",
+    "sv": "Spela gratis onlinespel hos CrazyGames, sidan som har dom bästa webbläsarspelen. Vi lägger till nya spel varje dag. Ha så kul!",
+    "th": "เล่นเกมส์ออนไลน์ฟรีได้ที่ CrazyGames เว็บไซต์สำหรับเกมส์บนบราวเซอร์ที่ดีที่สุด เรามีเกมส์ใหม่ทุกวัน ขอให้ทุกคนสนุกกับการเล่นเกมส์!",
+    "tr": "Yüksek kaliteli tarayıcı oyunları oynamak için en iyi yer olan CrazyGames'te ücretsiz çevrimiçi oyunlar oynayın. Her gün yeni oyunlar ekliyoruz. İyi eğlenceler!",
+    "uk": "Грайте у безкоштовні онлайн ігри на CrazyGames, найкраще місце для гри у якісні браузерні ігри. Ми додаємо нові ігри щодня. Насолоджуйся!",
+    "vi": "Chơi các trò chơi trực tuyến miễn phí tại CrazyGames, nơi tốt nhất để chơi các trò chơi trên trình duyệt chất lượng cao. Chúng tôi thêm các trò chơi mới mỗi ngày. Chúc bạn chơi vui vẻ!"
+  },
+  "url": [
+    "www.crazygames.com",
+    "www.crazygames.nl",
+    "it.crazygames.com",
+    "www.1001juegos.com",
+    "www.crazygames.co.id",
+    "www.crazygames.fr",
+    "www.crazygames.com.br",
+    "www.crazygames.ru",
+    "www.crazygames.com.ua",
+    "www.crazygames.no",
+    "www.crazygames.ro",
+    "www.crazygames.fi",
+    "www.crazygames.se",
+    "de.crazygames.com",
+    "www.crazygames.pl",
+    "gr.crazygames.com",
+    "www.crazygames.cz",
+    "www.crazygames.hu",
+    "ar.crazygames.com",
+    "vn.crazygames.com",
+    "th.crazygames.com",
+    "www.crazygames.co.kr"
+  ],
+  "version": "1.0.0",
+  "logo": "https://cloud.falco.fun/s/G9ojdWxsnSRWyeZ/download/logo-v2.png",
+  "thumbnail": "https://cloud.falco.fun/s/a5DTpssyT7swyCi/download/thumbnail-v2.png",
+  "color": "#6842ff",
+  "category": "games",
+  "tags": [
+    "game"
+  ]
+}

--- a/websites/C/CrazyGames/presence.ts
+++ b/websites/C/CrazyGames/presence.ts
@@ -1,0 +1,61 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  clientId: '1348290237381611601',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://cloud.falco.fun/s/G9ojdWxsnSRWyeZ/download/logo-v2.png',
+}
+
+presence.on('UpdateData', async () => {
+  const strings = await presence.getStrings({
+    browsing: 'general.browsing',
+    buttonViewGame: 'general.buttonViewGame',
+  })
+
+  const presenceData: PresenceData = {
+    name: 'CrazyGames',
+    type: ActivityType.Playing,
+    details: strings.browsing,
+    startTimestamp: browsingTimestamp,
+    largeImageKey: ActivityAssets.Logo,
+  }
+
+  const englishUrl = document.querySelector('link[hreflang=en]')?.getAttribute('href')
+
+  if (englishUrl) {
+    const pathname = new URL(englishUrl).pathname
+
+    if (pathname.startsWith('/game/')) {
+      const name = document.querySelector('meta[name=apple-mobile-web-app-title]')?.getAttribute('content')
+      const thumbnail = document.querySelector('meta[property="og:image"')?.getAttribute('content')
+
+      if (name) {
+        presenceData.details = name
+        presenceData.buttons = [
+          {
+            label: strings.buttonViewGame,
+            url: document.location.href,
+          },
+        ]
+
+        if (thumbnail) {
+          const squareThumbnailUrl = thumbnail.replaceAll('16x9', '1x1')
+          const squareThumbnailResponse = await fetch(new URL('?width=1', squareThumbnailUrl))
+          const mobileThumbnailAvailable = squareThumbnailResponse.ok
+
+          const thumbnailUrl = mobileThumbnailAvailable
+            ? new URL('?width=512&', squareThumbnailUrl)
+            : new URL('?width=512&height=512&fit=crop', thumbnail)
+          presenceData.largeImageKey = thumbnailUrl.toString()
+          presenceData.smallImageKey = ActivityAssets.Logo
+          presenceData.smallImageText = 'CrazyGames'
+        }
+      }
+    }
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Adds support for CrazyGames.com and all locale variants of it.

This has 2 types of statuses:

* Browsing… - When on the site but not playing a game.
* Playing - When actually playing a game.

### Chores

I also did two chores on the side:

* Fixed typos in CONTRIBUTING.md
* This project uses npm, not Yarn. Amends the pull request template to lint with npm!

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

https://github.com/user-attachments/assets/f5e3bdbe-921e-4540-959a-2636cecbfda0

</details>

## Notes for Maintainers

* All of the descriptions come from the `meta[description]` tag of the site in each language.
* The `fetch` call that's done is to check if a mobile optimized (square) version of the games thumbnail is available, if so we prefer that over the desktop (rectangle) varient.
* Rather than handle the `pathname` from `document.location`, we get the English name of the resource, then parse that URL. This keeps the logic consistent across the site in all languages.
* The links to `cloud.falco.fun` are temporary! We can ofc replace them with either Imgur or CDN links before this is merged.

## Open Questions

### UI/UX

I tried to make the presence data as similar as possible to other activities in the store. However, I think it would be better if the data was presented like the following.

This brings the focus more on the game rather than the platform, but still attributes the platform in the details section. What do you think?

![](https://github.com/user-attachments/assets/1cc12db4-2d02-4187-b3d7-c071edfda2dc)

### Languages

While working on this, I encountered the following build failure:

>  Language nb is not a valid language 

It is a valid language!

> Norwegian Bokmål
> 
> — https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes#nb

I've opted to remove this language key as I see pmd is not using a localization library, but rather comparing to the list of locales from your API. Would you have any qualms with rewording the error to something like:

> Language nb is not a supported language

Which makes clear it's not stating the language code doesn't exist, but rather PreMiD doesn't support this language, so the key is unnecessary?

### CDN

Currently, your contribution guide suggests using Imgur. However, I think it would make more sense to use Discord itself as the CDN so we don't have to upload assets across more third-party platforms.

![](https://github.com/user-attachments/assets/da72c9c0-eaee-4d45-89ae-1da4139ce2b4)

Under **Rich Presence Assets**, one can upload an asset and we can use that CDN URL instead. Ideally, this asset will remain for as long as the app and Discord itself is around.

> ![](https://cdn.discordapp.com/app-assets/1348290237381611601/1351101516433588244.png)
> 
> — https://cdn.discordapp.com/app-assets/1348290237381611601/1351101516433588244.png

May I propose that you allow CDN URLs from Discord?

If this is allowed, the regex in the JSON Schema for asset URLs will have to allow query parameters.

## TODO

Before merging, the `cloud.falco.fun` links should be replaced with acceptable URLs. I've just left them like this for now while everything else gets reviewed. Was just hoping for an answer to my questions first!