### PR TITLE
chore: upgrade inquirer dependency

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "pmd",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pmd",
-      "version": "0.0.1",
+      "version": "2.0.0",
       "bin": {
         "pmd": "dist/index.js"
       },
       "devDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
+        "@inquirer/prompts": "^7.3.3",
         "@types/adm-zip": "^0.5.7",
         "@types/discord-rpc": "^4.0.9",
         "@types/got": "^9.6.12",
@@ -31,12 +32,9 @@
         "gitdiff-parser": "^0.3.1",
         "globby": "^14.1.0",
         "got": "^14.4.6",
-        "inquirer": "^12.4.2",
-        "inquirer-autocomplete-standalone": "^0.8.1",
         "is-ci": "^4.1.0",
         "json-to-ast": "^2.1.0",
         "jsonschema": "^1.5.0",
-        "mongodb": "^6.14.2",
         "multimatch": "^7.0.0",
         "ora": "^8.2.0",
         "semver": "^7.7.1",
@@ -999,15 +997,15 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.2.tgz",
-      "integrity": "sha512-PL9ixC5YsPXzXhAZFUPmkXGxfgjkdfZdPEPPmt4kFwQ4LBMDG9n/nHXYRGGZSKZJs+d1sGKWgS2GiPzVRKUdtQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.3.tgz",
+      "integrity": "sha512-KU1MGwf24iABJjGESxhyj+/rlQYSRoCfcuHDEHXfZ1DENmbuSRfyrUb+LLjHoee5TNOFKwaFxDXc5/zRwJUPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1024,14 +1022,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.6.tgz",
-      "integrity": "sha512-6ZXYK3M1XmaVBZX6FCfChgtponnL0R6I7k8Nu+kaoNkT828FVZTcca1MqmWQipaW2oNREQl5AaPCUOOCVNdRMw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.7.tgz",
+      "integrity": "sha512-Xrfbrw9eSiHb+GsesO8TQIeHSMTP0xyvTCeeYevgZ4sKW+iz9w/47bgfG9b0niQm+xaLY2EWPBINUPldLwvYiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -1046,14 +1044,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.7.tgz",
-      "integrity": "sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.8.tgz",
+      "integrity": "sha512-HpAqR8y715zPpM9e/9Q+N88bnGwqqL8ePgZ0SMv/s3673JLMv3bIkoivGmjPqXlEgisUksSXibweQccUwEx4qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -1074,14 +1072,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.7.tgz",
-      "integrity": "sha512-gktCSQtnSZHaBytkJKMKEuswSk2cDBuXX5rxGFv306mwHfBPjg5UAldw9zWGoEyvA9KpRDkeM4jfrx0rXn0GyA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.8.tgz",
+      "integrity": "sha512-UkGKbMFlQw5k4ZLjDwEi5z8NIVlP/3DAlLHta0o0pSsdpPThNmPtUL8mvGCHUaQtR+QrxR9yRYNWgKMsHkfIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -1097,14 +1095,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.9.tgz",
-      "integrity": "sha512-Xxt6nhomWTAmuSX61kVgglLjMEFGa+7+F6UUtdEUeg7fg4r9vaFttUUKrtkViYYrQBA5Ia1tkOJj2koP9BuLig==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.10.tgz",
+      "integrity": "sha512-leyBouGJ77ggv51Jb/OJmLGGnU2HYc13MZ2iiPNLwe2VgFgZPVqsrRWSa1RAHKyazjOyvSNKLD1B2K7A/iWi1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1120,9 +1118,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
-      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1130,14 +1128,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.6.tgz",
-      "integrity": "sha512-1f5AIsZuVjPT4ecA8AwaxDFNHny/tSershP/cTvTDxLdiIGTeILNcKozB0LaYt6mojJLUbOYhpIxicaYf7UKIQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.7.tgz",
+      "integrity": "sha512-rCQAipJNA14UTH84df/z4jDJ9LZ54H6zzuCAi7WZ0qVqx3CSqLjfXAMd5cpISIxbiHVJCPRB81gZksq6CZsqDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -1152,14 +1150,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.9.tgz",
-      "integrity": "sha512-iN2xZvH3tyIYXLXBvlVh0npk1q/aVuKXZo5hj+K3W3D4ngAEq/DkLpofRzx6oebTUhBvOgryZ+rMV0yImKnG3w==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.10.tgz",
+      "integrity": "sha512-GLsdnxzNefjCJUmWyjaAuNklHgDpCTL4RMllAVhVvAzBwRW9g38eZ5tWgzo1lirtSDTpsh593hqXVhxvdrjfwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -1174,14 +1172,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.9.tgz",
-      "integrity": "sha512-xBEoOw1XKb0rIN208YU7wM7oJEHhIYkfG7LpTJAEW913GZeaoQerzf5U/LSHI45EVvjAdgNXmXgH51cUXKZcJQ==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.10.tgz",
+      "integrity": "sha512-JC538ujqeYKkFqLoWZ0ILBteIUO2yajBMVEUZSxjl9x6fiEQtM+I5Rca7M2D8edMDbyHLnXifGH1hJZdh8V5rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -1197,22 +1195,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
-      "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.3.tgz",
+      "integrity": "sha512-QS1AQgJ113iE/nmym03yKZKHvGjVWwkGZT3B1yKrrMG0bJKQg1jUkntFP8aPd2FUQzu/nga7QU2eDpzIP5it0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.2",
-        "@inquirer/confirm": "^5.1.6",
-        "@inquirer/editor": "^4.2.7",
-        "@inquirer/expand": "^4.0.9",
-        "@inquirer/input": "^4.1.6",
-        "@inquirer/number": "^3.0.9",
-        "@inquirer/password": "^4.0.9",
-        "@inquirer/rawlist": "^4.0.9",
-        "@inquirer/search": "^3.0.9",
-        "@inquirer/select": "^4.0.9"
+        "@inquirer/checkbox": "^4.1.3",
+        "@inquirer/confirm": "^5.1.7",
+        "@inquirer/editor": "^4.2.8",
+        "@inquirer/expand": "^4.0.10",
+        "@inquirer/input": "^4.1.7",
+        "@inquirer/number": "^3.0.10",
+        "@inquirer/password": "^4.0.10",
+        "@inquirer/rawlist": "^4.0.10",
+        "@inquirer/search": "^3.0.10",
+        "@inquirer/select": "^4.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -1227,14 +1225,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.9.tgz",
-      "integrity": "sha512-+5t6ebehKqgoxV8fXwE49HkSF2Rc9ijNiVGEQZwvbMI61/Q5RcD+jWD6Gs1tKdz5lkI8GRBL31iO0HjGK1bv+A==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.10.tgz",
+      "integrity": "sha512-vOQbQkmhaCsF2bUmjoyRSZJBz77UnIF/F3ZS2LMgwbgyaG2WgwKHh0WKNj0APDB72WDbZijhW5nObQbk+TnbcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1250,15 +1248,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.9.tgz",
-      "integrity": "sha512-DWmKztkYo9CvldGBaRMr0ETUHgR86zE6sPDVOHsqz4ISe9o1LuiWfgJk+2r75acFclA93J/lqzhT0dTjCzHuoA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.10.tgz",
+      "integrity": "sha512-EAVKAz6P1LajZOdoL+R+XC3HJYSU261fbJzO4fCkJJ7UPFcm+nP+gzC+DDZWsb2WK9PQvKsnaKiNKsY8B6dBWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1274,15 +1272,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.9.tgz",
-      "integrity": "sha512-BpJyJe7Dkhv2kz7yG7bPSbJLQuu/rqyNlF1CfiiFeFwouegfH+zh13KDyt6+d9DwucKo7hqM3wKLLyJxZMO+Xg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.10.tgz",
+      "integrity": "sha512-Tg8S9nESnCfISu5tCZSuXpXq0wHuDVimj7xyHstABgR34zcJnLdq/VbjB2mdZvNAMAehYBnNzSjxB06UE8LLAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1299,9 +1297,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
-      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1451,16 +1449,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mongodb-js/saslprep": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
-      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2080,16 +2068,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.1.tgz",
-      "integrity": "sha512-0yQLzYhCqGz7CQPE3iDmYjhb7KMBFOP+tBkyw+/Y2YyDI5wpS7itXXxneN1zSsUwWx3Ji6YiVYrhAnpQGS/vkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
@@ -2111,30 +2089,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2473,16 +2427,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
       }
     },
     "node_modules/cac": {
@@ -2995,19 +2939,6 @@
         "@esbuild/win32-x64": "0.25.0"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3076,23 +3007,6 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -3470,180 +3384,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/inquirer": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.4.2.tgz",
-      "integrity": "sha512-reyjHcwyK2LObXgTJH4T1Dpfhwu88LNPTZmg/KenmTsy3T8lN/kZT8Oo7UwwkB9q8+ss2qjjN7GV8oFAfyz9Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/prompts": "^7.3.2",
-        "@inquirer/type": "^3.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^2.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-standalone/-/inquirer-autocomplete-standalone-0.8.1.tgz",
-      "integrity": "sha512-mlzwCTiXDX1Cw4yJL5PCq32k23XYLTK8K6BDFoL1a76iJeFB5ul6IoMU9spgdDagl2SM7P6ZaCNjj8VNXRDPOQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@inquirer/core": "^3.1.1",
-        "@inquirer/type": "^1.1.2",
-        "figures": "^5.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@inquirer/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-lR2GaqBkp42Ew9BOAOqf2pSp+ymVES1qN8OC90WWh45yeoYLl0Ty1GyCxmkKqBJtq/+Ea1MF12AdFcZcpRNFsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/type": "^1.1.2",
-        "@types/mute-stream": "^0.0.1",
-        "@types/node": "^20.4.8",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.0",
-        "cli-width": "^4.1.0",
-        "figures": "^3.2.0",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@inquirer/core/node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@types/node": {
-      "version": "20.17.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.19.tgz",
-      "integrity": "sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -3962,13 +3702,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4066,64 +3799,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mongodb": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.2.tgz",
-      "integrity": "sha512-kMEHNo0F3P6QKDq17zcDuPeaywK/YaJVCEQRzPF3TOM/Bl9MFg64YE5Tu7ifj37qZJMhwU1tl2Ioivws5gRG5Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mrmime": {
@@ -4588,16 +4263,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4620,16 +4285,6 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -4802,16 +4457,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/stackback": {
@@ -5116,7 +4761,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pmd",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "main": "dist/index.js",
   "bin": {
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
+    "@inquirer/prompts": "^7.3.3",
     "@types/adm-zip": "^0.5.7",
     "@types/discord-rpc": "^4.0.9",
     "@types/got": "^9.6.12",
@@ -36,8 +37,6 @@
     "gitdiff-parser": "^0.3.1",
     "globby": "^14.1.0",
     "got": "^14.4.6",
-    "inquirer": "^12.4.2",
-    "inquirer-autocomplete-standalone": "^0.8.1",
     "is-ci": "^4.1.0",
     "json-to-ast": "^2.1.0",
     "jsonschema": "^1.5.0",

--- a/cli/src/commands/bump.ts
+++ b/cli/src/commands/bump.ts
@@ -1,8 +1,8 @@
 import type { ActivityMetadataAndFolder } from '../util/getActivities.js'
 import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { select } from '@inquirer/prompts'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
 import { compare, inc, valid } from 'semver'
 import { getActivities, getChangedActivities } from '../util/getActivities.js'
 import { getSingleActivity } from '../util/getSingleActivity.js'
@@ -60,11 +60,9 @@ async function bumpActivity(activity: ActivityMetadataAndFolder, version?: strin
         inc(activity.metadata.version, 'major')!,
       ]
 
-      const { selectedVersion } = await inquirer.prompt({
-        type: 'select',
-        name: 'selectedVersion',
+      const selectedVersion = await select({
         message: `Please select a version to bump ${activity.metadata.service} to`,
-        choices: validVersions,
+        choices: validVersions.map(x => ({ name: x, value: x })),
       }).catch(() => exit('Something went wrong.'))
 
       if (!selectedVersion) {

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -3,8 +3,8 @@ import { cp, mkdir, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { confirm, input, select } from '@inquirer/prompts'
 import chalk from 'chalk'
-import inquirer from 'inquirer'
 import { Validator } from 'jsonschema'
 import { getDiscordUser, getDiscordUserById } from '../util/getDiscordUser.js'
 import { getFolderLetter } from '../util/getFolderLetter.js'
@@ -17,12 +17,7 @@ import { versionizeActivity } from './versionize.js'
 
 export async function newActivity(activity?: string) {
   if (!activity) {
-    ({ activity } = await inquirer.prompt({
-      type: 'input',
-      name: 'activity',
-      message: 'What is the name of the activity?',
-      validate: input => !!input,
-    }).catch(() => ({ activity: undefined })))
+    activity = await input({ message: 'What is the name of the activity?' }).catch(() => undefined)
   }
 
   if (!activity) {
@@ -34,18 +29,14 @@ export async function newActivity(activity?: string) {
   const path = resolve(process.cwd(), 'websites', folderLetter, sanitazedActivity)
 
   if (existsSync(path)) {
-    const { versionize } = await inquirer.prompt({
-      type: 'confirm',
-      name: 'versionize',
+    const versionize = await confirm({
       message: 'The activity already exists. Would you like to create a new api version for it?',
     })
 
     if (versionize)
       return versionizeActivity(activity)
 
-    const { develop } = await inquirer.prompt({
-      type: 'confirm',
-      name: 'develop',
+    const develop = await confirm({
       message: 'Would you like to develop the activity?',
     })
 
@@ -62,51 +53,45 @@ export async function newActivity(activity?: string) {
   const discordUser = await getDiscordUser()
   let author: { id: string, name: string } | undefined = discordUser ? { id: discordUser.id, name: discordUser.username! } : undefined
 
-  const { category, tags } = await inquirer.prompt([
-    {
-      name: 'author',
-      message: 'Discord ID of the author',
-      default: discordUser?.id,
-      type: 'input',
-      validate: async (input) => {
-        if (!input)
-          return 'Author cannot be empty!'
+  await input({
+    message: 'Discord ID of the author',
+    default: discordUser?.id,
+    validate: async (input) => {
+      if (!input)
+        return 'Author cannot be empty!'
 
-        const user = discordUser?.id === input ? discordUser : await getDiscordUserById(input)
+      const user = discordUser?.id === input ? discordUser : await getDiscordUserById(input)
 
-        if (!user)
-          return 'User not found.'
+      if (!user)
+        return 'User not found.'
 
-        author = { id: input, name: user.username! }
+      author = { id: input, name: user.username! }
 
-        return true
-      },
-      transformer: (input: string) => {
-        return author ? author.name : input
-      },
+      return true
     },
-    {
-      name: 'tags',
-      message: 'Tags of the Presence (separate multiple tags with a comma)',
-      type: 'input',
-      validate: (input: string) => {
-        if (!input)
-          return 'Tags cannot be empty!'
-
-        const schemaRes = v.validate(input.split(','), schema.properties.tags)
-
-        if (!schemaRes.valid)
-          return schemaRes.errors[0].message
-        return true
-      },
+    transformer: (input: string) => {
+      return author ? author.name : input
     },
-    {
-      name: 'category',
-      message: 'Category of the service',
-      type: 'list',
-      choices: schema.properties.category.enum,
+  }).catch(() => exit('Something went wrong.'))
+
+  const tags = await input({
+    message: 'Tags of the Presence (separate multiple tags with a comma)',
+    validate: (input: string) => {
+      if (!input)
+        return 'Tags cannot be empty!'
+
+      const schemaRes = v.validate(input.split(','), schema.properties.tags)
+
+      if (!schemaRes.valid)
+        return schemaRes.errors[0].message
+      return true
     },
-  ]).catch(() => exit('Something went wrong.'))
+  }).catch(() => exit('Something went wrong.'))
+
+  const category = await select<string>({
+    message: 'Category of the service',
+    choices: schema.properties.category.enum,
+  }).catch(() => exit('Something went wrong.'))
 
   const metadata = {
     $schema: 'https://schemas.premid.app/metadata/1.13',

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 #! /usr/bin/env node
 
+import process from 'node:process'
 import { cac } from 'cac'
 import { build } from './commands/build.js'
 import { bump } from './commands/bump.js'
@@ -62,3 +63,12 @@ cli.parse()
 if (!cli.matchedCommand && !cli.options.help && !cli.options.version) {
   cli.outputHelp()
 }
+
+process.on('uncaughtException', (error) => {
+  if (error instanceof Error && error.name === 'ExitPromptError') {
+    // Exit gracefully
+  }
+  else {
+    exit(error.message)
+  }
+})

--- a/cli/src/util/getSingleActivity.ts
+++ b/cli/src/util/getSingleActivity.ts
@@ -1,6 +1,6 @@
 import type { ActivityMetadata } from '../classes/ActivityCompiler.js'
 import type { ActivityMetadataAndFolder } from './getActivities.js'
-import autocomplete from 'inquirer-autocomplete-standalone'
+import { select } from '@inquirer/prompts'
 import { exit } from '../util/log.js'
 import { mapActivityToChoice } from '../util/mapActivityToChoice.js'
 import { getActivities } from './getActivities.js'
@@ -11,16 +11,9 @@ export async function getSingleActivity(searchMessage: string, service?: string)
   let folder: string
   let versionized: boolean
   if (!service) {
-    ({ metadata, folder, versionized } = await autocomplete<ActivityMetadataAndFolder>({
+    ({ metadata, folder, versionized } = await select({
       message: searchMessage,
-      source: async (input) => {
-        if (!input) {
-          return activities.map(activity => mapActivityToChoice(activity))
-        }
-        return activities
-          .filter(({ metadata }) => metadata.service.toLowerCase().includes(input.toLowerCase()))
-          .map(activity => mapActivityToChoice(activity))
-      },
+      choices: activities.map(activity => mapActivityToChoice(activity)),
     }))
   }
   else {
@@ -31,11 +24,9 @@ export async function getSingleActivity(searchMessage: string, service?: string)
     }
 
     if (sameServiceActivities.length > 1) {
-      ({ metadata, folder, versionized } = await autocomplete<ActivityMetadataAndFolder>({
+      ({ metadata, folder, versionized } = await select({
         message: searchMessage,
-        source: async () => {
-          return sameServiceActivities.map(activity => mapActivityToChoice(activity))
-        },
+        choices: sameServiceActivities.map(activity => mapActivityToChoice(activity)),
       }))
     }
     else {

--- a/cli/src/util/mapActivityToChoice.ts
+++ b/cli/src/util/mapActivityToChoice.ts
@@ -1,7 +1,6 @@
-import type { ChoiceOrSeparatorArray } from 'inquirer-autocomplete-standalone'
 import type { ActivityMetadataAndFolder } from './getActivities.js'
 
-export function mapActivityToChoice(activity: ActivityMetadataAndFolder): ChoiceOrSeparatorArray<ActivityMetadataAndFolder>[number] {
+export function mapActivityToChoice(activity: ActivityMetadataAndFolder) {
   return {
     value: activity,
     name: `${activity.metadata.service}${activity.versionized ? ` (APIv${activity.metadata.apiVersion})` : ''}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "cli": {
       "name": "pmd",
-      "version": "0.0.1",
+      "version": "2.1.0",
       "dev": true,
       "bin": {
         "pmd": "dist/index.js"
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
+        "@inquirer/prompts": "^7.3.3",
         "@types/adm-zip": "^0.5.7",
         "@types/discord-rpc": "^4.0.9",
         "@types/got": "^9.6.12",
@@ -52,12 +53,9 @@
         "gitdiff-parser": "^0.3.1",
         "globby": "^14.1.0",
         "got": "^14.4.6",
-        "inquirer": "^12.4.2",
-        "inquirer-autocomplete-standalone": "^0.8.1",
         "is-ci": "^4.1.0",
         "json-to-ast": "^2.1.0",
         "jsonschema": "^1.5.0",
-        "mongodb": "^6.14.2",
         "multimatch": "^7.0.0",
         "ora": "^8.2.0",
         "semver": "^7.7.1",
@@ -1555,15 +1553,15 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.2.tgz",
-      "integrity": "sha512-PL9ixC5YsPXzXhAZFUPmkXGxfgjkdfZdPEPPmt4kFwQ4LBMDG9n/nHXYRGGZSKZJs+d1sGKWgS2GiPzVRKUdtQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.3.tgz",
+      "integrity": "sha512-KU1MGwf24iABJjGESxhyj+/rlQYSRoCfcuHDEHXfZ1DENmbuSRfyrUb+LLjHoee5TNOFKwaFxDXc5/zRwJUPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1580,14 +1578,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.6.tgz",
-      "integrity": "sha512-6ZXYK3M1XmaVBZX6FCfChgtponnL0R6I7k8Nu+kaoNkT828FVZTcca1MqmWQipaW2oNREQl5AaPCUOOCVNdRMw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.7.tgz",
+      "integrity": "sha512-Xrfbrw9eSiHb+GsesO8TQIeHSMTP0xyvTCeeYevgZ4sKW+iz9w/47bgfG9b0niQm+xaLY2EWPBINUPldLwvYiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -1602,14 +1600,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.7.tgz",
-      "integrity": "sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.8.tgz",
+      "integrity": "sha512-HpAqR8y715zPpM9e/9Q+N88bnGwqqL8ePgZ0SMv/s3673JLMv3bIkoivGmjPqXlEgisUksSXibweQccUwEx4qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -1630,14 +1628,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.7.tgz",
-      "integrity": "sha512-gktCSQtnSZHaBytkJKMKEuswSk2cDBuXX5rxGFv306mwHfBPjg5UAldw9zWGoEyvA9KpRDkeM4jfrx0rXn0GyA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.8.tgz",
+      "integrity": "sha512-UkGKbMFlQw5k4ZLjDwEi5z8NIVlP/3DAlLHta0o0pSsdpPThNmPtUL8mvGCHUaQtR+QrxR9yRYNWgKMsHkfIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -1653,14 +1651,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.9.tgz",
-      "integrity": "sha512-Xxt6nhomWTAmuSX61kVgglLjMEFGa+7+F6UUtdEUeg7fg4r9vaFttUUKrtkViYYrQBA5Ia1tkOJj2koP9BuLig==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.10.tgz",
+      "integrity": "sha512-leyBouGJ77ggv51Jb/OJmLGGnU2HYc13MZ2iiPNLwe2VgFgZPVqsrRWSa1RAHKyazjOyvSNKLD1B2K7A/iWi1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1676,9 +1674,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
-      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1686,14 +1684,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.6.tgz",
-      "integrity": "sha512-1f5AIsZuVjPT4ecA8AwaxDFNHny/tSershP/cTvTDxLdiIGTeILNcKozB0LaYt6mojJLUbOYhpIxicaYf7UKIQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.7.tgz",
+      "integrity": "sha512-rCQAipJNA14UTH84df/z4jDJ9LZ54H6zzuCAi7WZ0qVqx3CSqLjfXAMd5cpISIxbiHVJCPRB81gZksq6CZsqDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -1708,14 +1706,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.9.tgz",
-      "integrity": "sha512-iN2xZvH3tyIYXLXBvlVh0npk1q/aVuKXZo5hj+K3W3D4ngAEq/DkLpofRzx6oebTUhBvOgryZ+rMV0yImKnG3w==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.10.tgz",
+      "integrity": "sha512-GLsdnxzNefjCJUmWyjaAuNklHgDpCTL4RMllAVhVvAzBwRW9g38eZ5tWgzo1lirtSDTpsh593hqXVhxvdrjfwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -1730,14 +1728,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.9.tgz",
-      "integrity": "sha512-xBEoOw1XKb0rIN208YU7wM7oJEHhIYkfG7LpTJAEW913GZeaoQerzf5U/LSHI45EVvjAdgNXmXgH51cUXKZcJQ==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.10.tgz",
+      "integrity": "sha512-JC538ujqeYKkFqLoWZ0ILBteIUO2yajBMVEUZSxjl9x6fiEQtM+I5Rca7M2D8edMDbyHLnXifGH1hJZdh8V5rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -1753,22 +1751,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
-      "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.3.tgz",
+      "integrity": "sha512-QS1AQgJ113iE/nmym03yKZKHvGjVWwkGZT3B1yKrrMG0bJKQg1jUkntFP8aPd2FUQzu/nga7QU2eDpzIP5it0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.2",
-        "@inquirer/confirm": "^5.1.6",
-        "@inquirer/editor": "^4.2.7",
-        "@inquirer/expand": "^4.0.9",
-        "@inquirer/input": "^4.1.6",
-        "@inquirer/number": "^3.0.9",
-        "@inquirer/password": "^4.0.9",
-        "@inquirer/rawlist": "^4.0.9",
-        "@inquirer/search": "^3.0.9",
-        "@inquirer/select": "^4.0.9"
+        "@inquirer/checkbox": "^4.1.3",
+        "@inquirer/confirm": "^5.1.7",
+        "@inquirer/editor": "^4.2.8",
+        "@inquirer/expand": "^4.0.10",
+        "@inquirer/input": "^4.1.7",
+        "@inquirer/number": "^3.0.10",
+        "@inquirer/password": "^4.0.10",
+        "@inquirer/rawlist": "^4.0.10",
+        "@inquirer/search": "^3.0.10",
+        "@inquirer/select": "^4.0.10"
       },
       "engines": {
         "node": ">=18"
@@ -1783,14 +1781,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.9.tgz",
-      "integrity": "sha512-+5t6ebehKqgoxV8fXwE49HkSF2Rc9ijNiVGEQZwvbMI61/Q5RcD+jWD6Gs1tKdz5lkI8GRBL31iO0HjGK1bv+A==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.10.tgz",
+      "integrity": "sha512-vOQbQkmhaCsF2bUmjoyRSZJBz77UnIF/F3ZS2LMgwbgyaG2WgwKHh0WKNj0APDB72WDbZijhW5nObQbk+TnbcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1806,15 +1804,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.9.tgz",
-      "integrity": "sha512-DWmKztkYo9CvldGBaRMr0ETUHgR86zE6sPDVOHsqz4ISe9o1LuiWfgJk+2r75acFclA93J/lqzhT0dTjCzHuoA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.10.tgz",
+      "integrity": "sha512-EAVKAz6P1LajZOdoL+R+XC3HJYSU261fbJzO4fCkJJ7UPFcm+nP+gzC+DDZWsb2WK9PQvKsnaKiNKsY8B6dBWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1830,15 +1828,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.9.tgz",
-      "integrity": "sha512-BpJyJe7Dkhv2kz7yG7bPSbJLQuu/rqyNlF1CfiiFeFwouegfH+zh13KDyt6+d9DwucKo7hqM3wKLLyJxZMO+Xg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.10.tgz",
+      "integrity": "sha512-Tg8S9nESnCfISu5tCZSuXpXq0wHuDVimj7xyHstABgR34zcJnLdq/VbjB2mdZvNAMAehYBnNzSjxB06UE8LLAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.8",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1855,9 +1853,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
-      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2007,16 +2005,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mongodb-js/saslprep": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
-      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2728,16 +2716,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.1.tgz",
-      "integrity": "sha512-0yQLzYhCqGz7CQPE3iDmYjhb7KMBFOP+tBkyw+/Y2YyDI5wpS7itXXxneN1zSsUwWx3Ji6YiVYrhAnpQGS/vkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.13.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
@@ -2773,30 +2751,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3519,16 +3473,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.20.1"
       }
     },
     "node_modules/builtin-modules": {
@@ -5320,36 +5264,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5898,163 +5812,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/inquirer": {
-      "version": "12.4.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.4.2.tgz",
-      "integrity": "sha512-reyjHcwyK2LObXgTJH4T1Dpfhwu88LNPTZmg/KenmTsy3T8lN/kZT8Oo7UwwkB9q8+ss2qjjN7GV8oFAfyz9Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/prompts": "^7.3.2",
-        "@inquirer/type": "^3.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^2.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-standalone/-/inquirer-autocomplete-standalone-0.8.1.tgz",
-      "integrity": "sha512-mlzwCTiXDX1Cw4yJL5PCq32k23XYLTK8K6BDFoL1a76iJeFB5ul6IoMU9spgdDagl2SM7P6ZaCNjj8VNXRDPOQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@inquirer/core": "^3.1.1",
-        "@inquirer/type": "^1.1.2",
-        "figures": "^5.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@inquirer/core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-3.1.2.tgz",
-      "integrity": "sha512-lR2GaqBkp42Ew9BOAOqf2pSp+ymVES1qN8OC90WWh45yeoYLl0Ty1GyCxmkKqBJtq/+Ea1MF12AdFcZcpRNFsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/type": "^1.1.2",
-        "@types/mute-stream": "^0.0.1",
-        "@types/node": "^20.4.8",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "cli-spinners": "^2.9.0",
-        "cli-width": "^4.1.0",
-        "figures": "^3.2.0",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@inquirer/core/node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/@types/node": {
-      "version": "20.17.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.23.tgz",
-      "integrity": "sha512-8PCGZ1ZJbEZuYNTMqywO+Sj4vSKjSjT6Ua+6RFOYlEvIvKQABPtrNkoVSLSKDb4obYcMhspVKmsw8Cm10NFRUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer-autocomplete-standalone/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -6857,13 +6614,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7607,64 +7357,6 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/mongodb": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.2.tgz",
-      "integrity": "sha512-kMEHNo0F3P6QKDq17zcDuPeaywK/YaJVCEQRzPF3TOM/Bl9MFg64YE5Tu7ifj37qZJMhwU1tl2Ioivws5gRG5Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mrmime": {
@@ -8636,16 +8328,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8668,16 +8350,6 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -8879,16 +8551,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/spdx-correct": {
@@ -9297,19 +8959,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -9759,30 +9408,6 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
-      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {


### PR DESCRIPTION
## Description

Closes #9402

Hi, I'm a PreMiD fan and also the maintainer of [inquirer](https://github.com/SBoudrias/Inquirer.js) project. This PR updated the old `inquirer` to the modern `@inquirer/prompts`.

### Changes

- Updated the `inquirer` dependency to our modern `@inquirer/prompts`.
- Added a `process.on('exit')` event listener to the `index.ts` to [handle the <kbd>ctrl+c</kbd> gracefully](https://github.com/SBoudrias/Inquirer.js?tab=readme-ov-file#handling-ctrlc-gracefully).
- Bumped `pmd` version to `2.1.0`
- Updated root `package-lock.json` with `npm install`


## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
