### PR TITLE
feat(SFACG): add activity

### DIFF
--- a/websites/S/SFACG/metadata.json
+++ b/websites/S/SFACG/metadata.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "792589695590465567",
+    "name": "h2so4_chan"
+  },
+  "service": "SFACG",
+  "description": {
+    "en": "TODO"
+  },
+  "url": "google.com",
+  "version": "1.0.0",
+  "logo": "https://rs.sfacg.com/web/account/images/avatars/common/0.gif",
+  "thumbnail": "https://i.imgur.com/h3IRTqB.png",
+  "color": "#E29464",
+  "category": "other",
+  "tags": [
+    "novel"
+  ]
+}

--- a/websites/S/SFACG/metadata.json
+++ b/websites/S/SFACG/metadata.json
@@ -7,9 +7,11 @@
   },
   "service": "SFACG",
   "description": {
-    "en": "TODO"
+    "en": "SFACG is a popular Chinese online reading platform offering a vast collection of web novels, comics, and light novels. It features a wide range of genres including fantasy, romance, martial arts, and more, catering to diverse reader preferences. The platform provides an immersive reading experience with regular updates, user-friendly interface, and mobile accessibility.",
+    "zh": "SFACG 是一个受欢迎的中文在线阅读平台，拥有海量的网络小说、漫画和轻小说资源。平台涵盖奇幻、言情、武侠等多种题材，满足不同读者的喜好。SFACG 提供沉浸式的阅读体验，内容定期更新，界面友好且支持移动端访问。"
   },
-  "url": "google.com",
+  "url": "book.sfacg.com",
+  "regExp": "([a-z0-9-]+[.])*(sfacg)[.]com[/]",
   "version": "1.0.0",
   "logo": "https://rs.sfacg.com/web/account/images/avatars/common/0.gif",
   "thumbnail": "https://i.imgur.com/h3IRTqB.png",

--- a/websites/S/SFACG/presence.ts
+++ b/websites/S/SFACG/presence.ts
@@ -1,0 +1,29 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  clientId: '1396393095100104785',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/zfq8ohe.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    details: 'Browsing other pages...',
+    // smallImageKey: Assets.Play,
+    type: ActivityType.Watching
+  }
+  switch (document.location.hostname) {
+    case 'book.sfacg.com': {
+      presenceData.details = 'SFACG'
+      presenceData.state = 'Watching home page'
+      presenceData.startTimestamp = browsingTimestamp
+      break
+    }
+  }
+  presence.setActivity(presenceData)
+})

