### PR TITLE
Añadiendo Anime-JL Presence

### DIFF
--- a/websites/A/AnimeJL/eslint.config.js
+++ b/websites/A/AnimeJL/eslint.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: globals.browser } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+]);

--- a/websites/A/AnimeJL/iframe.ts
+++ b/websites/A/AnimeJL/iframe.ts
@@ -1,0 +1,17 @@
+const iframe = new iFrame();
+
+iframe.on('UpdateData', async () => {
+    if (
+        document.querySelector('video[id$="_html5_api"]') || 
+        document.querySelector('div.jw-media.jw-reset > video')
+    ) {
+        const video = document.querySelector<HTMLVideoElement>('video');
+        if (video && !Number.isNaN(video.duration)) {
+            iframe.send({
+                duration: video.duration,
+                currentTime: video.currentTime,
+                paused: video.paused,
+            });
+        }
+    }
+});

--- a/websites/A/AnimeJL/metadata.json
+++ b/websites/A/AnimeJL/metadata.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "name": "Osc4r",
+    "id": "156481332652802048"
+  },
+
+  "service": "AnimeJL",
+  "description": {
+    "en": "AnimeJL is a streaming website where you can watch anime with Spanish subtitles. Made by Osc4r",
+    "es": "AnimeJL es un sitio web de streaming donde puedes ver anime con subtítulos y doblajes en español. Hecho por Osc4r"
+
+  },
+  "url": [
+    "www.anime-jl.net",
+    "anime-jl.net"
+  ],
+  "version": "1.0",
+  "logo": "https://www.anime-jl.net/favicon.ico",
+  "thumbnail": "https://c4.wallpaperflare.com/wallpaper/300/771/661/shingeki-no-kyojin-eren-jeager-anime-anime-boys-wallpaper-preview.jpg",
+  "color": "#db0000",
+  "category": "anime",
+  "tags": [
+  
+    "Anime",
+    "Community",
+    "Osc4r"
+  ],
+  "iframe": true,
+  "iFrameRegExp": ".*"
+}

