### PR TITLE
feat(ManwhaWeb): add activity

### DIFF
--- a/websites/M/ManhwaWeb/metadata.json
+++ b/websites/M/ManhwaWeb/metadata.json
@@ -15,7 +15,7 @@
   ],
   "version": "1.0.0",
   "logo": "https://i.imgur.com/kulV4oU.png",
-  "thumbnail": "https://i.imgur.com/kulV4oU.png",
+  "thumbnail": "https://i.imgur.com/Ct6AWqP.png",
   "color": "#1e1e2e",
   "category": "anime",
   "tags": [

--- a/websites/M/ManhwaWeb/metadata.json
+++ b/websites/M/ManhwaWeb/metadata.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "689564989484302415",
+    "name": "theAsk"
+  },
+  "service": "ManhwaWeb",
+  "description": {
+    "en": "Your online library of 18+ Manhwas in Spanish and favorite raws on a single page - Manhwa Web"
+  },
+  "url": [
+    "www.manhwaweb.com",
+    "manhwaweb.com"
+  ],
+  
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/kulV4oU.png",
+  "thumbnail": "https://i.imgur.com/kulV4oU.png",
+  "color": "#1e1e2e",
+  "category": "anime",
+  "tags": [
+    "manga",
+    "manhwa",
+    "reading"
+  ],
+  "settings": [
+    {
+      "id": "time",
+      "title": "Show Timestamps",
+      "icon": "fad fa-stopwatch",
+      "value": true
+    },
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "cover",
+      "title": "Show Cover Art",
+      "icon": "fad fa-image",
+      "value": true,
+      "if": {
+        "privacy": false
+      }
+    }
+  ]
+}

--- a/websites/M/ManhwaWeb/metadata.json
+++ b/websites/M/ManhwaWeb/metadata.json
@@ -13,7 +13,6 @@
     "www.manhwaweb.com",
     "manhwaweb.com"
   ],
-  
   "version": "1.0.0",
   "logo": "https://i.imgur.com/kulV4oU.png",
   "thumbnail": "https://i.imgur.com/kulV4oU.png",

--- a/websites/M/ManhwaWeb/presence.ts
+++ b/websites/M/ManhwaWeb/presence.ts
@@ -18,11 +18,11 @@ async function getStrings() {
     browsing: 'Navegando...',
     loading: 'Cargando...',
     library: 'Biblioteca',
-    rankings: 'Cromas',
+    rankings: 'Cromos',
     spoilers: 'Spoilers',
     preparing: 'Preparando...',
     chapter: 'Capítulo',
-    unknownChapter: '¿?'
+    unknownChapter: '¿?',
   })
 }
 
@@ -31,84 +31,67 @@ let oldLang: string | null = null
 
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
-    largeImageKey: ActivityAssets.Logo
+    largeImageKey: ActivityAssets.Logo,
   }
-
   const [lang, showTime, privacy, showCover] = await Promise.all([
     presence.getSetting<string>('lang').catch(() => 'en'),
     presence.getSetting<boolean>('time'),
     presence.getSetting<boolean>('privacy'),
-    presence.getSetting<boolean>('cover')
+    presence.getSetting<boolean>('cover'),
   ])
-
   if (!strings || lang !== oldLang) {
     oldLang = lang
     strings = await getStrings()
   }
-
   const { pathname } = location
-
   if (showTime) {
     presenceData.startTimestamp = browsingTimestamp
   }
