### PR TITLE
Added sflix.to in metadata.js

### DIFF
--- a/websites/S/Sflix/metadata.json
+++ b/websites/S/Sflix/metadata.json
@@ -11,7 +11,9 @@
   },
   "url": [
     "sflix2.to",
+    "sflix.to",
     "enorme.tv"
+    
   ],
   "version": "1.0.5",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/Sflix/assets/logo.png",


### PR DESCRIPTION
added "sflix.to" back, the original URL.

## Description
title.

## Acknowledgements
- [ Done. ] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [ Done. ] I linted the code by running `npm run lint`
- [ Done ] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)




</details>
