### PR TITLE
feat(OpenFront.io): add activity

### DIFF
--- a/websites/O/OpenFront.io/metadata.json
+++ b/websites/O/OpenFront.io/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "983433606393368577",
+    "name": "d.ima"
+  },
+  "service": "OpenFront.io",
+  "description": {
+    "en": "OpenFront.io is an online strategic territory expansion game."
+  },
+  "url": "openfront.io",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/Lc2MCM6.png",
+  "thumbnail": "https://i.imgur.com/kzHqugg.png",
+  "color": "#2563eb",
+  "category": "games",
+  "tags": [
+    "openfront",
+    "strategy",
+    "multiplayer",
+    "online",
+    "territory"
+  ]
+}

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -1,0 +1,72 @@
+import { Assets } from 'premid';
+
+const presence = new Presence({
+  clientId: '1395486313251213494',
+});
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/Lc2MCM6.png',
+}
+
+let isInGame = false;
+let gameStartTimestamp: number | null = null;
+
+presence.on('UpdateData', async () => {
+  const path = window.location.pathname.toLowerCase();
+
+  if (path.includes('/join/')) {
+    if (isInGame && gameStartTimestamp !== null) {
+      presence.setActivity({
+        largeImageKey: ActivityAssets.Logo,
+        smallImageKey: Assets.Play,
+        startTimestamp: gameStartTimestamp,
+        details: 'In a game',
+      });
+      return;
+    }
+
+    presence.setActivity({
+      largeImageKey: ActivityAssets.Logo,
+      smallImageKey: Assets.Search,
+      details: 'Waiting for players...',
+    });
+
+    const targetDiv = Array.from(document.querySelectorAll('div'))
+      .find(div => /^\d+s$/.test(div.textContent?.trim() ?? ''));
+
+    if (targetDiv) {
+      const observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === 'childList' || mutation.type === 'characterData') {
+            const newText = (targetDiv.textContent ?? '').trim();
+
+            if (/^\d+s$/.test(newText)) {
+              isInGame = true;
+              gameStartTimestamp = Math.floor(Date.now() / 1000);
+
+              presence.setActivity({
+                largeImageKey: ActivityAssets.Logo,
+                smallImageKey: Assets.Play,
+                startTimestamp: gameStartTimestamp,
+                details: 'In a game',
+              });
+
+              observer.disconnect();
+              break;
+            }
+          }
+        }
+      });
+
+      observer.observe(targetDiv, { childList: true, subtree: true, characterData: true });
+    }
+  } else {
+    isInGame = false;
+    gameStartTimestamp = null;
+
+    presence.setActivity({
+      largeImageKey: ActivityAssets.Logo,
+      details: 'In the lobby',
+    });
+  }
+});

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -28,7 +28,7 @@ presence.on('UpdateData', async () => {
     presence.setActivity({
       largeImageKey: ActivityAssets.Logo,
       smallImageKey: Assets.Search,
-      details: 'Waiting for players...',
+      details: 'Loading players...',
     })
 
     const targetDiv = document.querySelector('div.w-15.h-8.lg\\:w-24.lg\\:h-10')

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -12,7 +12,7 @@ let isInGame = false
 let gameStartTimestamp: number | null = null
 
 presence.on('UpdateData', async () => {
-  const path = window.location.pathname.toLowerCase()
+  const path = document.location.pathname.toLowerCase()
 
   if (path.includes('/join/')) {
     if (isInGame && gameStartTimestamp !== null) {

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -1,18 +1,18 @@
-import { Assets } from 'premid';
+import { Assets } from 'premid'
 
 const presence = new Presence({
   clientId: '1395486313251213494',
-});
+})
 
 enum ActivityAssets {
   Logo = 'https://i.imgur.com/Lc2MCM6.png',
 }
 
-let isInGame = false;
-let gameStartTimestamp: number | null = null;
+let isInGame = false
+let gameStartTimestamp: number | null = null
 
 presence.on('UpdateData', async () => {
-  const path = window.location.pathname.toLowerCase();
+  const path = window.location.pathname.toLowerCase()
 
   if (path.includes('/join/')) {
     if (isInGame && gameStartTimestamp !== null) {
@@ -21,52 +21,53 @@ presence.on('UpdateData', async () => {
         smallImageKey: Assets.Play,
         startTimestamp: gameStartTimestamp,
         details: 'In a game',
-      });
-      return;
+      })
+      return
     }
 
     presence.setActivity({
       largeImageKey: ActivityAssets.Logo,
       smallImageKey: Assets.Search,
       details: 'Waiting for players...',
-    });
+    })
 
     const targetDiv = Array.from(document.querySelectorAll('div'))
-      .find(div => /^\d+s$/.test(div.textContent?.trim() ?? ''));
+      .find(div => /^\d+s$/.test(div.textContent?.trim() ?? ''))
 
     if (targetDiv) {
       const observer = new MutationObserver((mutationsList) => {
         for (const mutation of mutationsList) {
           if (mutation.type === 'childList' || mutation.type === 'characterData') {
-            const newText = (targetDiv.textContent ?? '').trim();
+            const newText = (targetDiv.textContent ?? '').trim()
 
             if (/^\d+s$/.test(newText)) {
-              isInGame = true;
-              gameStartTimestamp = Math.floor(Date.now() / 1000);
+              isInGame = true
+              gameStartTimestamp = Math.floor(Date.now() / 1000)
 
               presence.setActivity({
                 largeImageKey: ActivityAssets.Logo,
                 smallImageKey: Assets.Play,
                 startTimestamp: gameStartTimestamp,
                 details: 'In a game',
-              });
+              })
 
-              observer.disconnect();
-              break;
+              observer.disconnect()
+              break
             }
           }
         }
-      });
+      })
 
