### PR TITLE
feat(AnimeLib): support for licensed animes

### DIFF
--- a/websites/A/AnimeLib/metadata.json
+++ b/websites/A/AnimeLib/metadata.json
@@ -14,7 +14,7 @@
     "ru": "Смотрите аниме онлайн на русском"
   },
   "url": "anilib.me",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/thumbnail.png",
   "color": "#A020F0",
@@ -41,8 +41,11 @@
     },
     {
       "id": "titleAsPresence",
-      "title": "Отображать название аниме как название Презенса",
+      "title": "Отображать аниме в статусе",
       "icon": "fad fa-user-edit",
+      "if": {
+        "privacy": false
+      },
       "value": false
     }
   ]


### PR DESCRIPTION
chore(AnimeLib): remove deprecated
chore(AnimeLib): modify and update settings

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![Discord_InGGHvPWh4](https://github.com/user-attachments/assets/3a73e136-3c51-4b15-9591-a46a0ea49677)
Note: Kodik player

![Discord_RBsUXanyXp](https://github.com/user-attachments/assets/b0ae84c0-fd9c-44fb-81ca-82c8880b2733)
Note: AnimeLib player

![Discord_Tjg0INvz8x](https://github.com/user-attachments/assets/fc836bf1-3299-43f5-a7ae-4c0a35bb1ef2)
Note: Anime homepage

Now "titleAsPresence" setting is hidden when privacy mode is enabled, also renamed the setting's name
![0cFKhxviVp](https://github.com/user-attachments/assets/51a92446-5165-4858-969b-34c1ee992fe8)
![Om6cAEBPE6](https://github.com/user-attachments/assets/a0137b70-fa0a-4842-81ed-79c8734d6ca8)

</details>
