### PR TITLE
fix(Lichess): stop timestamp from resetting constantly

### DIFF
--- a/websites/L/Lichess/presence.ts
+++ b/websites/L/Lichess/presence.ts
@@ -25,7 +25,7 @@ const pages: {
   '/paste': 'Import Game',
   '/games/search': 'Advanced Search',
 }
-const startTimestamp: number = Math.floor(Date.now() / 1000)
+const startTimestamp = Math.floor(Date.now() / 1000)
 
 presence.on('UpdateData', async () => {
   const page = document.location.pathname
@@ -43,7 +43,7 @@ presence.on('UpdateData', async () => {
     ?.trim()
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/L/Lichess/assets/logo.png',
-    startTimestamp: startTimestamp,
+    startTimestamp,
   }
 
   if ((page && pages[page]) || (page && pages[page.slice(0, -1)])) {

--- a/websites/L/Lichess/presence.ts
+++ b/websites/L/Lichess/presence.ts
@@ -25,6 +25,7 @@ const pages: {
   '/paste': 'Import Game',
   '/games/search': 'Advanced Search',
 }
+const startTimestamp: number = Math.floor(Date.now() / 1000)
 
 presence.on('UpdateData', async () => {
   const page = document.location.pathname
@@ -42,7 +43,7 @@ presence.on('UpdateData', async () => {
     ?.trim()
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/L/Lichess/assets/logo.png',
-    startTimestamp: Math.floor(Date.now() / 1000),
+    startTimestamp: startTimestamp,
   }
 
   if ((page && pages[page]) || (page && pages[page.slice(0, -1)])) {


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Create a variable outside the `UpdateData` listener to retain `startTimestamp` in order to prevent it from resetting on every data update during matches.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

> _Screenshots omitted_


</details>
