### PR TITLE
feat(AnimeKai): Update Presence functions

### DIFF
--- a/websites/A/AnimeKai/metadata.json
+++ b/websites/A/AnimeKai/metadata.json
@@ -10,7 +10,7 @@
     "en": "AnimeKai is the best website to watch anime online for free, watch anime with DUB, SUB in HD."
   },
   "url": ["animekai.to", "animekai.bz"],
-  "version": "1.0.6",
+  "version": "1.1.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeKai/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeKai/assets/thumbnail.png",
   "color": "#40b15d",

--- a/websites/A/AnimeKai/metadata.json
+++ b/websites/A/AnimeKai/metadata.json
@@ -10,7 +10,7 @@
     "en": "AnimeKai is the best website to watch anime online for free, watch anime with DUB, SUB in HD."
   },
   "url": ["animekai.to", "animekai.bz"],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeKai/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeKai/assets/thumbnail.png",
   "color": "#40b15d",

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -182,8 +182,18 @@ presence.on('UpdateData', async () => {
         break
       }
       case '/user/import': {
-        presenceData.details = 'MAL Import/Export'
+        presenceData.details = 'MAL/AL Import'
+        presenceData.smallImageKey = Assets.Uploading
+        break
+      }
+      case '/user/export': {
+        presenceData.details = 'MAL/AL Export'
         presenceData.smallImageKey = Assets.Downloading
+        break
+      }
+      case '/user/sync': {
+        presenceData.details = 'Syncing with AL'
+        presenceData.smallImageKey = Assets.Writing
         break
       }
       case '/user/notifications': {

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -195,7 +195,7 @@ presence.on('UpdateData', async () => {
         const type = new URLSearchParams(window.location.search).get('type')
         if (type === 'community') {
           presenceData.details = 'Looking at Community Notifications'
-        } 
+        }
         else {
           presenceData.details = 'Looking at Anime Notifications'
         }

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -193,17 +193,28 @@ presence.on('UpdateData', async () => {
       }
       case '/user/sync': {
         presenceData.details = 'Syncing with AL'
-        presenceData.smallImageKey = Assets.Writing
+        presenceData.smallImageKey = Assets.Live
         break
       }
       case '/user/notifications': {
-        presenceData.details = 'Looking at Notifications'
+        const type = new URLSearchParams(window.location.search).get('type')
+        
+        if (type === 'community') {
+          presenceData.details = 'Looking at Community Notifications'
+        } else {
+          presenceData.details = 'Looking at Anime Notifications'
+        }
         presenceData.smallImageKey = Assets.Reading
         break
       }
       case '/user/bookmarks': {
         presenceData.details = 'Managing Bookmarks'
         presenceData.smallImageKey = ActivityAssets.Settings
+        break
+      }
+      case '/upcoming': {
+        presenceData.details = 'Looking at Upcoming'
+        presenceData.smallImageKey = Assets.Reading
         break
       }
       default: {

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -201,13 +201,11 @@ presence.on('UpdateData', async () => {
         presenceData.smallImageKey = Assets.Reading
         break
       }
-      
       case '/user/bookmarks': {
         presenceData.details = 'Managing Bookmarks'
         presenceData.smallImageKey = ActivityAssets.Settings
         break
       }
-      
       case '/upcoming': {
         presenceData.details = 'Looking at Upcoming'
         presenceData.smallImageKey = Assets.Reading

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -192,7 +192,7 @@ presence.on('UpdateData', async () => {
         break
       }
       case '/user/notifications': {
-        const type = new URLSearchParams(window.location.search).get('type')
+        const type = new URLSearchParams(document.location.search).get('type')
         if (type === 'community') {
           presenceData.details = 'Looking at Community Notifications'
         }

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -171,11 +171,6 @@ presence.on('UpdateData', async () => {
         presenceData.smallImageKey = ActivityAssets.Settings
         break
       }
-      case '/user/notification': {
-        presenceData.details = 'Looking at Notifications'
-        presenceData.smallImageKey = ActivityAssets.Notifications
-        break
-      }
       case '/user/watching': {
         presenceData.details = 'Continue Watching'
         presenceData.smallImageKey = Assets.Reading
@@ -198,10 +193,10 @@ presence.on('UpdateData', async () => {
       }
       case '/user/notifications': {
         const type = new URLSearchParams(window.location.search).get('type')
-        
         if (type === 'community') {
           presenceData.details = 'Looking at Community Notifications'
-        } else {
+        }
+        else {
           presenceData.details = 'Looking at Anime Notifications'
         }
         presenceData.smallImageKey = Assets.Reading

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -195,7 +195,8 @@ presence.on('UpdateData', async () => {
         const type = new URLSearchParams(window.location.search).get('type')
         if (type === 'community') {
           presenceData.details = 'Looking at Community Notifications'
-        } else {
+        } 
+        else {
           presenceData.details = 'Looking at Anime Notifications'
         }
         presenceData.smallImageKey = Assets.Reading

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -183,12 +183,12 @@ presence.on('UpdateData', async () => {
       }
       case '/user/import': {
         presenceData.details = 'MAL/AL Import'
-        presenceData.smallImageKey = Assets.Uploading
+        presenceData.smallImageKey = Assets.Downloading
         break
       }
       case '/user/export': {
         presenceData.details = 'MAL/AL Export'
-        presenceData.smallImageKey = Assets.Downloading
+        presenceData.smallImageKey = Assets.Uploading
         break
       }
       case '/user/sync': {


### PR DESCRIPTION
## Description
feat(AnimeKai):
Add functionality when syncing with Anilist
Add functionality when looking at upcoming animes
Add functionality when in MAL/AL Export
Add functionality when looking at notifications (Small change from #9674)
 - Shows 'Looking at Community Notifications' if on community notifications
 - Shows 'Looking at Anime Notifications' if on anime notifications
 
 ## Acknowledgements
- [✅] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [✅] I linted the code by running npm run lint
- [✅] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)