### PR TITLE
feat(巴哈姆特動畫瘋): update activity image and details

### DIFF
--- a/websites/#/巴哈姆特動畫瘋/metadata.json
+++ b/websites/#/巴哈姆特動畫瘋/metadata.json
@@ -15,7 +15,7 @@
     "zh-tw": "完全免費的動畫平台。"
   },
   "url": "ani.gamer.com.tw",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/%23/%E5%B7%B4%E5%93%88%E5%A7%86%E7%89%B9%E5%8B%95%E7%95%AB%E7%98%8B/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/%23/%E5%B7%B4%E5%93%88%E5%A7%86%E7%89%B9%E5%8B%95%E7%95%AB%E7%98%8B/assets/thumbnail.png",
   "color": "#58bec9",

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -42,7 +42,7 @@ presence.on('UpdateData', async () => {
         presenceData.name = title?.textContent || '巴哈姆特動畫瘋'
 
         const score = document.querySelector<HTMLElement>(
-          '.score-overall-number'
+          '.score-overall-number',
         )
 
         const views = document.querySelector<HTMLElement>(

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -80,6 +80,48 @@ presence.on('UpdateData', async () => {
         presenceData.smallImageKey = Assets.Reading
       }
     }
+    else if (document.querySelector('#partyPlayer_html5_api')) {
+      const video = document.querySelector<HTMLVideoElement>(
+        '#partyPlayer_html5_api',
+      )!;
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
+      if (!Number.isNaN(video.duration)) {
+        presenceData.type = ActivityType.Watching
+        presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play
+        presenceData.smallImageText = video.paused
+          ? (await strings).pause
+          : (await strings).play
+
+        const data = document.querySelector<HTMLImageElement>(
+          '.ani-play-queue-item.is-playing .img-block img'
+        )
+
+        presenceData.largeImageKey = data?.getAttribute('data-src') || ActivityAssets.Logo
+        presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋'
+        presenceData.details = data?.getAttribute('alt')
+        presenceData.name = data?.getAttribute('alt') || '巴哈姆特動畫瘋'
+
+        const onlineViewers = document.querySelector<HTMLElement>(
+          '.people-count'
+        )
+        const queueList = document.querySelector('.ani-queue-list')
+        const upcomingEpisodes = queueList? queueList.querySelectorAll('.ani-play-queue-item').length: 0
+        
+        presenceData.state = `動畫派對 | ${onlineViewers?.textContent || ''}| ${upcomingEpisodes}集待看`
+
+        presenceData.buttons = [
+          {
+            label: (await strings).browseanime,
+            url: document.location.href,
+          },
+        ]
+        if (video.paused) {
+          delete presenceData.startTimestamp
+          delete presenceData.endTimestamp
+        }
+
+    }
+  }
     else if (document.location.pathname.includes('/animeList')) {
       presenceData.startTimestamp = browsingTimestamp
       presenceData.state = '所有動畫'

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -53,7 +53,7 @@ presence.on('UpdateData', async () => {
 
         const image = document.querySelector<HTMLImageElement>('.data-file .data-img')?.getAttribute('data-src')
         presenceData.largeImageKey = image || ActivityAssets.Logo
-        presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋'
+        presenceData.largeImageText = 'PreMiD - 巴哈姆特動畫瘋'
 
         if (score && views)
           presenceData.state = `動畫瘋 | ✩${score.textContent} | ${views?.textContent}觀看`
@@ -97,7 +97,7 @@ presence.on('UpdateData', async () => {
         )
 
         presenceData.largeImageKey = data?.getAttribute('data-src') || ActivityAssets.Logo
-        presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋'
+        presenceData.largeImageText = 'PreMiD - 巴哈姆特動畫瘋'
         presenceData.details = data?.getAttribute('alt')
         presenceData.name = data?.getAttribute('alt') || '巴哈姆特動畫瘋'
 

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -55,7 +55,7 @@ presence.on('UpdateData', async () => {
         presenceData.largeImageKey = image || ActivityAssets.Logo
         presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋';
 
-        if (score)
+        if (score && views)
           presenceData.state = `動畫瘋 | ✩${score.textContent} | ${views?.textContent}觀看`
 
         presenceData.buttons = [

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -114,10 +114,6 @@ presence.on('UpdateData', async () => {
         }
       }
     }
-    else if (document.location.pathname.includes('/animeList')) {
-      presenceData.startTimestamp = browsingTimestamp
-      presenceData.state = '所有動畫'
-    }
   }
 
   if (!presenceData.details) {

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -102,10 +102,10 @@ presence.on('UpdateData', async () => {
         presenceData.name = data?.getAttribute('alt') || '巴哈姆特動畫瘋'
 
         const onlineViewers = document.querySelector<HTMLElement>(
-          '.people-count'
+          '.people-count',
         )
         const queueList = document.querySelector('.ani-queue-list')
-        const upcomingEpisodes = queueList? queueList.querySelectorAll('.ani-play-queue-item').length: 0
+        const upcomingEpisodes = queueList ? queueList.querySelectorAll('.ani-play-queue-item').length : 0
         presenceData.state = `動畫派對 | ${onlineViewers?.textContent || ''}| ${upcomingEpisodes}集待看`
 
         if (video.paused) {

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -39,21 +39,19 @@ presence.on('UpdateData', async () => {
           '#BH_background > div.container-player > div.anime-title > div.anime-option > section.videoname > div.anime_name > h1',
         )
         presenceData.details = title?.textContent
-        presenceData.name = title?.textContent || '巴哈姆特動畫瘋';
+        presenceData.name = title?.textContent || '巴哈姆特動畫瘋'
 
         const score = document.querySelector<HTMLElement>(
           '.score-overall-number'
         )
 
         const views = document.querySelector<HTMLElement>(
-          '.newanime-count span'
+          '.newanime-count span',
         )
 
-        const image = document.querySelector<HTMLImageElement>(
-          '.data-file .data-img')?.getAttribute('data-src'
-        )
+        const image = document.querySelector<HTMLImageElement>('.data-file .data-img')?.getAttribute('data-src')
         presenceData.largeImageKey = image || ActivityAssets.Logo
-        presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋';
+        presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋'
 
         if (score && views)
           presenceData.state = `動畫瘋 | ✩${score.textContent} | ${views?.textContent}觀看`

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -7,6 +7,7 @@ const strings = presence.getStrings({
   play: 'general.playing',
   pause: 'general.paused',
   browsing: 'general.browsing',
+  browseanime: 'general.buttonViewAnime',
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
@@ -59,7 +60,7 @@ presence.on('UpdateData', async () => {
 
         presenceData.buttons = [
           {
-            label: '前往動畫瘋觀看',
+            label: (await strings).browseanime,
             url: document.location.href,
           },
         ]

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -106,15 +106,8 @@ presence.on('UpdateData', async () => {
         )
         const queueList = document.querySelector('.ani-queue-list')
         const upcomingEpisodes = queueList? queueList.querySelectorAll('.ani-play-queue-item').length: 0
-        
         presenceData.state = `動畫派對 | ${onlineViewers?.textContent || ''}| ${upcomingEpisodes}集待看`
 
-        presenceData.buttons = [
-          {
-            label: (await strings).browseanime,
-            url: document.location.href,
-          },
-        ]
         if (video.paused) {
           delete presenceData.startTimestamp
           delete presenceData.endTimestamp

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -6,6 +6,7 @@ const presence = new Presence({
 const strings = presence.getStrings({
   play: 'general.playing',
   pause: 'general.paused',
+  browsing: 'general.browsing',
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
@@ -70,10 +71,11 @@ presence.on('UpdateData', async () => {
       }
       else if (Number.isNaN(video.duration)) {
         presenceData.startTimestamp = browsingTimestamp
+        presenceData.details = (await strings).browsing
         const title = document.querySelector(
           '#BH_background > div.container-player > div.anime-title > div.anime-option > section.videoname > div.anime_name > h1',
         )
-        presenceData.details = title?.textContent
+        presenceData.state = title?.textContent
         presenceData.smallImageKey = Assets.Reading
       }
     }
@@ -85,7 +87,8 @@ presence.on('UpdateData', async () => {
 
   if (!presenceData.details) {
     presenceData.startTimestamp = browsingTimestamp
-    presenceData.details = document
+    presenceData.details = (await strings).browsing
+    presenceData.state = document
       .querySelector('head > title')
       ?.textContent
       ?.replace(' - 巴哈姆特動畫瘋', '')

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets } from 'premid'
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
 
 const presence = new Presence({
   clientId: '640194732718292992',
@@ -15,20 +15,19 @@ enum ActivityAssets {
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
-    type: ActivityType.Playing,
-    largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Watching,
   } as PresenceData
 
   if (document.location.hostname === 'ani.gamer.com.tw') {
     if (document.location.pathname === '/') {
       presenceData.startTimestamp = browsingTimestamp
-      presenceData.details = 'Viewing home page'
+      presenceData.details = '首頁'
     }
     else if (document.querySelector('#ani_video_html5_api')) {
       const video = document.querySelector<HTMLVideoElement>(
         '#ani_video_html5_api',
       )!;
-      [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestampsfromMedia(video)
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
       if (!Number.isNaN(video.duration)) {
         presenceData.type = ActivityType.Watching
         presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play
@@ -40,13 +39,31 @@ presence.on('UpdateData', async () => {
           '#BH_background > div.container-player > div.anime-title > div.anime-option > section.videoname > div.anime_name > h1',
         )
         presenceData.details = title?.textContent
+        presenceData.name = title?.textContent || '巴哈姆特動畫瘋';
 
-        const user = document.querySelector<HTMLElement>(
-          '#BH_background > div.container-player > div.anime-title > div.anime-option > section.videoname > div.anime_name > div > p',
+        const score = document.querySelector<HTMLElement>(
+          '.score-overall-number'
         )
 
-        if (user)
-          presenceData.state = user.textContent
+        const views = document.querySelector<HTMLElement>(
+          '.newanime-count span'
+        )
+
+        const image = document.querySelector<HTMLImageElement>(
+          '.data-file .data-img')?.getAttribute('data-src'
+        )
+        presenceData.largeImageKey = image || ActivityAssets.Logo
+        presenceData.largeImageText = 'Premid - 巴哈姆特動畫瘋';
+
+        if (score)
+          presenceData.state = `動畫瘋 | ✩${score.textContent} | ${views?.textContent}觀看`
+
+        presenceData.buttons = [
+          {
+            label: '前往動畫瘋觀看',
+            url: document.location.href,
+          },
+        ]
 
         if (video.paused) {
           delete presenceData.startTimestamp
@@ -55,7 +72,7 @@ presence.on('UpdateData', async () => {
       }
       else if (Number.isNaN(video.duration)) {
         presenceData.startTimestamp = browsingTimestamp
-        presenceData.details = 'Looking at: '
+        presenceData.details = '正在瀏覽 '
         const title = document.querySelector(
           '#BH_background > div.container-player > div.anime-title > div.anime-option > section.videoname > div.anime_name > h1',
         )
@@ -65,13 +82,13 @@ presence.on('UpdateData', async () => {
     }
     else if (document.location.pathname.includes('/animeList')) {
       presenceData.startTimestamp = browsingTimestamp
-      presenceData.details = 'Viewing all animes'
+      presenceData.details = '瀏覽所有動畫'
     }
   }
 
   if (!presenceData.details) {
     presenceData.startTimestamp = browsingTimestamp
-    presenceData.details = 'Viewing page:'
+    presenceData.details = '正在瀏覽:'
     presenceData.state = document
       .querySelector('head > title')
       ?.textContent

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -111,9 +111,9 @@ presence.on('UpdateData', async () => {
         if (video.paused) {
           delete presenceData.startTimestamp
           delete presenceData.endTimestamp
+        }
       }
     }
-  }
     else if (document.location.pathname.includes('/animeList')) {
       presenceData.startTimestamp = browsingTimestamp
       presenceData.state = '所有動畫'

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -70,24 +70,22 @@ presence.on('UpdateData', async () => {
       }
       else if (Number.isNaN(video.duration)) {
         presenceData.startTimestamp = browsingTimestamp
-        presenceData.details = '正在瀏覽 '
         const title = document.querySelector(
           '#BH_background > div.container-player > div.anime-title > div.anime-option > section.videoname > div.anime_name > h1',
         )
-        presenceData.state = title?.textContent
+        presenceData.details = title?.textContent
         presenceData.smallImageKey = Assets.Reading
       }
     }
     else if (document.location.pathname.includes('/animeList')) {
       presenceData.startTimestamp = browsingTimestamp
-      presenceData.details = '瀏覽所有動畫'
+      presenceData.state = '所有動畫'
     }
   }
 
   if (!presenceData.details) {
     presenceData.startTimestamp = browsingTimestamp
-    presenceData.details = '正在瀏覽:'
-    presenceData.state = document
+    presenceData.details = document
       .querySelector('head > title')
       ?.textContent
       ?.replace(' - 巴哈姆特動畫瘋', '')

--- a/websites/#/巴哈姆特動畫瘋/presence.ts
+++ b/websites/#/巴哈姆特動畫瘋/presence.ts
@@ -93,7 +93,7 @@ presence.on('UpdateData', async () => {
           : (await strings).play
 
         const data = document.querySelector<HTMLImageElement>(
-          '.ani-play-queue-item.is-playing .img-block img'
+          '.ani-play-queue-item.is-playing .img-block img',
         )
 
         presenceData.largeImageKey = data?.getAttribute('data-src') || ActivityAssets.Logo
@@ -111,8 +111,7 @@ presence.on('UpdateData', async () => {
         if (video.paused) {
           delete presenceData.startTimestamp
           delete presenceData.endTimestamp
-        }
-
+      }
     }
   }
     else if (document.location.pathname.includes('/animeList')) {


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

- Displaying the anime title directly as the presence name.

- Updating the presence image to use the anime cover art directly.

- Modifying presence details to show the anime rating and watch count.

- Add anime party support

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
![CleanShot 2025-07-01 at 15 01 14](https://github.com/user-attachments/assets/9b64dee7-d88b-4317-9dfd-26294e28c247)
![CleanShot 2025-07-01 at 18 50 20](https://github.com/user-attachments/assets/f747b8a7-01ec-40e8-9eed-286ed5f4b708)
![CleanShot 2025-07-02 at 13 05 43](https://github.com/user-attachments/assets/e47ed5a8-7f67-4052-a591-03bf4474c942)

<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->


</details>
