### PR TITLE
feat(Streaming+): add presence

### DIFF
--- a/websites/S/Streaming+/metadata.json
+++ b/websites/S/Streaming+/metadata.json
@@ -20,7 +20,6 @@
     "live",
     "video"
   ],
-  "iframe": true,
   "settings": [
     {
       "id": "privacy",

--- a/websites/S/Streaming+/metadata.json
+++ b/websites/S/Streaming+/metadata.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "586157827400400907",
+    "name": "nekok500"
+  },
+  "service": "Streaming+",
+  "description": {
+    "en": "Streaming+ is a e+(イープラス)'s live streaming platform.",
+    "ja": "イープラスが運営する視聴チケット制のストリーミング・サービスです。音楽ライブ、舞台、クラシック、イベント、トークショー、美術展など多彩なジャンルのコンテンツを配信予定です。"
+  },
+  "url": "live.eplus.jp",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/AkxzWld.jpeg",
+  "thumbnail": "https://i.imgur.com/d2ZkDmk.jpeg",
+  "color": "#e75296",
+  "category": "videos",
+  "tags": [
+    "live",
+    "video"
+  ],
+  "iframe": true,
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy mode",
+      "icon": "fas fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "buttons",
+      "title": "Show buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    }
+  ]
+}

--- a/websites/S/Streaming+/metadata.json
+++ b/websites/S/Streaming+/metadata.json
@@ -12,7 +12,7 @@
   },
   "url": "live.eplus.jp",
   "version": "1.0.0",
-  "logo": "https://i.imgur.com/AkxzWld.jpeg",
+  "logo": "https://i.imgur.com/eNdtcpQ.jpeg",
   "thumbnail": "https://i.imgur.com/d2ZkDmk.jpeg",
   "color": "#e75296",
   "category": "videos",

