### PR TITLE
feat(cli): add fallback username to discord username api

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pmd",
   "type": "module",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "main": "dist/index.js",
   "bin": {

--- a/cli/src/util/getDiscordUser.ts
+++ b/cli/src/util/getDiscordUser.ts
@@ -18,7 +18,9 @@ export async function getDiscordUser(): Promise<User | undefined> {
   }
 }
 
-export async function getDiscordUserById(id: string): Promise<{ username: string } | undefined> {
+export async function getDiscordUserById(
+  id: string,
+): Promise<{ username: string } | undefined> {
   const res = await fetch('https://api.premid.app/v3/graphql', {
     method: 'POST',
     headers: {
@@ -34,7 +36,11 @@ export async function getDiscordUserById(id: string): Promise<{ username: string
     }),
   })
 
-  const { data } = await res.json()
-
-  return data.discordUsers[0]
+  try {
+    const { data } = await res.json()
+    return data.discordUsers[0]
+  }
+  catch {
+    return { username: 'unknown-please-replace' }
+  }
 }


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds a fallback username for `getDiscordUser` which is used if the API is broken

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)