### PR TITLE
fix(Simulator Radio): remove listener count

### DIFF
--- a/websites/S/Simulator Radio/metadata.json
+++ b/websites/S/Simulator Radio/metadata.json
@@ -18,7 +18,7 @@
   },
   "url": "simulatorradio.com",
   "version": "1.5.21",
-  "logo": "https://cdnrr.rcd.gg/PreMiD/websites/S/Simulator%20Radio/assets/logo.png",
+  "logo": "https://cdn.rcd.gg/PreMiD/websites/S/Simulator%20Radio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Simulator%20Radio/assets/thumbnail.png",
   "color": "#FB352A",
   "category": "music",

--- a/websites/S/Simulator Radio/metadata.json
+++ b/websites/S/Simulator Radio/metadata.json
@@ -17,8 +17,8 @@
     "nl": "Simulator Radio: Uw #1 Simulatie Station"
   },
   "url": "simulatorradio.com",
-  "version": "1.5.20",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/S/Simulator%20Radio/assets/logo.png",
+  "version": "1.5.21",
+  "logo": "https://cdnrr.rcd.gg/PreMiD/websites/S/Simulator%20Radio/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Simulator%20Radio/assets/thumbnail.png",
   "color": "#FB352A",
   "category": "music",

--- a/websites/S/Simulator Radio/presence.ts
+++ b/websites/S/Simulator Radio/presence.ts
@@ -7,7 +7,6 @@ const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 let currentTitle = 'Simulator Radio'
 let currentArtist = 'Your #1 Simulation Station'
-let currentListeners = 0
 let currentDj = 'Otto'
 
 function newStats(): void {
@@ -17,7 +16,6 @@ function newStats(): void {
         response.json().then((data) => {
           currentTitle = data.now_playing.title
           currentArtist = data.now_playing.artists
-          currentListeners = data.listeners
           currentDj = data.djs.now.displayname
         })
       }
@@ -31,7 +29,6 @@ let lastTimeStart = Math.floor(Date.now() / 1000)
 function pushMusicPresence(presenceData: PresenceData): void {
   presenceData.details = `${currentTitle} - ${currentArtist}`
   presenceData.state = `Listening to ${currentDj}`
-  presenceData.smallImageText = currentListeners !== 0 ? `Listeners: ${currentListeners}` : ''
   presenceData.smallImageKey = Assets.Play
 
   if (lastTitle !== currentTitle) {


### PR DESCRIPTION

## Description

SimulatorRadio's API does not release listener count so I removed it. These issues were in the API part where it attempted to request listener count, making the listener count come out as: undefined.


## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

</details>