-
   if (pathname === '/') {
     presenceData.details = strings.preparing
-  } else if (pathname.startsWith('/manhwa/')) {
+  }
+  else if (pathname.startsWith('/manhwa/')) {
     const title = document.querySelector('h2')?.textContent?.trim() || strings.loading
-    const cover = document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content ||
-                  document.querySelector<HTMLImageElement>('img.w-full.object-cover')?.src
-
-    presenceData.details = privacy
-      ? strings.viewing
-      : `${strings.viewing}: ${title}`
-
+    const cover = document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content || document.querySelector<HTMLImageElement>('img.w-full.object-cover')?.src
+    presenceData.details = privacy ? strings.viewing : `${strings.viewing}: ${title}`
     presenceData.smallImageKey = Assets.Viewing
     presenceData.smallImageText = strings.viewing
-
-    presenceData.largeImageKey = !privacy && showCover && cover
-      ? cover
-      : ActivityAssets.Logo
-
-  } else if (pathname.startsWith('/leer/')) {
+    presenceData.largeImageKey = !privacy && showCover && cover ? cover : ActivityAssets.Logo
+  }
+  else if (pathname.startsWith('/leer/')) {
     const title = document.querySelector('div.text-center')?.textContent?.trim()
     const chapterMatch = document.title.match(/Cap[ií]tulo\s+(\d+)/i)
     const chapter = chapterMatch?.[1] ?? strings.unknownChapter
-
-    presenceData.details = privacy
-      ? strings.reading
-      : `${strings.reading}: ${title}`
-
+    presenceData.details = privacy ? strings.reading : `${strings.reading}: ${title}`
     presenceData.state = privacy ? undefined : `${strings.chapter} ${chapter}`
-
     presenceData.smallImageKey = Assets.Reading
     presenceData.smallImageText = strings.reading
-
     presenceData.largeImageKey = ActivityAssets.Logo
-
-  } else if (pathname.startsWith('/profile')) {
-    const username = document.querySelector<HTMLDivElement>(
-      "div.text-md, .xs\\:text-2xl, .sm\\:text-3xl, .md\\:text-4xl.font-semibold"
-    )?.textContent?.trim()
-
-    presenceData.details = `${'Viendo perfil:'} ${username ?? 'Usuario desconocido'}`
-    presenceData.largeImageKey = ActivityAssets.Logo
-
-  } else if (pathname.startsWith('/mis-manhwas')) {
+  }
+  else if (pathname.startsWith('/profile')) {
+    const username = document.querySelector<HTMLDivElement>('div.text-md, .xs\\:text-2xl, .sm\\:text-3xl, .md\\:text-4xl.font-semibold')?.textContent?.trim()
+    presenceData.details = `Viendo perfil: ${username ?? 'Usuario desconocido'}`
+  }
+  else if (pathname.startsWith('/mis-manhwas')) {
     presenceData.details = strings.library
-  } else if (pathname.startsWith('/rank')) {
+  }
+  else if (pathname.startsWith('/rank')) {
     presenceData.details = strings.rankings
-  } else if (pathname.startsWith('/spoilers')) {
+  }
+  else if (pathname.startsWith('/spoilers')) {
     presenceData.details = strings.spoilers
-  } else if (pathname.startsWith('/latest-chapters')) {
+  }
+  else if (pathname.startsWith('/latest-chapters')) {
     presenceData.details = 'Viendo últimos capítulos'
-  } else if (pathname.startsWith('/register')) {
+  }
+  else if (pathname.startsWith('/register')) {
     presenceData.details = 'En la página de Registro'
-  } else if (pathname.startsWith('/login')) {
+  }
+  else if (pathname.startsWith('/login')) {
     presenceData.details = 'En la página de Inicio de Sesión'
-  } else {
+  }
+  else {
     presenceData.details = strings.browsing
   }
-
   presence.setActivity(presenceData)
 })