--- a/websites/A/AnimeJL/presence.ts
+++ b/websites/A/AnimeJL/presence.ts
@@ -13,7 +13,7 @@ let video = {
 let cachedGif: string | null = null; // Cache para evitar múltiples llamadas a Giphy
 
 const ActivityAssets = {
-    DefaultLogo: 'https://www.anime-jl.net/favicon.ico',
+    DefaultLogo: 'https://github.com/OscarHDYT/img/blob/main/favicon.png?raw=true',
     CatalogImageFallback: 'https://www.anime-jl.net/storage/animes_tumbl/default-cover.jpg',
 };
 

--- a/websites/A/AnimeJL/presence.ts
+++ b/websites/A/AnimeJL/presence.ts
@@ -1,0 +1,136 @@
+import { ActivityType, Assets } from 'premid';
+
+const presence = new Presence({
+    clientId: '634081860972052490',
+});
+
+let video = {
+    duration: 0,
+    currentTime: 0,
+    paused: true,
+};
+
+let cachedGif: string | null = null; // Cache para evitar múltiples llamadas a Giphy
+
+const ActivityAssets = {
+    DefaultLogo: 'https://www.anime-jl.net/favicon.ico',
+    CatalogImageFallback: 'https://www.anime-jl.net/storage/animes_tumbl/default-cover.jpg',
+};
+
+// Función para obtener un GIF basado en el título del episodio
+async function fetchGif(animeTitle: string): Promise<string> {
+    const apiKey = 'Xku5Q4lnHQQ0KI0PJG679v2BzQahVn5W';
+    const query = encodeURIComponent(animeTitle.split(' ').slice(0, 3).join(' '));
+    const url = `https://api.giphy.com/v1/gifs/search?api_key=${apiKey}&q=${query}&limit=1`;
+
+    try {
+        const response = await fetch(url);
+        const data = await response.json();
+        console.log('Resultados de Giphy:', data);
+        return data.data[0]?.images?.original?.url || ActivityAssets.DefaultLogo;
+    } catch (error) {
+        console.error('Error al buscar GIF:', error);
+        return ActivityAssets.DefaultLogo;
+    }
+}
+
+presence.on('iFrameData', (data: unknown) => {
+    video = data as typeof video;
+});
+
+presence.on('UpdateData', async () => {
+    const presenceData: PresenceData = {
+        type: ActivityType.Watching,
+    };
+
+    const { pathname } = document.location;
+
+    if (video && !Number.isNaN(video.duration) && pathname.includes('/anime/')) {
+        [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(
+            Math.floor(video.currentTime),
+            Math.floor(video.duration),
+        );
+
+        const episodeMatch = pathname.match(/\/anime\/(.+)-(\d+)$/);
+        const isEpisodePage = episodeMatch !== null;
+        const animeTitle = document.querySelector('h1.Title')?.textContent?.trim() || 'Anime desconocido';
+
+        let imageUrl = ActivityAssets.DefaultLogo;
+        let detailsText = animeTitle;
+        let stateText = '';
+
+        if (isEpisodePage) {
+            const episodeNumber = episodeMatch[2];
+
+            const episodeImgElement = document.querySelector<HTMLImageElement>('img[title*="Episodio"]');
+            if (episodeImgElement) {
+                imageUrl = episodeImgElement.getAttribute('src') || ActivityAssets.DefaultLogo;
+            }
+
+            if (!cachedGif) {
+                cachedGif = await fetchGif(`${animeTitle} Episodio ${episodeNumber}`);
+            }
+            imageUrl = cachedGif || imageUrl;
+
+            const titleParts = animeTitle.split(' ');
+            detailsText = titleParts.slice(0, -2).join(' ') || animeTitle; // Quita "Episodio X"
+            stateText = `Episodio ${episodeNumber}`;
+
+            presenceData.buttons = [
+                {
+                    label: 'Ver capítulo',
+                    url: window.location.href,
+                },
+                {
+                    label: 'Ir a Anime-JL',
+                    url: 'https://www.anime-jl.net/',
+                },
+            ];
+        } else {
+            const catalogImageElement = document.querySelector<HTMLImageElement>('img[itemprop="image"]');
+            if (catalogImageElement) {
+                imageUrl = catalogImageElement.getAttribute('src') ?? ActivityAssets.CatalogImageFallback;
+            }
+
+            presenceData.buttons = [
+                {
+                    label: 'Ir al catálogo',
+                    url: window.location.href,
+                },
+                {
+                    label: 'Ir a Anime-JL',
+                    url: 'https://www.anime-jl.net/',
+                },
+            ];
+        }
+
+        console.log(`Imagen seleccionada: ${imageUrl}`);
+
+        presenceData.largeImageKey = imageUrl;
+        presenceData.details = detailsText;
+        presenceData.state = stateText;
+        presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play;
+        presenceData.smallImageText = video.paused ? 'En pausa' : 'Viendo';
+
+        if (video.paused) {
+            delete presenceData.startTimestamp;
+            delete presenceData.endTimestamp;
+        }
+
+        presence.setActivity(presenceData, !video.paused);
+    } else {
+        presenceData.largeImageKey = ActivityAssets.DefaultLogo;
+        presenceData.details = 'Explorando Anime-JL';
+        presenceData.state = 'Navegando por la web';
+        presenceData.smallImageKey = Assets.Search;
+        presenceData.smallImageText = 'Explorando Anime-JL';
+        presenceData.buttons = [
+            {
+                label: 'Ir a Anime-JL',
+                url: 'https://www.anime-jl.net/',
+            },
+        ];
+
+        presence.setActivity(presenceData);
+    }
+});


### PR DESCRIPTION
Este Pull Request añade soporte para Anime-JL en PreMiD, permitiendo que los usuarios vean su actividad de visualización en Discord.

### Características:
- Soporte para capítulos y catálogo de Anime-JL.
- Integración de imágenes de los capítulos como fallback si el GIF de Giphy no carga.
- Botones dinámicos que permiten acceder directamente al capítulo o al catálogo desde Discord.
- Optimización de la detección de episodios para mejorar la experiencia del usuario.

## Acknowledgements
- [ ✅ ] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [ ✅ ] I linted the code by running `npm run lint`
- [ ✅ ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
![imagen_2025-04-04_173823570](https://github.com/user-attachments/assets/c3c1965d-60e8-4758-ad9e-eac03e743ae5)
![image](https://github.com/user-attachments/assets/f0b5d8f2-2e67-44fc-b99c-91ae11037555)


<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