--- a/websites/S/SFACG/presence.ts
+++ b/websites/S/SFACG/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType } from 'premid'
+import { ActivityType, Assets} from 'premid'
 
 const presence = new Presence({
   clientId: '1396393095100104785',
@@ -9,20 +9,191 @@ enum ActivityAssets {
   Logo = 'https://i.imgur.com/zfq8ohe.png',
 }
 
+enum NovelTypeID {
+  Magic = 21, // 魔幻
+  Fantasy = 22, // 玄幻
+  Historical = 23, // 古风
+  SciFi = 24, // 科幻
+  School = 25, // 校园
+  Urban = 26, // 都市
+  Game = 27, // 游戏
+  Doujin = 28, // 同人
+  Mystery = 29, // 悬疑
+}
+
+const NovelType: Record<number, string> = {
+  [NovelTypeID.Magic]: '魔幻',
+  [NovelTypeID.Fantasy]: '玄幻',
+  [NovelTypeID.Historical]: '古风',
+  [NovelTypeID.SciFi]: '科幻',
+  [NovelTypeID.School]: '校园',
+  [NovelTypeID.Urban]: '都市',
+  [NovelTypeID.Game]: '游戏',
+  [NovelTypeID.Doujin]: '同人',
+  [NovelTypeID.Mystery]: '悬疑',
+}
+
+const NovelProgressStatusMap: Record<number, string> = {
+  0: '连载中',
+  1: '完结',
+}
+
+const UpdatedWithinDaysMap: Record<number, string> = {
+  7: '7天内更新',
+  15: '15天内更新',
+  30: '30天内更新',
+}
+
+function decodeUnicode(str: string) {
+  return str.replace(/%u[0-9a-fA-F]{4}/g, match =>
+    String.fromCharCode(parseInt(match.slice(2), 16))
+  );
+}
+
+function decodeSearchKey(str: string) {
+  try {
+    return decodeURIComponent(str); // 尝试标准 URI 解码
+  } catch {
+    return decodeUnicode(str);      // 如果失败则用 %u 解码
+  }
+}
+
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
-    details: 'Browsing other pages...',
+    details: '浏览其他页面',
+    state: 'SF轻小说',
     // smallImageKey: Assets.Play,
-    type: ActivityType.Watching
+    type: ActivityType.Watching,
   }
-  switch (document.location.hostname) {
+
+  const currentHostname = document.location.hostname
+  const currentPathname = document.location.pathname
+
+  switch (currentHostname) {
     case 'book.sfacg.com': {
-      presenceData.details = 'SFACG'
-      presenceData.state = 'Watching home page'
-      presenceData.startTimestamp = browsingTimestamp
+      switch (true) {
+        case currentPathname === '/': {
+          presenceData.details = '浏览主页'
+          presenceData.state = 'SF轻小说'
+          presenceData.startTimestamp = browsingTimestamp
+          break
+        }
+        case currentPathname.includes('/List/'): {
+          presenceData.details = '查看小说列表'
+
+          // 提取筛选参数
+          const params = new URLSearchParams(document.location.search)
+          const novelTypeId = Number.parseInt(params.get('tid') ?? '-1')
+          const novelProgressStatus = Number.parseInt(params.get('if') ?? '2')
+          const novelUpdatedWithinDays = Number.parseInt(params.get('ud') ?? '-1')
+          const novelInitialLetter = params.get('l') ?? '*'
+
+          // 按优先级获取显示值，符合“不限”则返回 undefined
+          const novelTypeName = NovelType[novelTypeId] ?? undefined
+          const progressStatusName = novelProgressStatus !== 2 ? (NovelProgressStatusMap[novelProgressStatus] ?? undefined) : undefined
+          const updatedWithinName = novelUpdatedWithinDays !== -1 ? (UpdatedWithinDaysMap[novelUpdatedWithinDays] ?? undefined) : undefined
+          const initialLetterName = (novelInitialLetter !== '*' && novelInitialLetter !== '') ? novelInitialLetter : undefined
+
+          // 先按顺序把可能的值放进数组
+          const stateParts = [novelTypeName, progressStatusName, updatedWithinName]
+
+          // 首字母放最后（如果有）
+          if (initialLetterName) {
+            stateParts.push(`首字母： ${initialLetterName}`)
+          }
+          // 过滤掉所有 undefined 或空字符串项
+          const filteredParts = stateParts.filter(part => part && part.trim() !== '')
+
+          // 根据个数决定如何赋值 state
+          if (filteredParts.length === 0) {
+            presenceData.state = 'SF轻小说' // 全部不限，state为空
+          }
+          else if (filteredParts.length === 1) {
+            presenceData.state = filteredParts[0] // 只有一个筛选项，不加“·”
+          }
+          else {
+            presenceData.state = filteredParts.join(' · ') // 多个筛选项，用“·”连接
+          }
+          break
+        }
+        case currentPathname.includes('/rank/'): {
+          presenceData.details = '查看排行榜'
+          presenceData.state = 'SF轻小说'
+          break
+        }
+        case currentPathname.includes('/Novel/'): {
+          switch (true) {
+            case /^\/Novel\/\d+\/?$/.test(currentPathname): {
+              // 小说简介页
+              presenceData.details = '浏览小说简介'
+              const titleElement = document.querySelector("h1.title .text");
+              const authorElement = document.querySelector(".author-name span");
+
+              const title = titleElement?.childNodes[0]?.nodeValue?.trim();
+              const author = authorElement?.textContent?.trim();
+
+              let displayTitle: string | undefined
+              if (title && author) {
+                displayTitle = `《${title}》· ${author}`
+              } else if (title) {
+                displayTitle = `《${title}》· 未知作者`
+              } else if (author) {
+                displayTitle = `未知作品 · ${author}`
+              } else {
+                displayTitle = `未知作品 · 未知作者`
+              }
+              presenceData.state = displayTitle
+              break
+            }
+          
+            case /^\/Novel\/\d+\/MainIndex\/?$/.test(currentPathname): {
+              // 章节索引页
+              presenceData.details = '查看章节目录'
+              const novelTitle = document.querySelector('h1')?.textContent?.trim()
+              presenceData.state = novelTitle ? `《${novelTitle}》` : '未知作品'
+              break
+            }
+          
+            case /^\/Novel\/\d+\/\d+\/\d+\/?$/.test(currentPathname): {
+              // 正在阅读章节中
+              presenceData.smallImageKey = Assets.Reading
+              const title = document.querySelector('a.item.bold')?.textContent?.trim();
+              const chapterName = document.querySelector('h1')?.textContent?.trim();
+              const authorText = document.querySelector('.article-desc .text')?.textContent;
+              const author = authorText?.replace(/^作者：/, '').trim();
+              
+              const detailsText = title ? `《${title}》` : '未知作品'
+              let stateText: string | undefined
+              if (chapterName && author) {
+                stateText = `${chapterName} · ${author}`
+              } else if (chapterName) {
+                stateText = `${chapterName} · 未知作者`
+              } else if (author) {
+                stateText = `未知章节 · ${author}`
+              } else {
+                stateText = `未知章节 · 未知作者`
+              }
+
+              presenceData.details = detailsText
+              presenceData.state = stateText
+              break
+            }
+          }
+          break
+        }
+      }
       break
+    }
+    case 's.sfacg.com': {
+      // 此处获取QueryKey
+      const urlParams = new URLSearchParams(document.location.search)
+      const key = urlParams.get('Key') ?? "";
+      const decodedKey = decodeSearchKey(key) ?? undefined;
+      
+      presenceData.details = '搜索小说';
+      presenceData.state = decodedKey ? `>> "${decodedKey}"` : '未知关键词';
     }
   }
   presence.setActivity(presenceData)

--- a/websites/T/Taobao/metadata.json
+++ b/websites/T/Taobao/metadata.json
@@ -8,7 +8,7 @@
   "service": "Taobao",
   "description": {
     "en": "China’s largest online shopping platform offering everything from daily essentials to electronics, with personalized recommendations, live commerce, and worldwide delivery. It’s all on Taobao.",
-    "zh-cn": "中国最大的综合性购物平台，提供从日用品到电子产品的一切商品，支持个性化推荐、直播带货与全球配送，尽在淘宝。"
+    "zh": "中国最大的综合性购物平台，提供从日用品到电子产品的一切商品，支持个性化推荐、直播带货与全球配送，尽在淘宝。"
   },
   "url": "taobao.com",
   "regExp": "([a-z0-9-]+[.])*(taobao|tmall)[.]com[/]",

--- a/websites/T/Taobao/metadata.json
+++ b/websites/T/Taobao/metadata.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "792589695590465567",
+    "name": "h2so4_chan"
+  },
+  "service": "Taobao",
+  "description": {
+    "en": "China’s largest online shopping platform offering everything from daily essentials to electronics, with personalized recommendations, live commerce, and worldwide delivery. It’s all on Taobao.",
+    "zh-cn": "中国最大的综合性购物平台，提供从日用品到电子产品的一切商品，支持个性化推荐、直播带货与全球配送，尽在淘宝。"
+  },
+  "url": "taobao.com",
+  "regExp": "([a-z0-9-]+[.])*(taobao|tmall)[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/hhHDHt8.png",
+  "thumbnail": "https://i.imgur.com/LaC0zuf.jpeg",
+  "color": "#FF5000",
+  "category": "other",
+  "tags": [
+    "social",
+    "shopping"
+  ]
+}

