### PR TITLE
chore: add country to bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,10 +1,12 @@
-name: Bug Report
-description: Create a report to help us improve the PreMiD Store
-labels: [bug, needs repro]
+name: "Bug Report"
+description: "Create a report to help us improve the PreMiD Store"
+labels: ["bug", "needs-repro"]
 body:
   - type: markdown
     attributes:
-      value: Before submitting a new issue, ensure your bug hasn't already been reported. If it has, reply to the open issue instead.
+      value: |
+        **Before submitting a new issue, ensure your bug hasn’t already been reported.**  
+        If it has, simply reply to the open issue instead.
   - type: textarea
     id: reproduction
     validations:
@@ -13,9 +15,9 @@ body:
       label: Steps to Reproduce
       description: Provide clear and unambiguous steps on how to reproduce the bug
       placeholder: |
-        1. Go to this link
-        2. Click on this
-        3. Observe that
+        1. Go to this link  
+        2. Click on this  
+        3. Observe that…
   - type: input
     id: expected_behavior
     validations:
@@ -37,27 +39,28 @@ body:
     attributes:
       label: Page URL
       description: The URL you were visiting when the bug happens
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: Optionally, add some screenshots to show the issue
   - type: input
-    id: os
+    id: country
     validations:
       required: true
     attributes:
-      label: Operating System
-      description: E.g. Windows 11, macOS 12, etc
+      label: Country
+      description: The country you are accessing the service from (web content can vary by region)
+      placeholder: e.g., United States, Germany, Japan
   - type: input
     id: browser
     validations:
       required: true
     attributes:
       label: Browser and Version
-      description: Include the type of browser you use AND the browser version
+      description: Include both browser name and version (e.g. Chrome 113.0.5672.63)
   - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Optionally, add one or more screenshots to illustrate the issue
+  - type: input
     id: additional_comments
     attributes:
       label: Additional Comments
-      description: Optionally, add further comments which may enhance the issue
+      description: Anything else you think might help us track down this bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,11 +1,11 @@
-name: "Bug Report"
-description: "Create a report to help us improve the PreMiD Store"
-labels: ["bug", "needs-repro"]
+name: Bug Report
+description: Create a report to help us improve the PreMiD Store
+labels: [bug, needs-repro]
 body:
   - type: markdown
     attributes:
       value: |
-        **Before submitting a new issue, ensure your bug hasn’t already been reported.**  
+        **Before submitting a new issue, ensure your bug hasn’t already been reported.**
         If it has, simply reply to the open issue instead.
   - type: textarea
     id: reproduction
@@ -15,8 +15,8 @@ body:
       label: Steps to Reproduce
       description: Provide clear and unambiguous steps on how to reproduce the bug
       placeholder: |
-        1. Go to this link  
-        2. Click on this  
+        1. Go to this link
+        2. Click on this
         3. Observe that…
   - type: input
     id: expected_behavior
@@ -53,7 +53,7 @@ body:
       required: true
     attributes:
       label: Browser and Version
-      description: Include both browser name and version (e.g. Chrome 113.0.5672.63)
+      description: Include both browser name and version (e.g. Chrome 113.0.5672.63)
   - type: textarea
     id: screenshots
     attributes:


### PR DESCRIPTION
This pull request updates the bug report issue template to improve clarity, accessibility, and relevance. Key changes include reformatting text for better readability, updating field descriptions, and reorganizing the structure of input fields.

### Improvements to readability and formatting:
* Updated text in the `description` and `body` sections to use consistent quotation marks and Markdown formatting for better readability. For example, added bold emphasis and line breaks in the introductory instructions. [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL1-R9) [[2]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL18-R20)

### Updates to input fields:
* Replaced the `os` field with a `country` field to gather region-specific information, including a new placeholder and description.
* Updated the `browser` field description to clarify the required format (e.g., "Include both browser name and version").
* Reorganized the `screenshots` field to appear later in the form, with an updated description encouraging users to attach relevant images.
* Enhanced the `additional_comments` field description to encourage users to provide any helpful context.