### PR TITLE
🌟 feat: added https://mangalivre.tv/ presence

### DIFF
--- a/websites/M/mangalivre-tv/metadata.json
+++ b/websites/M/mangalivre-tv/metadata.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "1220554515149750273",
+    "name": "kyomu_densen"
+  },
+  "service": "mangalivre",
+  "description": {
+    "pt": "Website com mangás em pt-br",
+    "en": "Website com mangás em pt-br"
+  },
+  "url": "mangalivre.tv",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/JEt3cEP.png",
+  "thumbnail": "https://mangalivre.tv/wp-content/uploads/2024/12/mlivre.png",
+  "color": "#000000",
+  "category": "anime",
+  "tags": [
+    "mangás",
+    "webtoons",
+    "anime"
+  ]
+}

--- a/websites/M/mangalivre-tv/presence.ts
+++ b/websites/M/mangalivre-tv/presence.ts
@@ -1,0 +1,65 @@
+const presence = new Presence({
+    clientId: "1355724922483114115" // Seu Client ID
+});
+
+const browsingTimestamp = Math.floor(Date.now() / 1000);
+
+presence.on("UpdateData", async () => {
+    const presenceData: PresenceData = {
+        largeImageKey: "logo", // Key da logo do metadata.json
+        startTimestamp: browsingTimestamp
+    };
+
+    const { pathname, href } = window.location;
+    const pathParts = pathname.split('/').filter(part => part !== '');
+
+    try {
+        // Página inicial
+        if (pathname === "/") {
+            presenceData.details = "em: mangalivre.tv";
+            presenceData.state = "Escolhendo o que ler na página inicial";
+            presenceData.smallImageKey = "https://i.imgur.com/JEt3cEP.png";
+            presenceData.largeImageKey = "https://i.imgur.com/JEt3cEP.png";
+        }
+        
+        else if (pathParts[0] === "manga" && pathParts[2]?.startsWith("capitulo-")) {
+            const mangaName = pathParts[1]?.replace(/-/g, " ") || "Desconhecido";
+            const chapterNumber = pathParts[2]?.replace("capitulo-", "") || "0";
+
+            presenceData.details = `Lendo: ${mangaName}`;
+            presenceData.state = `Capítulo: ${chapterNumber}`;
+            presenceData.largeImageKey = "https://i.imgur.com/JEt3cEP.png";
+            presenceData.smallImageKey = "https://i.imgur.com/JEt3cEP.png"
+            presenceData.buttons = [
+                {
+                    label: `Capítulo ${chapterNumber}`,
+                    url: href
+                }
+            ];
+        }
+        // Página de mangá (ex: /manga/swordmasters-youngest-son/)
+        else if (pathParts[0] === "manga" && pathParts.length === 2) {
+            const mangaName = pathParts[1]?.replace(/-/g, " ") || "Desconhecido";
+            
+            presenceData.details = "Visualizando mangá";
+            presenceData.state = mangaName;
+            presenceData.largeImageKey = "https://i.imgur.com/JEt3cEP.png";
+            presenceData.smallImageKey = "https://i.imgur.com/JEt3cEP.png"
+        }
+        // Outras páginas
+        else {
+            presenceData.details = "Navegando no Mangá Livre";
+            presenceData.state = "Explorando conteúdo";
+            presenceData.largeImageKey = "https://i.imgur.com/JEt3cEP.png";
+            presenceData.smallImageKey = "https://i.imgur.com/JEt3cEP.png";
+        }
+
+        if (presenceData.details) {
+            presence.setActivity(presenceData);
+        } else {
+            presence.setActivity();
+        }
+    } catch (error) {
+        console.error("Erro no Presence:", error);
+    }
+});


### PR DESCRIPTION
### **Changelog**: feature

## Description  
- **Added integration with mangalivre.tv**:
-  Now, the user's status is updated based on the navigation through the website. 
- If on the homepage, the status will show "Choosing what to read on the homepage".
-  If reading a chapter, the status will display the manga name and chapter number.  


## Acknowledgements  
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)  
- [x] I linted the code by running `npm run lint`  
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots  
<details>  
<summary> Proof showing the creation/modification is working as expected </summary>  


![main page](https://i.imgur.com/LjoiiXu.png)

![reading chapter](https://i.imgur.com/ehODr6k.png)

</details>
