### PR TITLE
feat(Home Assistant): add presence tracking and routing configuration

### DIFF
--- a/websites/H/Home Assistant/metadata.json
+++ b/websites/H/Home Assistant/metadata.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "124239574951002113",
+    "name": "mrburtuk"
+  },
+  "service": "Home Assistant",
+  "description": {
+    "en": "Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts"
+  },
+  "url": "www.home-assistant.io",
+  "version": "1.0.0",
+  "logo": "https://pub-d896e4ce4d21475fab8e7d1c02eded98.r2.dev/home-assistant-logomark.png", 
+  "thumbnail": "https://pub-d896e4ce4d21475fab8e7d1c02eded98.r2.dev/home-assistant-logomark.png",
+  "color": "#03A9F4",
+  "category": "other",
+  "tags": [
+    "integrations",
+    "blog",
+    "help",
+    "documentation",
+    "automation"  
+  ]
+}
+

--- a/websites/H/Home Assistant/presence.ts
+++ b/websites/H/Home Assistant/presence.ts
@@ -1,0 +1,74 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1142916495991652422',
+})
+const startTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://pub-d896e4ce4d21475fab8e7d1c02eded98.r2.dev/home-assistant-logomark.png', //TODO Change to a RCD logo, along with metadata.json logo
+}
+
+interface RouteConfig {
+  prefix: string
+  defaultDetail: string
+  defaultTitle: string
+  detailFormatter?: (title: string) => string
+}
+
+const ROUTES: RouteConfig[] = [
+  {
+    prefix: '/integrations',
+    defaultDetail: 'Browsing integrations',
+    defaultTitle: 'Integrations',
+    detailFormatter: title => `Browsing ${title} Integration`,
+  },
+  {
+    prefix: '/docs',
+    defaultDetail: 'Browsing Documentation',
+    defaultTitle: 'Documentation',
+    detailFormatter: title => `Browsing ${title} Docs`,
+  },
+  {
+    prefix: '/installation',
+    defaultDetail: 'Browsing Installation Guide',
+    defaultTitle: 'Installation Guide',
+    detailFormatter: title => `Browsing ${title} Guide`,
+  },
+  {
+    prefix: '/getting-started',
+    defaultDetail: 'Browsing Getting Started Guide',
+    defaultTitle: 'Getting Started Guide',
+    detailFormatter: title => `Browsing ${title} Guide`,
+  },
+  { prefix: '/blog', defaultDetail: 'Browsing blog', defaultTitle: '' },
+  { prefix: '/help', defaultDetail: 'Browsing help', defaultTitle: '' },
+]
+
+presence.on('UpdateData', () => {
+  const { pathname } = window.location;
+
+  const route = ROUTES.find(r => pathname.startsWith(r.prefix));
+  let details = 'Browsing website';
+
+  if (route) {
+    details = route.defaultDetail;
+
+    if (route.detailFormatter && route.defaultTitle) {
+      const heading = document.querySelector<HTMLHeadingElement>('h1.title.indent')
+      const title = heading?.textContent?.trim() || '';
+
+      if (title && title !== route.defaultTitle) {
+        details = route.detailFormatter(title);
+      }
+    }
+  }
+
+  presence.setActivity({
+    largeImageKey: ActivityAssets.Logo,
+    smallImageKey: Assets.Search,
+    startTimestamp,
+    type: ActivityType.Playing,
+    details: details,
+  })
+})


### PR DESCRIPTION
## Description
home-assistant.io is the main website for the popular home automation service of the same name. This presence tracks when a user is looking at the intergrations, blog, docs, help and getting started page including the specific page based on the title name. 

The only change that is required (outside my control) is a permanant location for the image host as its currently hosted on a personal cloudflare r2 bucket.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![7RGFCPbIvS](https://github.com/user-attachments/assets/0b65ad13-0a4d-4b88-95ee-8c65b5d44cff)

![Discord_69ak44itTJ](https://github.com/user-attachments/assets/96fe92d9-2d39-4ab5-afa2-fd1407587fc5)

![Discord_rg9VBryD3Ws](https://github.com/user-attachments/assets/7131c088-1e2d-4a21-b5ff-db66efeb9ae5)

</details>
