### PR TITLE
feat(Microsoft Learn): add new presence

### DIFF
--- a/websites/M/Microsoft Learn/metadata.json
+++ b/websites/M/Microsoft Learn/metadata.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "430729478151602183",
+    "name": "rikunz"
+  },
+  "service": "Microsoft Learn",
+  "description": {
+    "en": "Microsoft Learn is an official platform by Microsoft offering free, interactive training for a wide range of Microsoft products and technologies, from Azure to Power Platform.",
+    "es": "Microsoft Learn es una plataforma oficial de Microsoft que ofrece capacitación interactiva gratuita sobre una amplia gama de productos y tecnologías de Microsoft, desde Azure hasta Power Platform.",
+    "fr": "Microsoft Learn est une plateforme officielle de Microsoft offrant une formation interactive gratuite sur un large éventail de produits et technologies Microsoft, d'Azure à Power Platform.",
+    "hi": "Microsoft Learn Microsoft का एक आधिकारिक प्लेटफ़ॉर्म है जो Azure से लेकर Power Platform तक की विभिन्न तकनीकों पर मुफ्त इंटरैक्टिव प्रशिक्षण प्रदान करता है.",
+    "id": "Microsoft Learn adalah platform resmi dari Microsoft yang menawarkan pelatihan interaktif gratis untuk berbagai produk dan teknologi Microsoft, mulai dari Azure hingga Power Platform.",
+    "ja": "Microsoft Learn は、Microsoft が提供する公式プラットフォームで、Azure や Power Platform など幅広い製品や技術に関する無料のインタラクティブトレーニングを提供しています。",
+    "ru": "Microsoft Learn — это официальная платформа Microsoft, предлагающая бесплатное интерактивное обучение по широкому спектру продуктов и технологий Microsoft, от Azure до Power Platform.",
+    "zh": "Microsoft Learn 是微软官方平台，提供免费的互动式培训，涵盖从 Azure 到 Power Platform 等各种微软产品和技术。"
+  },
+  "url": "learn.microsoft.com",
+  "version": "1.0.0",
+  "logo": "https://minio.rikztech.my.id/personalized/assets%2FMicrosoft_Logo_512px.png",
+  "thumbnail": "https://imgur.com/a/ERluFem.png",
+  "color": "#FFFFFF",
+  "category": "other",
+  "tags": [
+    "learns",
+    "microsoft"
+  ],
+  "settings": [
+    {
+      "id": "time",
+      "title": "Show timestamps",
+      "icon": "fad fa-stopwatch",
+      "value": true
+    },
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "show-level",
+      "title": "Show Level",
+      "icon": "fad fa-images",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "show-button",
+      "title": "Show Button",
+      "icon": "fad fa-hand-pointer",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    }
+  ]
+}

--- a/websites/M/Microsoft Learn/metadata.json
+++ b/websites/M/Microsoft Learn/metadata.json
@@ -9,17 +9,12 @@
   "description": {
     "en": "Microsoft Learn is an official platform by Microsoft offering free, interactive training for a wide range of Microsoft products and technologies, from Azure to Power Platform.",
     "es": "Microsoft Learn es una plataforma oficial de Microsoft que ofrece capacitación interactiva gratuita sobre una amplia gama de productos y tecnologías de Microsoft, desde Azure hasta Power Platform.",
-    "fr": "Microsoft Learn est une plateforme officielle de Microsoft offrant une formation interactive gratuite sur un large éventail de produits et technologies Microsoft, d'Azure à Power Platform.",
-    "hi": "Microsoft Learn Microsoft का एक आधिकारिक प्लेटफ़ॉर्म है जो Azure से लेकर Power Platform तक की विभिन्न तकनीकों पर मुफ्त इंटरैक्टिव प्रशिक्षण प्रदान करता है.",
-    "id": "Microsoft Learn adalah platform resmi dari Microsoft yang menawarkan pelatihan interaktif gratis untuk berbagai produk dan teknologi Microsoft, mulai dari Azure hingga Power Platform.",
-    "ja": "Microsoft Learn は、Microsoft が提供する公式プラットフォームで、Azure や Power Platform など幅広い製品や技術に関する無料のインタラクティブトレーニングを提供しています。",
-    "ru": "Microsoft Learn — это официальная платформа Microsoft, предлагающая бесплатное интерактивное обучение по широкому спектру продуктов и технологий Microsoft, от Azure до Power Platform.",
-    "zh": "Microsoft Learn 是微软官方平台，提供免费的互动式培训，涵盖从 Azure 到 Power Platform 等各种微软产品和技术。"
+    "fr": "Microsoft Learn est une plateforme officielle de Microsoft offrant une formation interactive gratuite sur un large éventail de produits et technologies Microsoft, d'Azure à Power Platform."
   },
   "url": "learn.microsoft.com",
   "version": "1.0.0",
   "logo": "https://minio.rikztech.my.id/personalized/assets%2FMicrosoft_Logo_512px.png",
