### PR TITLE
chore(movie-web): Update urls and meta

### DIFF
--- a/websites/M/movie-web/metadata.json
+++ b/websites/M/movie-web/metadata.json
@@ -6,6 +6,10 @@
     "name": "jordaar"
   },
   "service": "movie-web",
+  "altnames": [
+    "P-Stream",
+    "pstream"
+  ],
   "description": {
     "en": "The place for your favorite movies & shows"
   },

--- a/websites/M/movie-web/metadata.json
+++ b/websites/M/movie-web/metadata.json
@@ -11,17 +11,19 @@
   },
   "url": [
     "pstream.org",
+    "mirror.pstream.org",
     "beta.pstream.org",
+    "nostalgia.pstream.org",
+    "iframe.pstream.org",
     "pseudo-flix.pro",
     "mw.lonelil.com",
     "mw.lonelil.ru",
-    "movies.levrx.lol",
     "movies.levrx.de",
     "streamerflix.xyz",
-    "sudo-flix.fmovies0.cc",
     "streamwatch.online",
     "movies.samj.app",
-    "movie-site.tech"
+    "movie-site.tech",
+    "sudo-flix.nl"
   ],
   "regExp": "(dev[.])?(movie-web[.]app)",
   "version": "1.2.0",

--- a/websites/M/movie-web/presence.ts
+++ b/websites/M/movie-web/presence.ts
@@ -67,7 +67,7 @@ presence.on('UpdateData', async () => {
     type: ActivityType.Watching,
   }
 
-  if (pathname === '' || pathname.startsWith('/search')) {
+  if (pathname === '' || pathname.startsWith('/search') || pathname.startsWith('/discover')) {
     presenceData.startTimestamp = browsingTimestamp
   }
   else if (pathname.startsWith('/media')) {
@@ -100,7 +100,7 @@ presence.on('UpdateData', async () => {
     }
 
     const title = `${meta.title} (${meta.year})`
-    presenceData.name = title
+    presenceData.name = document.title
 
     if (meta.type === 'show' && episode && season)
       presenceData.details = `Season ${season.number}, Episode ${episode.number}`


### PR DESCRIPTION
## Description
Updates the instance URLs and hopefully displays the page title instead of "movie-web"

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)