--- a/websites/T/Taobao/presence.ts
+++ b/websites/T/Taobao/presence.ts
@@ -1,0 +1,74 @@
+import { ActivityType } from 'premid'
+
+const presence = new Presence({
+  clientId: '1395995754849370132',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets { // Other default assets can be found at index.d.ts
+  Logo = 'https://i.imgur.com/hhHDHt8.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    details: 'Browsing other pages...',
+    type: ActivityType.Watching,
+  }
+  switch (document.location.hostname) {
+    case 'www.taobao.com': {
+      presenceData.details = 'Taobao'
+      presenceData.state = 'Watching home page'
+      presenceData.startTimestamp = browsingTimestamp
+      break
+    }
+    case 's.taobao.com': {
+      const searchParams = new URLSearchParams(document.location.search)
+      const rawQuery = searchParams.get('q') ?? ''
+      const decodedQuery = decodeURIComponent(rawQuery)
+
+      presenceData.details = decodedQuery
+        ? `Searching for "${decodedQuery}"`
+        : 'Searching on Taobao'
+
+      presenceData.startTimestamp = browsingTimestamp
+      break
+    }
+    case 'item.taobao.com':
+    case 'detail.tmall.com': {
+      const productTitle
+        = document.querySelector('#J_Title > h3')?.textContent?.trim()
+          || document.querySelector('.tb-main-title')?.textContent?.trim()
+          || document.title.replace(/[\n\r]+/g, '').trim()
+
+      const shopName
+        = document.querySelector('.tb-shop-name > dl > dd > strong')?.textContent?.trim()
+          || document.querySelector('.tb-shop-name > dl > dd')?.textContent?.trim()
+          || document.querySelector('span[class*="--shopName--"]')?.textContent?.trim()
+          || document.querySelector('span[title][class*="--shopName--"]')?.getAttribute('title')?.trim()
+
+      presenceData.details = productTitle
+        ? `Viewing product: “${productTitle}”`
+        : 'Viewing a product'
+
+      presenceData.state = shopName
+        ? `From shop: "${shopName}"`
+        : undefined
+
+      const originalURL = new URL(document.location.href)
+      const id = originalURL.searchParams.get('id')
+      const platform = originalURL.hostname
+
+      presenceData.buttons = [
+        {
+          label: 'View Product',
+          url: `https://${platform}/item.htm?id=${id}`,
+        },
+      ]
+      presenceData.startTimestamp = browsingTimestamp
+      break
+    }
+  }
+  presence.setActivity(presenceData)
+})

