### PR TITLE
feat(AnimeLib): added support for mirror

### DIFF
--- a/websites/A/AnimeLib/lib.ts
+++ b/websites/A/AnimeLib/lib.ts
@@ -134,7 +134,11 @@ export class AnimeLib {
     endpoint: APIEndpoint,
     endpointPart?: string,
   ) {
-    return await fetch(`${this.api}/${endpoint}/${endpointPart ?? id}`).then(
+    return await fetch(`${this.api}/${endpoint}/${endpointPart ?? id}`, {
+      headers: {
+        'Site-Id': '5',
+      },
+    }).then(
       async (response): Promise<CachedResponse> => {
         return {
           id,

--- a/websites/A/AnimeLib/metadata.json
+++ b/websites/A/AnimeLib/metadata.json
@@ -13,8 +13,11 @@
     "en": "Watch anime online in Russian",
     "ru": "Смотрите аниме онлайн на русском"
   },
-  "url": "anilib.me",
-  "version": "1.0.12",
+  "url": [
+    "anilib.me",
+    "v1.animelib.org"
+  ],
+  "version": "1.0.13",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeLib/assets/thumbnail.png",
   "color": "#A020F0",


### PR DESCRIPTION
fix(AnimeLib): crash on some pages due to missing headers

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

![изображение](https://github.com/user-attachments/assets/45673d7b-e7a8-4f51-ae99-763bed3e30d2)


</details>

The crashes on some pages (like reviews and collections) were caused by missing headers when accessing API (specifically, only `Site-Id` header). In the past it didn't matter, but apparently API was updated.
