### PR TITLE
fix: editor now shows language & file currently being edited

### DIFF
--- a/websites/C/Crowdin/metadata.json
+++ b/websites/C/Crowdin/metadata.json
@@ -32,7 +32,7 @@
     "status.crowdin.com",
     "blog.crowdin.com"
   ],
-  "version": "4.0.14",
+  "version": "4.0.15",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/C/Crowdin/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/C/Crowdin/assets/thumbnail.png",
   "color": "#2e3340",

--- a/websites/C/Crowdin/presence.ts
+++ b/websites/C/Crowdin/presence.ts
@@ -328,7 +328,7 @@ presence.on('UpdateData', async () => {
         const languageName = document.querySelector(
           '.language-name-wrapper.text-overflow',
         )?.textContent ?? document.querySelector(
-          `.navbar-item--language`
+          '.navbar-item--language',
         )?.textContent
 
         if (pathname.includes('/proofread'))

--- a/websites/C/Crowdin/presence.ts
+++ b/websites/C/Crowdin/presence.ts
@@ -319,6 +319,7 @@ presence.on('UpdateData', async () => {
       else if (
         pathname.includes('/translate')
         || pathname.includes('/proofread')
+        || pathname.includes('/editor')
       ) {
         // Ensure the editor has loaded to prevent undefined text
         if (!document.querySelector('#crowdin-editor-wrapper'))
@@ -326,6 +327,8 @@ presence.on('UpdateData', async () => {
         const fileName = document.querySelector('.file-name')?.textContent
         const languageName = document.querySelector(
           '.language-name-wrapper.text-overflow',
+        )?.textContent ?? document.querySelector(
+          `.navbar-item--language`
         )?.textContent
 
         if (pathname.includes('/proofread'))


### PR DESCRIPTION
## Description
fix: editor now shows language & file currently being edited

## Acknowledgements
- [X ] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X ] I linted the code by running `npm run lint`
- [ X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![image](https://github.com/user-attachments/assets/874783a8-6b22-4d15-8212-ef1ca7a523ed)


</details>