--- a/websites/T/Taobao/presence.ts
+++ b/websites/T/Taobao/presence.ts
@@ -5,7 +5,7 @@ const presence = new Presence({
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
-enum ActivityAssets { // Other default assets can be found at index.d.ts
+enum ActivityAssets {
   Logo = 'https://i.imgur.com/hhHDHt8.png',
 }
 


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Activity for SFACG, supporting status display on the homepage, novel list, rankings, novel details, chapter index, reading pages, and search pages.
This plugin uniquely enables displaying the current reading chapter status, including the novel title, chapter name, and author, directly on Discord Rich Presence, enhancing user engagement and real-time sharing of reading progress.
Includes handling of various filter parameters and encoding formats to accurately reflect user browsing state.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="612" height="786" alt="Screenshot 2025-07-20 190239" src="https://github.com/user-attachments/assets/53e9079c-50a3-4a55-9440-26ff90fb9765" />
<img width="614" height="789" alt="Screenshot 2025-07-20 190307" src="https://github.com/user-attachments/assets/b99455c9-faed-434b-81f5-d1cb08a06c6c" />
<img width="616" height="802" alt="Screenshot 2025-07-20 190322" src="https://github.com/user-attachments/assets/1369c1d4-1b25-419b-a93b-24b754ad67d0" />
<img width="610" height="792" alt="Screenshot 2025-07-20 190348" src="https://github.com/user-attachments/assets/7be812f2-b8a6-466b-b7bb-4de462039c35" />
<img width="611" height="792" alt="Screenshot 2025-07-20 190403" src="https://github.com/user-attachments/assets/cf4213db-4fbf-4126-942f-97214865e1f9" />
<img width="609" height="790" alt="Screenshot 2025-07-20 190417" src="https://github.com/user-attachments/assets/7f73dfc1-cb0a-4b18-90c4-03ea2ee92a45" />
<img width="608" height="787" alt="Screenshot 2025-07-20 190434" src="https://github.com/user-attachments/assets/26bc159c-9e91-4826-9799-54be5769e5e5" />



</details>
