### PR TITLE
chore: update lint command in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -3,7 +3,7 @@
 
 ## Acknowledgements
 - [ ] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
-- [ ] I linted the code by running `yarn format`
+- [ ] I linted the code by running `npm run lint`
 - [ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
 
 ## Screenshots


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Update the `yarn format` to `npm run lint` in PR template
PR #9370 seems to have been reverted, idk why.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `yarn format`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