--- a/websites/S/Streaming+/presence.ts
+++ b/websites/S/Streaming+/presence.ts
@@ -1,0 +1,124 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1359510663159877642',
+})
+const getStrings = presence.getStrings({
+  playing: 'general.playing',
+  paused: 'general.paused',
+  watchingLive: 'general.watchingLive',
+  waitingLive: 'general.waitingLive',
+  waitingLiveThe: 'general.waitingLiveThe',
+  waitingVid: 'general.waitingVid',
+  waitingVidThe: 'general.waitingVidThe',
+  buttonWatchStream: 'general.buttonWatchStream',
+  buttonViewPage: 'general.buttonViewPage',
+  viewAPage: 'general.viewAPage',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+let data: Metadata | undefined
+
+presence.on('UpdateData', async () => {
+  const strings = await getStrings
+  const [privacy, buttons] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('buttons'),
+  ])
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: 'https://i.imgur.com/AkxzWld.jpeg',
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (!data)
+    data = extractMetadata()
+
+  const streamId = /(\d+|sample)/.exec(document.location.pathname)?.[1]
+
+  if (streamId && data) {
+    switch (data.delivery_status) {
+      case 'PREPARING': // pre event
+        presenceData.details = privacy ? strings.waitingLive : strings.waitingLiveThe
+        break
+
+      case 'WAIT_CONFIRM_ARCHIVED': // post event, waiting for encoding
+        presenceData.details = privacy ? strings.waitingVid : strings.waitingVidThe
+        break
+
+      case 'STARTED': // now event, live is now
+      case 'CONFIRMED_ARCHIVE': // post event, archive is available
+        presenceData.details = strings.watchingLive
+        break
+
+      default: // archive is dead, etc...
+        presenceData.details = strings.viewAPage
+    }
+
+    const video = document.querySelector<HTMLVideoElement>('#video0_html5_api')
+    if (video) {
+      presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play
+      presenceData.smallImageText = video.paused
+        ? strings.paused
+        : strings.playing
+    }
+
+    if (!privacy) {
+      presenceData.state = data?.app_name
+      presenceData.largeImageText = data?.app_name
+
+      if (buttons) {
+        presenceData.buttons = [{
+          label: strings.buttonWatchStream,
+          url: location.href.split('?')[0] || location.href,
+        }, {
+          label: strings.buttonViewPage,
+          url: data.buy_ticket_url,
+        }]
+      }
+
+      if (data.thumbnail)
+        presenceData.largeImageKey = data.thumbnail
+
+      if (video?.paused === false) {
+        [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
+      }
+    }
+  }
+
+  presence.setActivity(presenceData)
+})
+
+interface Metadata {
+  app_name: string // streaming title
+  buy_ticket_url: string
+  // archive_mode: 'ON' | string
+  delivery_status: 'PREPARING' | 'STARTED' | 'WAIT_CONFIRM_ARCHIVED' | 'CONFIRMED_ARCHIVE' | string
+
+  thumbnail?: string
+}
+
+function extractMetadata(): Metadata | undefined {
+  let meta: Metadata | undefined
+  for (const tag of document.querySelectorAll('script')) {
+    const raw = /var app = (.+);/.exec(tag.innerHTML)
+    if (raw)
+      meta = JSON.parse(raw[1]!)
+  }
+
+  if (meta) {
+    presence.info(`metadata found: ${meta}`)
+    meta.thumbnail = extractEventThumbnail(meta)
+  }
+
+  return meta
+}
+
+function extractEventThumbnail(meta: Metadata) {
+  if (meta?.buy_ticket_url) {
+    const id = /.*(\d{6})(\d{4}).*/.exec(meta.buy_ticket_url)
+    if (id?.length === 3) {
+      return `https://eplus.jp/s/image/${id[1]}/${id[2]}/000/${id[1]}${id[2]}_1.png`
+    }
+  }
+}

--- a/websites/S/Streaming+/presence.ts
+++ b/websites/S/Streaming+/presence.ts
@@ -27,7 +27,7 @@ presence.on('UpdateData', async () => {
   ])
   const presenceData: PresenceData = {
     type: ActivityType.Watching,
-    largeImageKey: 'https://i.imgur.com/AkxzWld.jpeg',
+    largeImageKey: 'https://i.imgur.com/eNdtcpQ.jpeg',
     startTimestamp: browsingTimestamp,
   }
 

--- a/websites/S/Streaming+/presence.ts
+++ b/websites/S/Streaming+/presence.ts
@@ -3,24 +3,24 @@ import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
 const presence = new Presence({
   clientId: '1359510663159877642',
 })
-const getStrings = presence.getStrings({
-  playing: 'general.playing',
-  paused: 'general.paused',
-  watchingLive: 'general.watchingLive',
-  waitingLive: 'general.waitingLive',
-  waitingLiveThe: 'general.waitingLiveThe',
-  waitingVid: 'general.waitingVid',
-  waitingVidThe: 'general.waitingVidThe',
-  buttonWatchStream: 'general.buttonWatchStream',
-  buttonViewPage: 'general.buttonViewPage',
-  viewAPage: 'general.viewAPage',
-})
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 let data: Metadata | undefined
 
 presence.on('UpdateData', async () => {
-  const strings = await getStrings
+  const strings = await presence.getStrings({
+    playing: 'general.playing',
+    paused: 'general.paused',
+    watchingLive: 'general.watchingLive',
+    waitingLive: 'general.waitingLive',
+    waitingLiveThe: 'general.waitingLiveThe',
+    waitingVid: 'general.waitingVid',
+    waitingVidThe: 'general.waitingVidThe',
+    buttonWatchStream: 'general.buttonWatchStream',
+    buttonViewPage: 'general.buttonViewPage',
+    viewAPage: 'general.viewAPage',
+  })
+
   const [privacy, buttons] = await Promise.all([
     presence.getSetting<boolean>('privacy'),
     presence.getSetting<boolean>('buttons'),
@@ -70,7 +70,7 @@ presence.on('UpdateData', async () => {
       if (buttons) {
         presenceData.buttons = [{
           label: strings.buttonWatchStream,
-          url: location.href.split('?')[0] || location.href,
+          url: document.location.href.split('?')[0] || document.location.href,
         }, {
           label: strings.buttonViewPage,
           url: data.buy_ticket_url,
@@ -92,7 +92,6 @@ presence.on('UpdateData', async () => {
 interface Metadata {
   app_name: string // streaming title
   buy_ticket_url: string
-  // archive_mode: 'ON' | string
   delivery_status: 'PREPARING' | 'STARTED' | 'WAIT_CONFIRM_ARCHIVED' | 'CONFIRMED_ARCHIVE' | string
 
   thumbnail?: string


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Added [Streaming+](https://eplus.jp/sf/streamingplus) presence.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![スクリーンショット 2025-04-09 235038](https://github.com/user-attachments/assets/ea14c925-2cd9-4eab-a67d-bfdb01648f41)
![image](https://github.com/user-attachments/assets/ea606dce-fe77-47c6-b5c9-7a66e9bda55a)


</details>
