### PR TITLE
fix(nebula): update channel status + add watching activity type

### DIFF
--- a/websites/N/Nebula/metadata.json
+++ b/websites/N/Nebula/metadata.json
@@ -9,8 +9,8 @@
   "description": {
     "en": "Nebula is the home of smart, thoughtful videos, podcasts, and classes from your favorite creators."
   },
-  "url": "nebula.tv",
-  "version": "1.0.11",
+  "url": ["nebula.tv", "beta.nebula.tv"],
+  "version": "1.1.12",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/N/Nebula/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/Nebula/assets/thumbnail.jpeg",
   "color": "#67bef5",

--- a/websites/N/Nebula/metadata.json
+++ b/websites/N/Nebula/metadata.json
@@ -5,6 +5,12 @@
     "id": "189690228292845568",
     "name": "angelolz"
   },
+  "contributors": [
+    {
+      "id": "330462254053064704",
+      "name": "imgalvin"
+    }
+  ],
   "service": "Nebula",
   "description": {
     "en": "Nebula is the home of smart, thoughtful videos, podcasts, and classes from your favorite creators."

--- a/websites/N/Nebula/presence.ts
+++ b/websites/N/Nebula/presence.ts
@@ -176,32 +176,31 @@ function getOtherDetails(
 
   if (videoElement === null && audioElement === null) {
     // Viewing a channel or podcast page
-    let channelName: string | null = null;
+    let channelName: string | null = null
 
     // Try getting channel name from the page
-    const channelHeading = document.querySelector('main > div > h1');
+    const channelHeading = document.querySelector('main > div > h1')
     if (channelHeading instanceof HTMLElement) {
-      channelName = channelHeading.textContent?.trim() || null;
+      channelName = channelHeading.textContent?.trim() || null
     }
 
-    const podcastElement = document.querySelector('main > div > div > div > div > h1') as HTMLElement | null;
-    const podcastName = podcastElement?.textContent?.trim() || null;
+    const podcastElement = document.querySelector('main > div > div > div > div > h1') as HTMLElement | null
+    const podcastName = podcastElement?.textContent?.trim() || null
 
     // Fallback to RSS link + title if no channel heading
     // I know this solution is very... "what" but all headings are images and this is the only way to tell for sure that a page is a channel
     if (!channelName && !podcastName) {
-      const rssLink = document.querySelector('link[rel="alternate"][type="application/rss+xml"]') as HTMLLinkElement | null;
-      const title = document.querySelector('title')?.textContent?.trim();
-      if (!channelName && rssLink?.href && title) {
-        channelName = title.includes(' | ') ? title.split(' | ')[0] || null : null;
-      } else {
-        return;
-      }
+      const rssLink = document.querySelector('link[rel="alternate"][type="application/rss+xml"]') as HTMLLinkElement | null
+      const title = document.querySelector('title')?.textContent?.trim()
+      if (channelName || !(rssLink?.href && title))
+        return
+
+      channelName = title.includes(' | ') ? title.split(' | ')[0] || null : null
     }
 
-    const isPodcast = !channelName;
-    presenceData.details = isPodcast ? 'Viewing a podcast' : 'Viewing a channel';
-    presenceData.state = isPodcast ? podcastName : channelName;
+    const isPodcast = !channelName
+    presenceData.details = isPodcast ? 'Viewing a podcast' : 'Viewing a channel'
+    presenceData.state = isPodcast ? podcastName : channelName
 
     if (showButtons) {
       presenceData.buttons = [
@@ -209,7 +208,7 @@ function getOtherDetails(
           label: isPodcast ? 'View Podcast' : 'View Channel',
           url: href,
         },
-      ];
+      ]
     }
   }
 
@@ -255,10 +254,10 @@ function getOtherDetails(
       presenceData.details = `${document.querySelector(
         `${classInfoElementSelector} > div:nth-of-type(1)`,
       )?.textContent
-        } | ${document.querySelector(
-          `${classInfoElementSelector} > div:nth-of-type(2)`,
-        )?.textContent
-        }`
+      } | ${document.querySelector(
+        `${classInfoElementSelector} > div:nth-of-type(2)`,
+      )?.textContent
+      }`
       presenceData.state = document.querySelector(
         `${classInfoElementSelector} > div:nth-of-type(3)`,
       )?.textContent
@@ -317,5 +316,5 @@ function parseQueryParams(): QueryParams {
 
 function getRootUrl(): string {
   return `${document.location.protocol}//${document.location.hostname}${document.location.port ? `:${document.location.port}` : ''
-    }`
+  }`
 }

--- a/websites/N/Nebula/presence.ts
+++ b/websites/N/Nebula/presence.ts
@@ -1,4 +1,5 @@
-import { Assets } from 'premid'
+import { ActivityType, Assets } from 'premid'
+import { getTimestampsFromMedia } from 'premid'
 
 const presence = new Presence({
   clientId: '1212664221788274698',
@@ -38,6 +39,9 @@ function getDetails(
   }
 
   switch (path[0]?.toLowerCase()) {
+    case 'featured':
+      presenceData.details = 'Viewing featured page'
+      break
     case 'classes':
       presenceData.details = 'Viewing classes'
       break
@@ -236,15 +240,13 @@ function getOtherDetails(
       )?.textContent
     }
     else {
-      presenceData.details = `${
-        document.querySelector(
-          `${classInfoElementSelector} > div:nth-of-type(1)`,
-        )?.textContent
-      } | ${
-        document.querySelector(
+      presenceData.details = `${document.querySelector(
+        `${classInfoElementSelector} > div:nth-of-type(1)`,
+      )?.textContent
+        } | ${document.querySelector(
           `${classInfoElementSelector} > div:nth-of-type(2)`,
         )?.textContent
-      }`
+        }`
       presenceData.state = document.querySelector(
         `${classInfoElementSelector} > div:nth-of-type(3)`,
       )?.textContent
@@ -268,12 +270,13 @@ function setTimestamps(
   presenceData: PresenceData,
 ): void {
   delete presenceData.startTimestamp;
-  [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestampsfromMedia(element)
+  [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(element)
   if (element.paused) {
     delete presenceData.endTimestamp
     presenceData.smallImageKey = Assets.Pause
   }
   else {
+    presenceData.type = ActivityType.Watching
     presenceData.smallImageKey = Assets.Play
   }
 }
@@ -301,7 +304,6 @@ function parseQueryParams(): QueryParams {
 }
 
 function getRootUrl(): string {
-  return `${document.location.protocol}//${document.location.hostname}${
-    document.location.port ? `:${document.location.port}` : ''
-  }`
+  return `${document.location.protocol}//${document.location.hostname}${document.location.port ? `:${document.location.port}` : ''
+    }`
 }


### PR DESCRIPTION
## Description

- Some channel pages have a different layout compared to the rest so this fixes the activity just showing "nebula" and shows "viewing channel" as intended
- When watching a video, it shows the activity type as watching
- Home page redirects to /featured for signed-in users, and adds support for this new page

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![image](https://github.com/user-attachments/assets/59de192c-7601-44e0-9f33-fcb38857c876)

![image](https://github.com/user-attachments/assets/26e28977-9f22-41fa-9c3e-7369f8e6547c)




</details>
