### PR TITLE
fix(SoundCloud): replace asset key with link

### DIFF
--- a/websites/S/SoundCloud/metadata.json
+++ b/websites/S/SoundCloud/metadata.json
@@ -27,7 +27,7 @@
     "zh-tw": "SoundCloud是一個線上音樂分享平臺，它允許人們合作、交流和分享原創音樂錄音。"
   },
   "url": "soundcloud.com",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/thumbnail.jpg",
   "color": "#FF7E30",

--- a/websites/S/SoundCloud/metadata.json
+++ b/websites/S/SoundCloud/metadata.json
@@ -27,7 +27,7 @@
     "zh-tw": "SoundCloud是一個線上音樂分享平臺，它允許人們合作、交流和分享原創音樂錄音。"
   },
   "url": "soundcloud.com",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/thumbnail.jpg",
   "color": "#FF7E30",

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -1,8 +1,13 @@
-import { ActivityType, Assets } from 'premid'
+import { ActivityType, Assets, getTimestamps, timestampFromFormat } from 'premid'
 
 const presence = new Presence({
   clientId: '802958833214423081',
 })
+
+enum ActivityAssets {
+  logo = 'https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png',
+}
+
 async function getStrings() {
   return presence.getStrings(
     {
@@ -144,7 +149,7 @@ presence.on('UpdateData', async () => {
 
   let presenceData: PresenceData = {
     type: ActivityType.Listening,
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png',
+    largeImageKey: ActivityAssets.logo,
     startTimestamp: elapsed,
   }
 
@@ -174,15 +179,15 @@ presence.on('UpdateData', async () => {
       'div.playbackTimeline__duration > span:nth-child(2)',
     )?.textContent
     const [currentTime, duration] = [
-      presence.timestampFromFormat(timePassed ?? ''),
+      timestampFromFormat(timePassed ?? ''),
       (() => {
         if (!durationString?.startsWith('-')) {
-          return presence.timestampFromFormat(durationString ?? '')
+          return timestampFromFormat(durationString ?? '')
         }
         else {
           return (
-            presence.timestampFromFormat(durationString.slice(1))
-            + presence.timestampFromFormat(timePassed ?? '')
+            timestampFromFormat(durationString.slice(1))
+            + timestampFromFormat(timePassed ?? '')
           )
         }
       })(),
@@ -194,7 +199,7 @@ presence.on('UpdateData', async () => {
       ?.getAttribute('href')
 
     if (playing) {
-      [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestamps(currentTime, duration)
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(currentTime, duration)
     }
     else {
       presenceData.smallImageKey = Assets.Pause
@@ -209,7 +214,7 @@ presence.on('UpdateData', async () => {
         ?.style
         .backgroundImage
         .match(/"(.*)"/)?.[1]
-        ?.replace('-t50x50.jpg', '-t500x500.jpg') ?? 'soundcloud'
+        ?.replace('-t50x50.jpg', '-t500x500.jpg') ?? ActivityAssets.logo
     }
 
     if (showButtons && pathLinkSong) {

--- a/websites/S/SoundCloud/presence.ts
+++ b/websites/S/SoundCloud/presence.ts
@@ -5,7 +5,7 @@ const presence = new Presence({
 })
 
 enum ActivityAssets {
-  logo = 'https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png',
+  Logo = 'https://cdn.rcd.gg/PreMiD/websites/S/SoundCloud/assets/logo.png',
 }
 
 async function getStrings() {
@@ -149,7 +149,7 @@ presence.on('UpdateData', async () => {
 
   let presenceData: PresenceData = {
     type: ActivityType.Listening,
-    largeImageKey: ActivityAssets.logo,
+    largeImageKey: ActivityAssets.Logo,
     startTimestamp: elapsed,
   }
 
@@ -214,7 +214,7 @@ presence.on('UpdateData', async () => {
         ?.style
         .backgroundImage
         .match(/"(.*)"/)?.[1]
-        ?.replace('-t50x50.jpg', '-t500x500.jpg') ?? ActivityAssets.logo
+        ?.replace('-t50x50.jpg', '-t500x500.jpg') ?? ActivityAssets.Logo
     }
 
     if (showButtons && pathLinkSong) {


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

Replaced a left over discord asset key with the logo link

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![opera_jZ6UbMgaNJ](https://github.com/user-attachments/assets/06365847-05b5-4de4-84fb-03530e0bc0a2)
![opera_Z9I43dIPjD](https://github.com/user-attachments/assets/6655d9db-8e8f-465b-ac9b-4e656db94c6f)


</details>
