### PR TITLE
feat(AniXL): add activity

### DIFF
--- a/websites/A/Anixl/metadata.json
+++ b/websites/A/Anixl/metadata.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "name": "Anant",
+    "id": "629851641579044874"
+  },
+  "contributors": [
+    {
+      "name": "xDoritos",
+      "id": "432215088686956565"
+    }
+  ],
+  "service": "Anixl",
+  "description": {
+    "en": "Anixl is a modern anime tracker and viewer. Track, review, and organize anime the way you like.",
+    "hi": "Anixl एक आधुनिक एनीमे ट्रैकर है जहाँ आप आसानी से एनीमे ट्रैक, रिव्यू और मैनेज कर सकते हैं।"
+  },
+  "url": [
+    "anixl.to",
+    "www.anixl.to"
+  ],
+  "version": "1.0.0",
+  "logo": "https://i.ibb.co/ycdcwCC0/icon.png",
+  "thumbnail": "https://i.ibb.co/8DhVyvVy/thumbnail.png",
+  "color": "#8151ff",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "manga",
+    "tracker",
+    "anilist"
+  ]
+}

--- a/websites/A/Anixl/presence.ts
+++ b/websites/A/Anixl/presence.ts
@@ -1,0 +1,200 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1380925833371451482',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.ibb.co/ycdcwCC0/icon.png',
+}
+
+function videoActive() {
+  return !!document.querySelector('#app-wrapper > main > div.player-container > div > div > video')
+}
+
+async function getVideoInformation() {
+  const videoEl = document.querySelector<HTMLVideoElement>('#app-wrapper > main > div.player-container > div > div > video')
+  const animeName = document.querySelector('#app-wrapper > main > div.space-y-2 > div:nth-child(1) > a')?.textContent?.trim()
+  const episodeTitle = document.querySelector('#app-wrapper > main > div.space-y-2 > div:nth-child(2) > a')?.textContent?.trim()
+  const bannerSrc = document.querySelector('#app-wrapper > main > div.flex.flex-col.md\\:flex-row > div.flex > div.w-24.md\\:w-52.flex-none.justify-start.items-start > div > img')?.getAttribute('src')
+
+  let currentTime: string | undefined, totalDuration: string | undefined
+  const timeEl = document.querySelector('.art-control-time')
+  const timeText = timeEl?.textContent?.trim() || ''
+  if (timeText.includes(' / ')) {
+    [currentTime, totalDuration] = timeText.split(' / ').map(s => s.trim())
+  }
+
+  const isPlaying = videoEl ? !videoEl.paused && !videoEl.ended : false
+
+  let startTs: number | undefined, endTs: number | undefined
+  if (videoEl && isPlaying && !Number.isNaN(videoEl.duration)) {
+    [startTs, endTs] = getTimestampsFromMedia(videoEl)
+  }
+
+  return {
+    animeName,
+    episodeTitle,
+    bannerSrc,
+    currentTime,
+    totalDuration,
+    isPlaying,
+    startTs,
+    endTs,
+  }
+}
+
+let cacheSeason = {
+  titleId: '',
+  bannerUrl: '',
+  nameAnime: '',
+}
+
+async function updateSeasonInformation(titleId: string) {
+  if (cacheSeason.titleId === titleId)
+    return
+  try {
+    const res = await fetch(`https://anixl.to/title/${titleId}`)
+    const html = await res.text()
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+    const banner = doc.querySelector('#app-wrapper > main > div.flex.flex-col.md\\:flex-row > div.flex > div.w-24.md\\:w-52.flex-none.justify-start.items-start > div > img')?.getAttribute('src')
+    const bannerUrl = `https://anixl.to${banner}`
+    const fullName = doc.querySelector("#app-wrapper > main > div.flex.flex-col.md\\:flex-row > div.mt-3.md\\:mt-0.md\\:pl-3.grow.grid.gap-3.grid-cols-1.lg\\:grid-cols-3 > div.space-y-2.hidden.md\\:block > h3 > a")?.textContent
+    const cleanName = fullName!.split(/Season\s+\d+/i)[0]!.trim()
+    cacheSeason = {
+      bannerUrl: bannerUrl,
+      titleId: '',
+      nameAnime: cleanName,
+    }
+  } catch (e) {
+    console.error(`Error fetching banner`, e)
+  }
+}
+
+const routeMap: Record<string, string> = {
+  '/': 'On Homepage',
+  '/latest': 'Browsing Latest Releases',
+  '/search': 'Searching Anime',
+  '/anilists': 'Exploring AniLists',
+  '/reviews': 'Reading Reviews',
+  '/comments': 'Viewing Comments',
+  '/reports': 'Checking Reports',
+  '/changelog': 'Viewing Changelog',
+  '/my/history': 'Viewing Watch History',
+  '/my/follows': 'Viewing Followed Shows',
+  '/my/folders': 'Browsing Folders',
+  '/my/status': 'Browsing Watch Status',
+  '/my/scores': 'Browsing Scores',
+  '/my/emotions': 'Browsing Emotions',
+  '/my/ctags': 'Browsing Custom Tags',
+  '/my/notes': 'Reading Notes',
+  '/my/anilists': 'Viewing My AniLists',
+  '/my/anilists/liked': 'Viewing Liked AniLists',
+  '/my/reviews': 'Viewing My Reviews',
+  '/my/comments': 'Viewing My Comments',
+  '/site-settings': 'Viewing Site Settings',
+  '/my/messages': 'Viewing Messages',
+  '/my/contacts': 'Viewing Contacts',
+  '/my/contacts/pending': 'Pending Contact Requests',
+  '/my/contacts/ignored': 'Ignored Contacts',
+  '/my/contacts/accepted': 'Accepted Contacts',
+  '/my/contacts/request': 'Contact Requests',
+  '/my/contacts/blocked': 'Blocked Contacts',
+  '/account/profiles': 'Editing Profile',
+  '/account/emails': 'Managing Emails',
+  '/account/password': 'Changing Password',
+  '/account/sessions': 'Managing Sessions',
+  '/account/deletion': 'Account Deletion Page',
+}
+
+const statusMap: Record<string, string> = {
+  wish: 'Wishlisted Anime',
+  doing: 'Currently Watching',
+  completed: 'Completed Anime',
+  on_hold: 'On Hold',
+  dropped: 'Dropped Anime',
+  repeat: 'Rewatching Anime',
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname, search } = document.location
+
+  const presenceData: PresenceData = {
+    details: 'Browsing AniXL',
+    state: 'Browsing AniXL!',
+    largeImageKey: ActivityAssets.Logo,
+    largeImageText: 'AniXL',
+    smallImageKey: Assets.Search,
+    smallImageText: 'Home Page',
+    type: ActivityType.Watching,
+    startTimestamp: browsingTimestamp,
+  }
+
+  let titleId: string | undefined
+  if (pathname.startsWith('/title/')) {
+    const parts = pathname.split('/')
+    titleId = parts[2]
+    if (titleId) await updateSeasonInformation(titleId)
+  }
+
+  if (videoActive()) {
+    const info = await getVideoInformation()
+    if (info.animeName && info.episodeTitle) {
+      presenceData.name = cacheSeason.nameAnime
+      presenceData.state = info.animeName
+      presenceData.details = info.episodeTitle
+      if (cacheSeason.bannerUrl) {
+        presenceData.largeImageKey = cacheSeason.bannerUrl
+        presenceData.largeImageText = info.animeName!
+      }
+      presenceData.smallImageKey = info.isPlaying ? Assets.Play : Assets.Pause
+      presenceData.smallImageText = info.isPlaying ? 'Playing' : 'Paused'
+      if (info.isPlaying && info.startTs && info.endTs) {
+        presenceData.startTimestamp = info.startTs
+        presenceData.endTimestamp = info.endTs
+      } else {
+        delete presenceData.startTimestamp
+        delete presenceData.endTimestamp
+      }
+    }
+  }
+  else if (pathname.startsWith('/title/') && pathname.split('/').length > 3) {
+    const segments = pathname.split('/')
+    const rawEp = segments[segments.length - 1]!
+    presenceData.state = `Episode: ${rawEp.replace(/-/g, ' ')}`
+    presenceData.details = 'Loading...'
+    if (cacheSeason.bannerUrl) {
+      presenceData.largeImageKey = cacheSeason.bannerUrl
+    }
+  }
+  else {
+    if (pathname.startsWith('/my/status') && search.includes('status=')) {
+      const key = new URLSearchParams(search).get('status') || ''
+      presenceData.details = statusMap[key] || presenceData.details
+    }
+    else if (pathname.startsWith('/my/notifications')) {
+      presenceData.details = 'Viewing Notifications'
+    }
+    else if (pathname.startsWith('/title/') && pathname.split('/').length === 3) {
+      const animeName = document.querySelector('img')?.alt
+      const banner = document.querySelector('#app-wrapper > main > div.flex.flex-col.md\\:flex-row > div.flex > div.w-24.md\\:w-52.flex-none.justify-start.items-start > div > img')?.getAttribute('src')
+      if (animeName) {
+        presenceData.state = animeName
+        presenceData.details = 'Browsing Anime'
+        presenceData.largeImageKey = banner?.startsWith('http') ? banner! : `https://anixl.to${banner}`
+        presenceData.largeImageText = animeName
+      }
+    }
+    else {
+      for (const [route, desc] of Object.entries(routeMap)) {
+        if (pathname === route) {
+          presenceData.details = desc
+          break
+        }
+      }
+    }
+  }
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR adds a new presence for AniXL, an anime streaming platform. The presence provides comprehensive support for all major sections of the website and includes optimized performance features.

Features
- Full navigation support across all website tabs including:

- Home page
- Latest releases
- Browse/Search functionality
- AniLists (user lists)
- Account settings


- Built-in caching system to prevent unnecessary API calls and improve performance
- Media timestamp support using getTimestampsFromMedia for detailed playback information when watching videos
- Real-time status updates showing current viewing activity and progress

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

HomePage
![image](https://github.com/user-attachments/assets/87958fa6-57ec-434e-b5b8-77bc0d17ec44)

Latest
![image](https://github.com/user-attachments/assets/6f372a29-5b23-471b-ba56-8980da51d13d)

Browse
![image](https://github.com/user-attachments/assets/91efcc0a-125b-461f-bf58-b3a9d6449374)

AniLists
![image](https://github.com/user-attachments/assets/4f665249-fd3c-4fdd-a4ef-015000d4c39c)

Title Description
![image](https://github.com/user-attachments/assets/ff141038-38a9-40ba-bf17-e7a627c7c7d2)

Video Reproduction
![image](https://github.com/user-attachments/assets/da07ba39-bf94-4313-9b9b-5e11dd773a8c)


</details>
