### PR TITLE
feat(HBO Max): add presence and remove the old Max

### DIFF
--- a/websites/H/HBO Max/metadata.json
+++ b/websites/H/HBO Max/metadata.json
@@ -16,7 +16,7 @@
     "en": "The streaming platform with a personalized user experience that brings unique and unexpected stories ranging from the highest quality in scripted programming to the best of unscripted, family-friendly content, the HBO service, HBO Max Originals and more."
   },
   "url": "play.hbomax.com",
-  "version": "1.0.6",
+  "version": "1.0.0",
   "logo": "https://i.imgur.com/emhftkc.jpeg",
   "thumbnail": "https://i.imgur.com/KfLS9TD.jpeg",
   "color": "#0014a4",

--- a/websites/H/HBO Max/metadata.json
+++ b/websites/H/HBO Max/metadata.json
@@ -5,10 +5,12 @@
     "name": "Slowlife",
     "id": "374905512661221377"
   },
-  "contributors": [{
-    "name": "entraptaa",
-    "id": "153980822670671872"
-  }],
+  "contributors": [
+    {
+      "name": "entraptaa",
+      "id": "153980822670671872"
+    }
+  ],
   "service": "HBO Max",
   "description": {
     "en": "The streaming platform with a personalized user experience that brings unique and unexpected stories ranging from the highest quality in scripted programming to the best of unscripted, family-friendly content, the HBO service, HBO Max Originals and more."

--- a/websites/H/HBO Max/metadata.json
+++ b/websites/H/HBO Max/metadata.json
@@ -5,14 +5,18 @@
     "name": "Slowlife",
     "id": "374905512661221377"
   },
-  "service": "Max",
+  "contributors": [{
+    "name": "entraptaa",
+    "id": "153980822670671872"
+  }],
+  "service": "HBO Max",
   "description": {
-    "en": "The streaming platform with a personalized user experience that brings unique and unexpected stories ranging from the highest quality in scripted programming to the best of unscripted, family-friendly content, the HBO service, Max Originals and more."
+    "en": "The streaming platform with a personalized user experience that brings unique and unexpected stories ranging from the highest quality in scripted programming to the best of unscripted, family-friendly content, the HBO service, HBO Max Originals and more."
   },
-  "url": "play.max.com",
-  "version": "1.0.5",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/M/Max/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Max/assets/thumbnail.jpeg",
+  "url": "play.hbomax.com",
+  "version": "1.0.6",
+  "logo": "https://i.imgur.com/emhftkc.jpeg",
+  "thumbnail": "https://i.imgur.com/KfLS9TD.jpeg",
   "color": "#0014a4",
   "category": "videos",
   "tags": [

--- a/websites/H/HBO Max/presence.ts
+++ b/websites/H/HBO Max/presence.ts
@@ -1,13 +1,13 @@
 import { ActivityType, Assets } from 'premid'
 
 const presence = new Presence({
-  clientId: '1256196660657393714',
+  clientId: '1394513095367463043',
 })
 
 let isFetching = false
 
 enum ActivityAssets {
-  Logo = 'https://cdn.rcd.gg/PreMiD/websites/M/Max/assets/logo.png',
+  Logo = 'https://i.imgur.com/emhftkc.jpeg',
 }
 
 let fetchedInfo: {
@@ -54,7 +54,7 @@ async function fetchPageInfo() {
 
   try {
     fetchedInfo = await fetch(
-      `https://default.any-amer.prd.api.max.com/cms/routes${pathname}?include=default&page[items.size]=10`,
+      `https://default.any-amer.prd.api.hbomax.com/cms/routes${pathname}?include=default&page[items.size]=10`,
       {
         method: 'GET',
         credentials: 'include',


### PR DESCRIPTION
## Description
Max has been shut down, going back to it's old HBO Max name.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="247" height="127" alt="Browsing" src="https://github.com/user-attachments/assets/90ca4efa-24c1-453d-b2dd-6f03ad995f44" />
<img width="298" height="114" alt="Viewing" src="https://github.com/user-attachments/assets/58a6eff1-a50f-4054-b09a-207a4b851cb5" />
<img width="704" height="119" alt="Watching" src="https://github.com/user-attachments/assets/b2d86c10-4feb-4490-ba87-dfe339b088f1" />
<img width="707" height="121" alt="Watching (No Logo)" src="https://github.com/user-attachments/assets/6b4b13cc-b1ad-4296-af04-8371926659af" />




</details>
