### PR TITLE
chore: use inquirer search prompt

### DIFF
--- a/cli/src/commands/bump.ts
+++ b/cli/src/commands/bump.ts
@@ -1,12 +1,13 @@
 import type { ActivityMetadataAndFolder } from '../util/getActivities.js'
 import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { select } from '@inquirer/prompts'
+import { search } from '@inquirer/prompts'
 import chalk from 'chalk'
 import { compare, inc, valid } from 'semver'
 import { getActivities, getChangedActivities } from '../util/getActivities.js'
 import { getSingleActivity } from '../util/getSingleActivity.js'
 import { exit, info, prefix } from '../util/log.js'
+import { searchChoices } from '../util/searchChoices.js'
 
 export async function bump(service?: string, version?: string, {
   all = false,
@@ -60,9 +61,9 @@ async function bumpActivity(activity: ActivityMetadataAndFolder, version?: strin
         inc(activity.metadata.version, 'major')!,
       ]
 
-      const selectedVersion = await select({
+      const selectedVersion = await search({
         message: `Please select a version to bump ${activity.metadata.service} to`,
-        choices: validVersions.map(x => ({ name: x, value: x })),
+        source: input => searchChoices(validVersions.map(x => ({ name: x, value: x })), input),
       }).catch(() => exit('Something went wrong.'))
 
       if (!selectedVersion) {

--- a/cli/src/commands/new.ts
+++ b/cli/src/commands/new.ts
@@ -3,7 +3,7 @@ import { cp, mkdir, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { confirm, input, select } from '@inquirer/prompts'
+import { confirm, input, search } from '@inquirer/prompts'
 import chalk from 'chalk'
 import { Validator } from 'jsonschema'
 import { getDiscordUser, getDiscordUserById } from '../util/getDiscordUser.js'
@@ -12,6 +12,7 @@ import { getSchema } from '../util/getSchema.js'
 import { isFirstTimeAuthor } from '../util/isFirstTimeAuthor.js'
 import { exit, prefix, success } from '../util/log.js'
 import { sanitazeFolderName } from '../util/sanitazeFolderName.js'
+import { searchChoices } from '../util/searchChoices.js'
 import { build } from './build.js'
 import { versionizeActivity } from './versionize.js'
 
@@ -88,9 +89,9 @@ export async function newActivity(activity?: string) {
     },
   }).catch(() => exit('Something went wrong.'))
 
-  const category = await select<string>({
+  const category = await search<string>({
     message: 'Category of the service',
-    choices: schema.properties.category.enum,
+    source: input => searchChoices(schema.properties.category.enum, input),
   }).catch(() => exit('Something went wrong.'))
 
   const metadata = {

--- a/cli/src/util/getSingleActivity.ts
+++ b/cli/src/util/getSingleActivity.ts
@@ -1,9 +1,10 @@
 import type { ActivityMetadata } from '../classes/ActivityCompiler.js'
 import type { ActivityMetadataAndFolder } from './getActivities.js'
-import { select } from '@inquirer/prompts'
-import { exit } from '../util/log.js'
-import { mapActivityToChoice } from '../util/mapActivityToChoice.js'
+import { search } from '@inquirer/prompts'
 import { getActivities } from './getActivities.js'
+import { exit } from './log.js'
+import { mapActivityToChoice } from './mapActivityToChoice.js'
+import { searchChoices } from './searchChoices.js'
 
 export async function getSingleActivity(searchMessage: string, service?: string): Promise<ActivityMetadataAndFolder> {
   const activities = await getActivities()
@@ -11,9 +12,9 @@ export async function getSingleActivity(searchMessage: string, service?: string)
   let folder: string
   let versionized: boolean
   if (!service) {
-    ({ metadata, folder, versionized } = await select({
+    ({ metadata, folder, versionized } = await search({
       message: searchMessage,
-      choices: activities.map(activity => mapActivityToChoice(activity)),
+      source: input => searchChoices(activities.map(activity => mapActivityToChoice(activity)), input),
     }))
   }
   else {
@@ -24,9 +25,9 @@ export async function getSingleActivity(searchMessage: string, service?: string)
     }
 
     if (sameServiceActivities.length > 1) {
-      ({ metadata, folder, versionized } = await select({
+      ({ metadata, folder, versionized } = await search({
         message: searchMessage,
-        choices: sameServiceActivities.map(activity => mapActivityToChoice(activity)),
+        source: input => searchChoices(sameServiceActivities.map(activity => mapActivityToChoice(activity)), input),
       }))
     }
     else {

--- a/cli/src/util/searchChoices.ts
+++ b/cli/src/util/searchChoices.ts
@@ -1,0 +1,10 @@
+interface Choice {
+  name: string
+  value: any
+}
+
+export function searchChoices(choices: Choice[], input?: string) {
+  if (!input)
+    return choices
+  return choices.filter(choice => choice.name.toLowerCase().includes(input.toLowerCase()))
+}


### PR DESCRIPTION
## Description

Related to #9406

I've replaced the Inquirer `select` with `search` for better UX:

<img width="357" alt="image" src="https://github.com/user-attachments/assets/c610ad3e-1e6e-4b7b-a037-b0b199faa0d9" />

Now, you can also input non-CJK characters to search.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