-      observer.observe(targetDiv, { childList: true, subtree: true, characterData: true });
+      observer.observe(targetDiv, { childList: true, subtree: true, characterData: true })
     }
-  } else {
-    isInGame = false;
-    gameStartTimestamp = null;
+  }
+  else {
+    isInGame = false
+    gameStartTimestamp = null
 
     presence.setActivity({
       largeImageKey: ActivityAssets.Logo,
       details: 'In the lobby',
-    });
+    })
   }
-});
+})

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -31,8 +31,7 @@ presence.on('UpdateData', async () => {
       details: 'Waiting for players...',
     })
 
-    const targetDiv = Array.from(document.querySelectorAll('div'))
-      .find(div => /^\d+s$/.test(div.textContent?.trim() ?? ''))
+    const targetDiv = document.querySelector('div.w-15.h-8.lg\\:w-24.lg\\:h-10')
 
     if (targetDiv) {
       const observer = new MutationObserver((mutationsList) => {
@@ -40,7 +39,7 @@ presence.on('UpdateData', async () => {
           if (mutation.type === 'childList' || mutation.type === 'characterData') {
             const newText = (targetDiv.textContent ?? '').trim()
 
-            if (/^\d+s$/.test(newText)) {
+            if (/^\d+/.test(newText)) {
               isInGame = true
               gameStartTimestamp = Math.floor(Date.now() / 1000)
 
@@ -60,8 +59,7 @@ presence.on('UpdateData', async () => {
 
       observer.observe(targetDiv, { childList: true, subtree: true, characterData: true })
     }
-  }
-  else {
+  } else {
     isInGame = false
     gameStartTimestamp = null
 

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -14,7 +14,7 @@ let observerInitialized = false
 let observer: MutationObserver | null = null
 
 presence.on('UpdateData', async () => {
-  const hash = window.location.hash.toLowerCase()
+  const hash = document.location.hash.toLowerCase()
 
   if (hash.startsWith('#join=')) {
     if (isInGame && gameStartTimestamp !== null) {

--- a/websites/O/OpenFront.io/presence.ts
+++ b/websites/O/OpenFront.io/presence.ts
@@ -59,7 +59,8 @@ presence.on('UpdateData', async () => {
 
       observer.observe(targetDiv, { childList: true, subtree: true, characterData: true })
     }
-  } else {
+  }
+  else {
     isInGame = false
     gameStartTimestamp = null
 


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Displays current status while playing OpenFront, including when in lobby, loading players, or in-game.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="288" height="123" alt="image" src="https://github.com/user-attachments/assets/f23feffc-8044-4de0-96c5-bb9940b97bc0" />
<img width="279" height="109" alt="image" src="https://github.com/user-attachments/assets/86ee42b5-749d-41fc-898b-3410382e6d20" />
<img width="276" height="105" alt="image" src="https://github.com/user-attachments/assets/8f4000e4-3217-4ab3-b00c-9e7d6cc20fc6" />


<img width="429" height="601" alt="image" src="https://github.com/user-attachments/assets/19339640-aefb-4faf-a033-eb8cd6825a95" />
<img width="426" height="601" alt="image" src="https://github.com/user-attachments/assets/7313daf9-cd35-4642-8061-1980a14de82c" />

</details>