--- a/websites/M/ManhwaWeb/presence.ts
+++ b/websites/M/ManhwaWeb/presence.ts
@@ -1,0 +1,123 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1395265529530548256',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/kulV4oU.png',
+}
+
+async function getStrings() {
+  return presence.getStrings({
+    reading: 'Leyendo',
+    viewing: 'Viendo',
+    home: 'Inicio',
+    browsing: 'Navegando...',
+    loading: 'Cargando...',
+    library: 'Biblioteca',
+    rankings: 'Cromas',
+    spoilers: 'Spoilers',
+    preparing: 'Preparando...',
+    chapter: 'Capítulo',
+    unknownChapter: '¿?'
+  })
+}
+
+let strings: Awaited<ReturnType<typeof getStrings>>
+let oldLang: string | null = null
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo
+  }
+
+  const [lang, showTime, privacy, showCover] = await Promise.all([
+    presence.getSetting<string>('lang').catch(() => 'en'),
+    presence.getSetting<boolean>('time'),
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('cover')
+  ])
+
+  if (!strings || lang !== oldLang) {
+    oldLang = lang
+    strings = await getStrings()
+  }
+
+  const { pathname } = location
+
+  if (showTime) {
+    presenceData.startTimestamp = browsingTimestamp
+  }
+
+  if (pathname === '/') {
+    presenceData.details = strings.preparing
+  } else if (pathname.startsWith('/manhwa/')) {
+    const title = document.querySelector('h2')?.textContent?.trim() || strings.loading
+    const cover = document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content ||
+                  document.querySelector<HTMLImageElement>('img.w-full.object-cover')?.src
+
+    presenceData.details = privacy
+      ? strings.viewing
+      : `${strings.viewing}: ${title}`
+
+    presenceData.smallImageKey = Assets.Viewing
+    presenceData.smallImageText = strings.viewing
+
+    presenceData.largeImageKey = !privacy && showCover && cover
+      ? cover
+      : ActivityAssets.Logo
+
+  } else if (pathname.startsWith('/leer/')) {
+    const title = document.querySelector('div.text-center')?.textContent?.trim()
+    const chapterMatch = document.title.match(/Cap[ií]tulo\s+(\d+)/i)
+    const chapter = chapterMatch?.[1] ?? strings.unknownChapter
+
+    presenceData.details = privacy
+      ? strings.reading
+      : `${strings.reading}: ${title}`
+
+    presenceData.state = privacy ? undefined : `${strings.chapter} ${chapter}`
+
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = strings.reading
+
+    const firstImage = document.querySelector<HTMLImageElement>('img.w-full, img.w-7\\/12')?.src
+
+    presenceData.largeImageKey = !privacy && showCover
+      ? firstImage ?? ActivityAssets.Logo
+      : ActivityAssets.Logo
+
+  } else if (pathname.startsWith('/profile')) {
+    const username = document.querySelector<HTMLDivElement>(
+      "div.text-md, .xs\\:text-2xl, .sm\\:text-3xl, .md\\:text-4xl.font-semibold"
+    )?.textContent?.trim()
+
+    const avatarImg = document.querySelector<HTMLImageElement>(
+      "img.object-cover.rounded-md.border-bronce"
+    )
+    const avatarUrl = avatarImg?.src
+
+    presenceData.details = `${'Viendo perfil:'} ${username ?? 'Usuario desconocido'}`
+    presenceData.largeImageKey = avatarUrl ?? ActivityAssets.Logo
+
+  } else if (pathname.startsWith('/mis-manhwas')) {
+    presenceData.details = strings.library
+  } else if (pathname.startsWith('/rank')) {
+    presenceData.details = strings.rankings
+  } else if (pathname.startsWith('/spoilers')) {
+    presenceData.details = strings.spoilers
+  } else if (pathname.startsWith('/latest-chapters')) {
+    presenceData.details = 'Viendo últimos capítulos'
+  } else if (pathname.startsWith('/register')) {
+    presenceData.details = 'En la página de Registro'
+  } else if (pathname.startsWith('/login')) {
+    presenceData.details = 'En la página de Inicio de Sesión'
+  } else {
+    presenceData.details = strings.browsing
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/M/ManhwaWeb/presence.ts
+++ b/websites/M/ManhwaWeb/presence.ts
@@ -84,24 +84,15 @@ presence.on('UpdateData', async () => {
     presenceData.smallImageKey = Assets.Reading
     presenceData.smallImageText = strings.reading
 
-    const firstImage = document.querySelector<HTMLImageElement>('img.w-full, img.w-7\\/12')?.src
-
-    presenceData.largeImageKey = !privacy && showCover
-      ? firstImage ?? ActivityAssets.Logo
-      : ActivityAssets.Logo
+    presenceData.largeImageKey = ActivityAssets.Logo
 
   } else if (pathname.startsWith('/profile')) {
     const username = document.querySelector<HTMLDivElement>(
       "div.text-md, .xs\\:text-2xl, .sm\\:text-3xl, .md\\:text-4xl.font-semibold"
     )?.textContent?.trim()
 
-    const avatarImg = document.querySelector<HTMLImageElement>(
-      "img.object-cover.rounded-md.border-bronce"
-    )
-    const avatarUrl = avatarImg?.src
-
     presenceData.details = `${'Viendo perfil:'} ${username ?? 'Usuario desconocido'}`
-    presenceData.largeImageKey = avatarUrl ?? ActivityAssets.Logo
+    presenceData.largeImageKey = ActivityAssets.Logo
 
   } else if (pathname.startsWith('/mis-manhwas')) {
     presenceData.details = strings.library


### PR DESCRIPTION
## Description
Hi, I'm elAsksito!
This PR introduces a new activity for ManwhaWeb, a site I personally enjoy for reading manga and manhwas.
The activity detects when a user is reading or browsing on the site and displays relevant rich presence information.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="1736" height="994" alt="reading" src="https://github.com/user-attachments/assets/cb2e0959-2857-4822-908f-8f9dc4731946" />
<img width="1736" height="994" alt="viewing" src="https://github.com/user-attachments/assets/ce46612f-ac08-432a-bbe3-500a4901cd3b" />
<img width="1736" height="994" alt="profile" src="https://github.com/user-attachments/assets/9ddff363-7c07-42ad-ba96-186e9a53108b" />

</details>