-  "thumbnail": "https://imgur.com/a/ERluFem.png",
+  "thumbnail": "https://minio.rikztech.my.id/personalized/assets%2FbGfL5hu-.png",
   "color": "#FFFFFF",
   "category": "other",
   "tags": [

--- a/websites/M/Microsoft Learn/presence.ts
+++ b/websites/M/Microsoft Learn/presence.ts
@@ -50,15 +50,19 @@ presence.on('UpdateData', async () => {
         const levelElement = document.querySelector('#level-status-text')
           ?.textContent
           ?.trim()
-        if (levelElement) {
-          presenceData.details += ` (${levelElement})`
-        }
+        const plusXp = document.querySelector('.xp-tag-xp')?.textContent?.trim()
         const nextExp = document.querySelector('#level-status-points')
           ?.textContent
           ?.trim()
           ?.replace('/', ' / ')
+        if (levelElement) {
+          presenceData.details += ` (${levelElement})`
+        }
         if (nextExp) {
-          presenceData.details += ` - ${nextExp}`
+          presenceData.details += ` - (${nextExp})`
+        }
+        if (plusXp) {
+          presenceData.details += ` + ${plusXp}`
         }
       }
     }

--- a/websites/M/Microsoft Learn/presence.ts
+++ b/websites/M/Microsoft Learn/presence.ts
@@ -8,7 +8,6 @@ const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
   Logo = 'https://minio.rikztech.my.id/personalized/assets%2FMicrosoft_Logo_512px.png',
-  // Logo Microsoft Learn
 }
 
 presence.on('UpdateData', async () => {
@@ -48,11 +47,16 @@ presence.on('UpdateData', async () => {
     else {
       presenceData.state = pageTitle
       if (showLevel) {
-        const levelElement = document.querySelector('#level-status-text')?.textContent?.trim()
+        const levelElement = document.querySelector('#level-status-text')
+          ?.textContent
+          ?.trim()
         if (levelElement) {
           presenceData.details += ` (${levelElement})`
         }
-        const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', ' / ')
+        const nextExp = document.querySelector('#level-status-points')
+          ?.textContent
+          ?.trim()
+          ?.replace('/', ' / ')
         if (nextExp) {
           presenceData.details += ` - ${nextExp}`
         }
@@ -61,9 +65,17 @@ presence.on('UpdateData', async () => {
     delete presenceData.buttons
   }
   else if (page.includes('/training/paths/')) {
-    const levelElement = document.querySelector('#level-status-text')?.textContent?.trim() || '0'
-    const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', ' / ') || '0'
-    presenceData.details = showLevel ? `Following a Path - (${levelElement}) - ${nextExp}` : 'Following a Learning Path'
+    const levelElement = document.querySelector('#level-status-text')
+      ?.textContent
+      ?.trim() || '0'
+    const nextExp = document.querySelector('#level-status-points')
+      ?.textContent
+      ?.trim()
+      ?.replace('/', ' / ')
+      || '0'
+    presenceData.details = showLevel
+      ? `Following a Path - (${levelElement}) - ${nextExp}`
+      : 'Following a Learning Path'
     presenceData.smallImageKey = Assets.Reading
     presenceData.smallImageText = 'Studying'
     presenceData.state = privacy ? 'A learning path' : pageTitle
@@ -71,7 +83,7 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'View Path',
-          url: document.URL.split('?')[0]!,
+          url: document.location.href,
         },
       ]
     }
@@ -108,13 +120,15 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'View Collection',
-          url: document.URL.split('?')[0]!,
+          url: document.location.href,
         },
       ]
     }
   }
   else if (page.includes('/challenges/')) {
-    const progressDescription = document.querySelector('#progress-description')?.textContent?.trim()
+    const progressDescription = document.querySelector('#progress-description')
+      ?.textContent
+      ?.trim()
     if (progressDescription) {
       presenceData.details = 'Completing a Challenge' + ` (${progressDescription})`
       presenceData.smallImageKey = Assets.Reading
@@ -135,13 +149,15 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'View Challenge',
-          url: document.URL.split('?')[0]!,
+          url: document.location.href,
         },
       ]
     }
   }
   else if (page.includes('/plans/')) {
-    const resumeButton = document.querySelector('button#resume-plan-button')?.textContent?.trim()
+    const resumeButton = document.querySelector('button#resume-plan-button')
+      ?.textContent
+      ?.trim()
     if (resumeButton) {
       presenceData.details = 'Completing a Plan'
       presenceData.smallImageKey = Assets.Reading
@@ -162,7 +178,7 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'View Plan',
-          url: document.URL.split('?')[0]!,
+          url: document.location.href,
         },
       ]
     }
