### PR TITLE
feat(Estácio): add activity

### DIFF
--- a/websites/E/Estácio/iframe.ts
+++ b/websites/E/Estácio/iframe.ts
@@ -1,0 +1,17 @@
+const iframe = new iFrame()
+
+export interface IframeData {
+  topic: string | null
+}
+
+iframe.on('UpdateData', async () => {
+  const currentTopic = document.querySelector(
+    'aside[data-testid=\'menu\'] li[data-selected=\'true\'] p',
+  )?.textContent || null
+
+  const data: IframeData = {
+    topic: currentTopic,
+  }
+
+  iframe.send(data)
+})

--- a/websites/E/Estácio/metadata.json
+++ b/websites/E/Estácio/metadata.json
@@ -21,7 +21,7 @@
   },
   "url": ["estudante.estacio.br", "sia.estacio.br", "estacio.saladeavaliacoes.com.br"],
   "version": "1.0.0",
-  "logo": "https://i.imgur.com/yU1Orek.png",
+  "logo": "https://imgur.com/2ooS3wz.png",
   "thumbnail": "https://i.imgur.com/L7J2lBc.png",
   "color": "#00C0F3",
   "category": "other",

--- a/websites/E/Estácio/metadata.json
+++ b/websites/E/Estácio/metadata.json
@@ -39,19 +39,19 @@
     {
       "id": "show-student-page",
       "title": "Exibir página do estudante (SAVA)",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-user-graduate",
       "value": true
     },
     {
       "id": "show-campus",
       "title": "Exibir campus virtual (SIA)",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-school",
       "value": true
     },
     {
       "id": "show-cursing",
       "title": "Exibir cursando",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-graduation-cap",
       "value": true,
       "if": {
         "show-student-page": true
@@ -60,7 +60,7 @@
     {
       "id": "show-disciplines",
       "title": "Exibir disciplinas",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-book",
       "value": true,
       "if": {
         "show-student-page": true
@@ -69,7 +69,7 @@
     {
       "id": "show-progress",
       "title": "Exibir progresso",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-spinner",
       "value": true,
       "if": {
         "show-disciplines": true
@@ -78,7 +78,7 @@
     {
       "id": "show-contents",
       "title": "Exibir informações da dicliplina",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-circle-info",
       "value": true,
       "if": {
         "show-disciplines": true
@@ -87,7 +87,7 @@
     {
       "id": "show-discipline-name",
       "title": "Exibir nome da disciplina",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-a",
       "value": true,
       "if": {
         "show-contents": true
@@ -96,7 +96,7 @@
     {
       "id": "show-theme",
       "title": "Exibir tema",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-list",
       "value": true,
       "if": {
         "show-contents": true
@@ -105,7 +105,7 @@
     {
       "id": "show-visualizing-exercises",
       "title": "Exibir visualisando exercícios",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-dumbbell",
       "value": true,
       "if": {
         "show-disciplines": true
@@ -114,7 +114,7 @@
     {
       "id": "show-visualizing-works",
       "title": "Exibir visualisando trabalhos",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-file-invoice",
       "value": true,
       "if": {
         "show-disciplines": true
@@ -123,7 +123,7 @@
     {
       "id": "show-visualizing-avaliations",
       "title": "Exibir visualisando avaliações",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-list-check",
       "value": true,
       "if": {
         "show-student-page": true
@@ -132,7 +132,7 @@
     {
       "id": "show-visualizing-socioemocional-formation",
       "title": "Exibir visualisando formação socioemocional",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-masks-theater",
       "value": true,
       "if": {
         "show-student-page": true
@@ -141,7 +141,7 @@
     {
       "id": "show-visualizing-complementary-courses",
       "title": "Exibir visualisando cursos complementares",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-person-rays",
       "value": true,
       "if": {
         "show-student-page": true
@@ -150,7 +150,7 @@
     {
       "id": "show-visualizing-academic-calendar",
       "title": "Exibir visualisando calendário acadêmico",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-calendar-days",
       "value": true,
       "if": {
         "show-student-page": true
@@ -159,13 +159,13 @@
     {
       "id": "show-avaliations-room",
       "title": "Exibir salas de avaliações",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-pencil",
       "value": true
     },
     {
       "id": "show-avaliations",
       "title": "Exibir informações das avaliações",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-scroll",
       "value": true,
       "if": {
         "show-avaliations-room": true
@@ -174,7 +174,7 @@
     {
       "id": "show-exercises",
       "title": "Exibir informações dos exercícios",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-receipt",
       "value": true,
       "if": {
         "show-avaliations-room": true
@@ -183,7 +183,7 @@
     {
       "id": "show-exercise-progress",
       "title": "Exibir progresso dos exercícios",
-      "icon": "fas fa-compress-arrows-alt",
+      "icon": "fas fa-bars-progress",
       "value": true,
       "if": {
         "show-exercises": true

--- a/websites/E/Estácio/metadata.json
+++ b/websites/E/Estácio/metadata.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "783120232134082580",
+    "name": "o_lobo"
+  },
+  "contributors": [
+    {
+      "id": "565153810599772171",
+      "name": "nobre09"
+    }
+  ],
+  "service": "Estácio",
+  "altnames": [
+    "Estácio de Sá"
+  ],
+  "description": {
+    "en": "Estácio de Sá is a private higher education institution. The university offers undergraduate and postgraduate courses, including bachelor's, licentiate, technological, master's and doctorate degrees, serving students from all over Brazil.",
+    "pt": "Estácio de Sá é uma instituição de ensino superior privada. A universidade oferece cursos de graduação e pós-graduação, incluindo bacharelado, licenciatura, tecnológico, mestrado e doutorado, Atendando aos estudantes de todo o Brasil."
+  },
+  "url": ["estudante.estacio.br", "sia.estacio.br", "estacio.saladeavaliacoes.com.br"],
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/yU1Orek.png",
+  "thumbnail": "https://i.imgur.com/L7J2lBc.png",
+  "color": "#00C0F3",
+  "category": "other",
+  "tags": [
+    "studies",
+    "college",
+    "courses",
+    "brazil",
+    "school",
+    "distance-learning"
+  ],
+  "iframe": true,
+  "iFrameRegExp": "^https://conteudo\\.ensineme\\.com\\.br/[^/]+/[^/]+\\?brand=estacio$",
+  "settings": [
+    {
+      "id": "show-student-page",
+      "title": "Exibir página do estudante (SAVA)",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    },
+    {
+      "id": "show-campus",
+      "title": "Exibir campus virtual (SIA)",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    },
+    {
+      "id": "show-cursing",
+      "title": "Exibir cursando",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-student-page": true
+      }
+    },
+    {
+      "id": "show-disciplines",
+      "title": "Exibir disciplinas",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-student-page": true
+      }
+    },
+    {
+      "id": "show-progress",
+      "title": "Exibir progresso",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-disciplines": true
+      }
+    },
+    {
+      "id": "show-contents",
+      "title": "Exibir informações da dicliplina",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-disciplines": true
+      }
+    },
+    {
+      "id": "show-discipline-name",
+      "title": "Exibir nome da disciplina",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-contents": true
+      }
+    },
+    {
+      "id": "show-theme",
+      "title": "Exibir tema",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-contents": true
+      }
+    },
+    {
+      "id": "show-visualizing-exercises",
+      "title": "Exibir visualisando exercícios",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-disciplines": true
+      }
+    },
+    {
+      "id": "show-visualizing-works",
+      "title": "Exibir visualisando trabalhos",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-disciplines": true
+      }
+    },
+    {
+      "id": "show-visualizing-avaliations",
+      "title": "Exibir visualisando avaliações",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-student-page": true
+      }
+    },
+    {
+      "id": "show-visualizing-socioemocional-formation",
+      "title": "Exibir visualisando formação socioemocional",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-student-page": true
+      }
+    },
+    {
+      "id": "show-visualizing-complementary-courses",
+      "title": "Exibir visualisando cursos complementares",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-student-page": true
+      }
+    },
+    {
+      "id": "show-visualizing-academic-calendar",
+      "title": "Exibir visualisando calendário acadêmico",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-student-page": true
+      }
+    },
+    {
+      "id": "show-avaliations-room",
+      "title": "Exibir salas de avaliações",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    },
+    {
+      "id": "show-avaliations",
+      "title": "Exibir informações das avaliações",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-avaliations-room": true
+      }
+    },
+    {
+      "id": "show-exercises",
+      "title": "Exibir informações dos exercícios",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-avaliations-room": true
+      }
+    },
+    {
+      "id": "show-exercise-progress",
+      "title": "Exibir progresso dos exercícios",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true,
+      "if": {
+        "show-exercises": true
+      }
+    }
+  ]
+}

--- a/websites/E/Estácio/presence.ts
+++ b/websites/E/Estácio/presence.ts
@@ -1,0 +1,306 @@
+import type { IframeData } from './iframe.js'
+import { ActivityType } from 'premid'
+
+import {
+  isValidUUID,
+  removeParentesisFromNumber,
+  removeThemePrefix,
+} from './utils/index.js'
+
+const presence = new Presence({
+  clientId: '1359697490579947590',
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/yU1Orek.png',
+}
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+let iframeContent: IframeData | null = null
+
+presence.on('iFrameData', (receivedData: IframeData) => {
+  iframeContent = receivedData
+})
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    type: ActivityType.Playing,
+  }
+
+  const [
+    showStudentPage,
+    showCursing,
+    showDisciplines,
+    showProgress,
+    showContents,
+    showDisciplineName,
+    showTheme,
+    showVisualizingExercises,
+    showVisualizingWorks,
+    showVisualizingAvaliations,
+    showVisualizingSocioemotionalFormation,
+    showVisualizingComplementaryCourses,
+    showVisualizingAcademicCalendar,
+    showAvaliationsRoom,
+    showAvaliations,
+    showExercises,
+    showExerciseProgress,
+    showCampus,
+  ] = await Promise.all([
+    presence.getSetting<boolean>('show-student-page'),
+    presence.getSetting<boolean>('show-cursing'),
+    presence.getSetting<boolean>('show-disciplines'),
+    presence.getSetting<boolean>('show-progress'),
+    presence.getSetting<boolean>('show-contents'),
+    presence.getSetting<boolean>('show-discipline-name'),
+    presence.getSetting<boolean>('show-theme'),
+    presence.getSetting<boolean>('show-visualizing-exercises'),
+    presence.getSetting<boolean>('show-visualizing-works'),
+    presence.getSetting<boolean>('show-visualizing-avaliations'),
+    presence.getSetting<boolean>('show-visualizing-socioemocional-formation'),
+    presence.getSetting<boolean>('show-visualizing-complementary-courses'),
+    presence.getSetting<boolean>('show-visualizing-academic-calendar'),
+    presence.getSetting<boolean>('show-avaliations-room'),
+    presence.getSetting<boolean>('show-avaliations'),
+    presence.getSetting<boolean>('show-exercises'),
+    presence.getSetting<boolean>('show-exercise-progress'),
+    presence.getSetting<boolean>('show-campus'),
+  ])
+
+  const host = document.location.hostname
+
+  // Estudante
+  if (host === 'estudante.estacio.br' && showStudentPage) {
+    presenceData.details = 'Navegando na página de estudante'
+
+    const courseName = document.querySelector(
+      'h1[data-testid=\'header-curso\']',
+    )?.textContent
+
+    if (courseName && showCursing) {
+      presenceData.details = `Cursando ${courseName}`
+    }
+
+    // Disciplinas
+    if (document.location.pathname.includes('/disciplinas') && showDisciplines) {
+      presenceData.state = 'Visualisando disciplinas'
+
+      const progress = document.querySelector(
+        'div[role="progressbar"] > progress',
+      )?.getAttribute('aria-valuenow')
+
+      if (progress && /^\d*$/.test(progress) && showProgress) {
+        presenceData.state += ` - ${progress}% concluído`
+      }
+
+      // Conteúdos
+      if (document.location.pathname.includes('/conteudos')) {
+        if (!showContents) {
+          presenceData.state = 'Visualisando disciplina'
+        }
+        else {
+          const disciplineName = document.querySelector(
+            'main h1',
+          )?.textContent
+
+          if (disciplineName && showDisciplineName) {
+            presenceData.state = `Visualizando disciplina: ${disciplineName}`
+          }
+
+          // Tema
+          const paths = document.location.pathname.split('/')
+          paths.shift()
+
+          if (paths[0] === 'disciplinas'
+            && paths[2] === 'conteudos'
+            && paths[3]
+            && isValidUUID(paths[3])) {
+            const themeName = document.querySelector(
+              'header[data-testid="header-modal-conteudo"] p > span',
+            )?.textContent
+
+            if (themeName && showTheme) {
+              let state = removeThemePrefix(themeName)
+
+              if (iframeContent?.topic)
+                state += ` - ${iframeContent.topic}`
+
+              presenceData.state = state
+            }
+            else {
+              presenceData.state = 'Estudando...'
+            }
+          }
+        }
+      }
+
+      // Exercícios
+      if (document.location.pathname.includes('/exercicios')) {
+        const disciplineName = document.querySelector(
+          'main h1',
+        )?.textContent
+
+        if (disciplineName && showDisciplineName) {
+          presenceData.state = `Visualizando exercícios: ${disciplineName}`
+        }
+        else if (disciplineName && !showDisciplineName) {
+          presenceData.state = 'Visualizando exercícios'
+        }
+
+        if (!showVisualizingExercises)
+          presenceData.state = ''
+      }
+
+      // Trabalhos
+      if (document.location.pathname.includes('/trabalhos')) {
+        const disciplineName = document.querySelector(
+          'main h1',
+        )?.textContent
+
+        if (disciplineName && showDisciplineName) {
+          presenceData.state = `Visualizando trabalhos: ${disciplineName}`
+        }
+        else if (disciplineName && !showDisciplineName) {
+          presenceData.state = 'Visualizando trabalhos'
+        }
+
+        if (!showVisualizingWorks)
+          presenceData.state = ''
+      }
+    }
+
+    // Avaliações
+    if (document.location.pathname.includes('/avaliacoes')) {
+      presenceData.state = 'Visualisando avaliações'
+
+      if (!showVisualizingAvaliations)
+        presenceData.state = ''
+    }
+
+    // Formação socioemocional
+    if (document.location.pathname.includes('/formacao-socioemocional')) {
+      presenceData.state = 'Visualisando formação socioemocional'
+
+      if (!showVisualizingSocioemotionalFormation)
+        presenceData.state = ''
+    }
+
+    // Cursos complementares
+    if (document.location.pathname.includes('/cursos-complementares')) {
+      presenceData.state = 'Visualisando cursos complementares'
+
+      if (!showVisualizingComplementaryCourses)
+        presenceData.state = ''
+    }
+
+    // Calendário Acadêmico
+    if (document.location.pathname.includes('/calendarios')) {
+      presenceData.state = 'Visualisando o calendário acadêmico'
+
+      if (!showVisualizingAcademicCalendar)
+        presenceData.state = ''
+    }
+  }
+
+  // Campus
+  if (host === 'sia.estacio.br' && document.location.pathname.includes('/sianet')) {
+    presenceData.details = 'Navegando no campus virtual'
+
+    if (!showCampus)
+      presenceData.details = ''
+  }
+
+  // Sala de avaliações
+  if (host === 'estacio.saladeavaliacoes.com.br') {
+    presenceData.details = 'Navegando na sala de avaliações'
+
+    const paths = document.location.pathname.split('/')
+    paths.shift()
+
+    // Avaliação
+    if (
+      paths[0] === 'avaliacoes' && (paths[1]?.length || 0) >= 3
+    ) {
+      const disciplineName = document.querySelector(
+        'div[data-testid="header"] h1',
+      )?.textContent
+
+      if (disciplineName && showDisciplineName) {
+        presenceData.state = `Visualizando avaliação: ${disciplineName}`
+      }
+      else if (disciplineName && !showDisciplineName) {
+        presenceData.state = 'Visualizando avaliação'
+      }
+
+      if (!showAvaliations) {
+        presenceData.details = ''
+        presenceData.state = ''
+      }
+    }
+
+    // Exercício
+    if (
+      paths[0] === 'exercicio' && (paths[1]?.length || 0) >= 16
+    ) {
+      const disciplineName = document.querySelector(
+        'div[data-section="section_exercicios-menu"] p',
+      )?.textContent
+
+      const answeredQuestions = document.querySelector(
+        'small[data-testid="answered-questions-value"]',
+      )?.textContent || '0'
+
+      const notFilledQuestions = document.querySelector(
+        'small[data-testid="not-filled-questions-value"]',
+      )?.textContent || '0'
+
+      if (disciplineName && showDisciplineName) {
+        presenceData.details = `Realizando exercício: ${disciplineName}`
+      }
+      else if (disciplineName && !showDisciplineName) {
+        presenceData.details = 'Realizando exercício'
+      }
+
+      if (answeredQuestions && notFilledQuestions) {
+        const answeredStr = removeParentesisFromNumber(answeredQuestions)
+        const notFilledStr = removeParentesisFromNumber(notFilledQuestions)
+
+        if (
+          (answeredStr && /^\d*$/.test(answeredStr))
+          && (notFilledStr && /^\d*$/.test(notFilledStr))
+        ) {
+          const answered = Number.parseInt(answeredStr)
+          const notFilled = Number.parseInt(notFilledStr)
+
+          const totalQuestions = answered + notFilled
+          const percentage = Math.floor((answered / totalQuestions) * 100) || 0
+
+          const blockAnswered = '🟦'
+          const blockNotFilled = '⬜'
+
+          const blocksAnswered = blockAnswered.repeat(answered)
+          const blocksNotFilled = blockNotFilled.repeat(notFilled)
+
+          if (showExerciseProgress) {
+            presenceData.state = `Perguntas respondidas: ${blocksAnswered}${blocksNotFilled} - ${percentage}%`
+          }
+        }
+      }
+
+      if (!showExercises) {
+        presenceData.details = ''
+        presenceData.state = ''
+      }
+    }
+
+    if (!showAvaliationsRoom) {
+      presenceData.details = ''
+      presenceData.state = ''
+    }
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/E/Estácio/presence.ts
+++ b/websites/E/Estácio/presence.ts
@@ -151,7 +151,7 @@ presence.on('UpdateData', async () => {
         }
 
         if (!showVisualizingExercises)
-          presenceData.state = ''
+          delete presenceData.state
       }
 
       // Trabalhos
@@ -168,7 +168,7 @@ presence.on('UpdateData', async () => {
         }
 
         if (!showVisualizingWorks)
-          presenceData.state = ''
+          delete presenceData.state
       }
     }
 
@@ -177,7 +177,7 @@ presence.on('UpdateData', async () => {
       presenceData.state = 'Visualisando avaliações'
 
       if (!showVisualizingAvaliations)
-        presenceData.state = ''
+        delete presenceData.state
     }
 
     // Formação socioemocional
@@ -185,7 +185,7 @@ presence.on('UpdateData', async () => {
       presenceData.state = 'Visualisando formação socioemocional'
 
       if (!showVisualizingSocioemotionalFormation)
-        presenceData.state = ''
+        delete presenceData.state
     }
 
     // Cursos complementares
@@ -193,7 +193,7 @@ presence.on('UpdateData', async () => {
       presenceData.state = 'Visualisando cursos complementares'
 
       if (!showVisualizingComplementaryCourses)
-        presenceData.state = ''
+        delete presenceData.state
     }
 
     // Calendário Acadêmico
@@ -201,7 +201,7 @@ presence.on('UpdateData', async () => {
       presenceData.state = 'Visualisando o calendário acadêmico'
 
       if (!showVisualizingAcademicCalendar)
-        presenceData.state = ''
+        delete presenceData.state
     }
   }
 
@@ -210,7 +210,7 @@ presence.on('UpdateData', async () => {
     presenceData.details = 'Navegando no campus virtual'
 
     if (!showCampus)
-      presenceData.details = ''
+      delete presenceData.details
   }
 
   // Sala de avaliações
@@ -236,8 +236,8 @@ presence.on('UpdateData', async () => {
       }
 
       if (!showAvaliations) {
-        presenceData.details = ''
-        presenceData.state = ''
+        delete presenceData.details
+        delete presenceData.state
       }
     }
 
@@ -291,14 +291,14 @@ presence.on('UpdateData', async () => {
       }
 
       if (!showExercises) {
-        presenceData.details = ''
-        presenceData.state = ''
+        delete presenceData.details
+        delete presenceData.state
       }
     }
 
     if (!showAvaliationsRoom) {
-      presenceData.details = ''
-      presenceData.state = ''
+      delete presenceData.details
+      delete presenceData.state
     }
   }
 

--- a/websites/E/Estácio/presence.ts
+++ b/websites/E/Estácio/presence.ts
@@ -12,7 +12,7 @@ const presence = new Presence({
 })
 
 enum ActivityAssets {
-  Logo = 'https://i.imgur.com/yU1Orek.png',
+  Logo = 'https://imgur.com/2ooS3wz.png',
 }
 
 const browsingTimestamp = Math.floor(Date.now() / 1000)

--- a/websites/E/Estácio/utils/index.ts
+++ b/websites/E/Estácio/utils/index.ts
@@ -1,0 +1,13 @@
+export function removeThemePrefix(text: string): string {
+  const regex = /Tema\s?\d*\s?-\s*/i
+  return text.replace(regex, '')
+}
+
+export function removeParentesisFromNumber(text: string): string {
+  const regex = /^\s*\(\s*(\d+)\s*\)\s*$/
+  return text.replace(regex, '$1')
+}
+
+export function isValidUUID(uuid: string): boolean {
+  return /^[A-Z0-9]{8}-[A-Z0-9]{4}-4[A-Z0-9]{3}-[A-Z0-9]{4}-[A-Z0-9]{12}$/i.test(uuid)
+}


### PR DESCRIPTION
## Description
Adds Estácio integration to PreMiD, allowing activity display on Discord.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

### Settings:

<img alt="settings 1 of 2" src="https://github.com/user-attachments/assets/81adeb49-37d8-49a1-81f7-c3c86808a090" width="300">

<img alt="settings 2 of 2" src="https://github.com/user-attachments/assets/30723d39-b9f1-4774-a75f-415e4758f37c" width="300">

### Activity:

<img alt="activity demo 1" src="https://github.com/user-attachments/assets/ec744e16-3278-4423-8135-f05006b3fae9" width="800">

<img alt="activity demo 2" src="https://github.com/user-attachments/assets/38349eed-821d-4dab-a03d-9571e4b65f6d" width="800">

<img alt="activity demo 3" src="https://github.com/user-attachments/assets/13a580e4-f4ed-4474-a60e-c95f64251d1e" width="800">

</details>