@@ -177,7 +193,7 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'View Course',
-          url: document.URL.split('?')[0]!,
+          url: document.location.href,
         },
       ]
     }
@@ -222,7 +238,7 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'View Profile',
-          url: document.URL.split('?')[0]!,
+          url: document.location.href,
         },
       ]
     }

--- a/websites/M/Microsoft Learn/presence.ts
+++ b/websites/M/Microsoft Learn/presence.ts
@@ -1,0 +1,253 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1367056833675661342',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://minio.rikztech.my.id/personalized/assets%2FMicrosoft_Logo_512px.png',
+  // Logo Microsoft Learn
+}
+
+presence.on('UpdateData', async () => {
+  const page = document.location.pathname
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  const [time, privacy, showLevel, showButton] = await Promise.all([
+    presence.getSetting<boolean>('time').catch(() => true),
+    presence.getSetting<boolean>('privacy').catch(() => false),
+    presence.getSetting<boolean>('show-level').catch(() => true),
+    presence.getSetting<boolean>('show-button').catch(() => true),
+  ])
+
+  if (!time) {
+    delete presenceData.startTimestamp
+  }
+
+  const pageTitle = document.title.split(' | ')[0]?.trim() || 'Unknown'
+
+  if (page === '/' || page === '/en-us/' || page === '/fr-fr/') {
+    presenceData.details = 'Exploring Microsoft Learn'
+    presenceData.state = 'Browsing the homepage'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Viewing'
+    delete presenceData.buttons
+  }
+  else if (page.includes('/training/modules/')) {
+    presenceData.details = 'Learning a Module'
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Studying'
+    if (privacy) {
+      presenceData.state = 'A training module'
+    }
+    else {
+      presenceData.state = pageTitle
+      if (showLevel) {
+        const levelElement = document.querySelector('#level-status-text')?.textContent?.trim()
+        if (levelElement) {
+          presenceData.details += ` (${levelElement})`
+        }
+        const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', '/ ')
+        if (nextExp) {
+          presenceData.details += ` - ${nextExp}`
+        }
+      }
+    }
+    delete presenceData.buttons
+  }
+  else if (page.includes('/training/paths/')) {
+    presenceData.details = 'Following a Learning Path'
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Studying'
+    presenceData.state = privacy ? 'A learning path' : pageTitle
+    if (showButton) {
+      presenceData.buttons = [
+        {
+          label: 'View Path',
+          url: document.URL.split('?')[0]!,
+        },
+      ]
+    }
+  }
+  else if (page.includes('/credentials/certifications/')) {
+    presenceData.details = 'Checking a Certification'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Viewing'
+    presenceData.state = privacy ? 'A certification' : pageTitle
+    delete presenceData.buttons
+  }
+  else if (page.includes('/answers/')) {
+    presenceData.details = 'Engaging in Q&A'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Browsing'
+    presenceData.state = privacy ? 'Q&A section' : 'Technical Questions & Answers'
+    delete presenceData.buttons
+  }
+  else if (page.includes('/training/support/')) {
+    presenceData.details = 'Seeking Support'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Browsing'
+    presenceData.state = privacy ? 'Support' : pageTitle
+    delete presenceData.buttons
+  }
+  else if (page.includes('/collections/')) {
+    presenceData.details = 'Exploring a Collection'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Browsing'
+    presenceData.state = privacy
+      ? 'A collection'
+      : document.querySelector('h1.title')?.textContent?.trim() || 'Collection'
+    if (showButton) {
+      presenceData.buttons = [
+        {
+          label: 'View Collection',
+          url: document.URL.split('?')[0]!,
+        },
+      ]
+    }
+  }
+  else if (page.includes('/challenges/')) {
+    const progressDescription = document.querySelector('#progress-description')?.textContent?.trim()
+    if (progressDescription) {
+      presenceData.details = 'Completing a Challenge' + ` (${progressDescription})`
+      presenceData.smallImageKey = Assets.Reading
+      presenceData.smallImageText = 'Studying'
+      presenceData.state = privacy
+        ? 'A challenge'
+        : document.querySelector('#hero-body-name')?.textContent?.trim() || 'Challange'
+    }
+    else {
+      presenceData.details = 'Exploring a Challenge'
+      presenceData.smallImageKey = Assets.Viewing
+      presenceData.smallImageText = 'Browsing'
+      presenceData.state = privacy
+        ? 'A challenge'
+        : document.querySelector('#hero-body-name')?.textContent?.trim() || 'Challange'
+    }
+    if (showButton) {
+      presenceData.buttons = [
+        {
+          label: 'View Challenge',
+          url: document.URL.split('?')[0]!,
+        },
+      ]
+    }
+  }
+  else if (page.includes('/plans/')) {
+    const resumeButton = document.querySelector('button#resume-plan-button')?.textContent?.trim()
+    if (resumeButton) {
+      presenceData.details = 'Completing a Plan'
+      presenceData.smallImageKey = Assets.Reading
+      presenceData.smallImageText = 'Studying'
+      presenceData.state = privacy
+        ? 'A plan '
+        : document.querySelector('h1.title')?.textContent?.trim() || ' Plan'
+    }
+    else {
+      presenceData.details = 'Exploring a Plan'
+      presenceData.smallImageKey = Assets.Viewing
+      presenceData.smallImageText = 'Browsing'
+      presenceData.state = privacy
+        ? 'A plan '
+        : document.querySelector('h1.title')?.textContent?.trim() || ' Plan'
+    }
+    if (showButton) {
+      presenceData.buttons = [
+        {
+          label: 'View Plan',
+          url: document.URL.split('?')[0]!,
+        },
+      ]
+    }
+  }
+  else if (page.includes('/courses/')) {
+    const titleElement = document.querySelector('h1.title')?.textContent?.trim()
+    presenceData.details = 'Checking a Course'
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Browsing'
+    presenceData.state = privacy ? 'A course' : titleElement || 'Course'
+    if (showButton) {
+      presenceData.buttons = [
+        {
+          label: 'View Course',
+          url: document.URL.split('?')[0]!,
+        },
+      ]
+    }
+  }
+  else if (page.includes('/users/')) {
+    const nameElement = document.querySelector('.media-content h1')?.textContent?.trim() || 'User'
+    const userName = document.querySelector('.persona-name')?.textContent?.trim() || 'User'
+    const achievementElement = document.querySelector('.box .columns')?.querySelectorAll('.column a p')
+    const badgeElement = achievementElement?.[0]?.textContent?.trim() || '0'
+    const trophyElement = achievementElement?.[1]?.textContent?.trim() || '0'
+    const levelElement = document.querySelector('#level-status-text')?.textContent?.trim() || '0'
+    const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', '/ ') || '0'
+    if (nameElement === userName) {
+      presenceData.details = privacy
+        ? 'Checking My Profile'
+        : showLevel
+          ? `Checking My Profile (${nameElement}) - (${levelElement}) - ${nextExp}`
+          : `Checking My Profile (${nameElement})`
+      presenceData.smallImageKey = Assets.Viewing
+      presenceData.smallImageText = 'Checking'
+      presenceData.state = privacy
+        ? 'My Profile'
+        : showLevel
+          ? `Badge (${badgeElement}) - Trophy (${trophyElement})`
+          : 'My Profile'
+    }
+    else {
+      presenceData.details = privacy
+        ? 'Checking a User Profile'
+        : showLevel
+          ? `Checking a ${nameElement} Profile - (${levelElement}) - ${nextExp}`
+          : `Checking a ${nameElement} Profile`
+      presenceData.smallImageKey = Assets.Viewing
+      presenceData.smallImageText = 'Browsing'
+      presenceData.state = privacy
+        ? 'A user profile'
+        : showLevel
+          ? `Badge (${badgeElement}) - Trophy (${trophyElement})`
+          : 'A user profile'
+    }
+    if (showButton) {
+      presenceData.buttons = [
+        {
+          label: 'View Profile',
+          url: document.URL.split('?')[0]!,
+        },
+      ]
+    }
+  }
+  else if (page.includes('/search')) {
+    const query = new URLSearchParams(document.location.search).get('terms')?.trim() || 'Something'
+    presenceData.details = 'Searching for Content'
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = 'Searching'
+    presenceData.state = privacy ? 'Something' : query
+    delete presenceData.buttons
+  }
+  else if (page.includes('/training/browse/')) {
+    const query = new URLSearchParams(document.location.search).get('terms')?.trim() || 'Something'
+    presenceData.details = 'Searching for Training'
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = 'Searching'
+    presenceData.state = privacy ? 'Something' : query
+    delete presenceData.buttons
+  }
+  else {
+    presenceData.details = 'Browsing Microsoft Learn'
+    presenceData.state = pageTitle
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = 'Viewing'
+    delete presenceData.buttons
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/M/Microsoft Learn/presence.ts
+++ b/websites/M/Microsoft Learn/presence.ts
@@ -52,7 +52,7 @@ presence.on('UpdateData', async () => {
         if (levelElement) {
           presenceData.details += ` (${levelElement})`
         }
-        const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', '/ ')
+        const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', ' / ')
         if (nextExp) {
           presenceData.details += ` - ${nextExp}`
         }
@@ -61,7 +61,9 @@ presence.on('UpdateData', async () => {
     delete presenceData.buttons
   }
   else if (page.includes('/training/paths/')) {
-    presenceData.details = 'Following a Learning Path'
+    const levelElement = document.querySelector('#level-status-text')?.textContent?.trim() || '0'
+    const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', ' / ') || '0'
+    presenceData.details = showLevel ? `Following a Path - (${levelElement}) - ${nextExp}` : 'Following a Learning Path'
     presenceData.smallImageKey = Assets.Reading
     presenceData.smallImageText = 'Studying'
     presenceData.state = privacy ? 'A learning path' : pageTitle
@@ -187,7 +189,7 @@ presence.on('UpdateData', async () => {
     const badgeElement = achievementElement?.[0]?.textContent?.trim() || '0'
     const trophyElement = achievementElement?.[1]?.textContent?.trim() || '0'
     const levelElement = document.querySelector('#level-status-text')?.textContent?.trim() || '0'
-    const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', '/ ') || '0'
+    const nextExp = document.querySelector('#level-status-points')?.textContent?.trim()?.replace('/', ' / ') || '0'
     if (nameElement === userName) {
       presenceData.details = privacy
         ? 'Checking My Profile'

--- a/websites/M/Microsoft Learn/presence.ts
+++ b/websites/M/Microsoft Learn/presence.ts
@@ -31,7 +31,7 @@ presence.on('UpdateData', async () => {
 
   const pageTitle = document.title.split(' | ')[0]?.trim() || 'Unknown'
 
-  if (page === '/' || page === '/en-us/' || page === '/fr-fr/') {
+  if (/^\/(?:[a-z]{2}-[a-z]{2}\/|\/)?$/.test(page)) {
     presenceData.details = 'Exploring Microsoft Learn'
     presenceData.state = 'Browsing the homepage'
     presenceData.smallImageKey = Assets.Viewing


### PR DESCRIPTION
## Description
Improves the Microsoft Learn presence by adding explicit button removal for pages where buttons are not needed, fixing a typo, and maintaining existing functionality. Ensures buttons are only shown for specific routes (`/training/paths/`, `/collections/`, `/challenges/`, `/plans/`, `/courses/`, `/users/`) when `show-button` is enabled and `privacy` is disabled. Corrects "Challange" to "Challenge" for consistency.

### Changes
- **feat**: Add new Microsoft Learn Presence
- **fix**: update homepage URL check to use regex for better matching
- **fix**: remove redundant translations and update thumbnail URL

### Testing
- Tested on `/training/paths/`, `/users/`, `/challenges/`, `/` with `show-button` and `privacy` toggled.
- Verified buttons appear only on intended pages and are absent on others (e.g., homepage, `/search`).
- Confirmed typo fix and no console errors.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary>Proof of functionality</summary>

### Settings
![Settings](https://minio.rikztech.my.id/personalized/Screenshot%202025-04-30%20195719.png)
*Caption*: Presence settings with `show-button`, `privacy`, `show-level`, and `time` toggles.

### Learning Path
![Learning Path](https://minio.rikztech.my.id/personalized/Screenshot%202025-04-30%20200816.png)
*Caption*: Rich Presence for `/training/paths/` with "View Path" button.

### Homepage (No Button)
![Homepage](https://minio.rikztech.my.id/personalized/Screenshot%202025-04-30%20201506.png)
*Caption*: Rich Presence for `/` without buttons, as intended.

</details>

Signed-off-by: [Rikunz](https://github.com/rikunz)