### PR TITLE
Feature/gronkhtv presence

### DIFF
--- a/websites/G/Gronkh.tv/metadata.json
+++ b/websites/G/Gronkh.tv/metadata.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "792589695590465567",
+    "name": "h2so4_chan"
+  },
+  "service": "Gronkh.tv",
+  "description": {
+    "en": "Gronkh.tv is the official website and streaming hub of Erik Range, better known by his online alias Gronkh—one of Germany’s most iconic and pioneering gaming content creators. With a massive following on platforms like YouTube and Twitch, Gronkh is known for his humorous, engaging, and down-to-earth streaming style."
+  },
+  "url": "gronkh.tv",
+  "regExp": "([a-z0-9-]+[.])*(gronkh)[.]tv[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/rZooYzo.png",
+  "thumbnail": "https://i.imgur.com/zTA2WWf.png",
+  "color": "#562BF2",
+  "category": "games",
+  "tags": [
+    "game",
+    "stream"
+  ]
+}

--- a/websites/G/Gronkh.tv/presence.ts
+++ b/websites/G/Gronkh.tv/presence.ts
@@ -1,4 +1,4 @@
-import { Assets } from 'premid'
+import { ActivityType, Assets } from 'premid'
 
 const presence = new Presence({
   clientId: '1396486294779068416',
@@ -12,9 +12,40 @@ enum ActivityAssets { // Other default assets can be found at index.d.ts
 presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Watching,
     startTimestamp: browsingTimestamp,
     // smallImageKey: Assets.Play,
+    endTimestamp: undefined,
+    details: 'Viewing Gronkh.tv',
   }
 
+  const curURL = document.location.href
+
+  if (curURL.includes('streams')) {
+    const el = document.querySelector('video');
+    if (el instanceof HTMLVideoElement) {
+      const timestamps = presence.getTimestamps(el.currentTime, el.duration);
+      const isPlaying = !el.paused && !el.ended && el.readyState > 2;
+      if (isPlaying) {
+        presenceData.smallImageKey = Assets.Play
+      }
+      else {
+        presenceData.smallImageKey = Assets.Pause
+      }
+      presenceData.startTimestamp = timestamps[0];
+      presenceData.endTimestamp = timestamps[1];
+    }
+    const match = curURL.match(/\/streams\/(\d+)/)
+    const videoId = match?.[1] || null
+    const videoTitle = document.querySelector('.g-video-meta-title')?.textContent?.trim()
+    const detailsText = `${videoTitle} · #${videoId}`
+    presenceData.details = detailsText;
+    presenceData.buttons = [
+      {
+        label: 'Watch Together',
+        url: curURL
+      }
+    ]
+  }
   presence.setActivity(presenceData)
 })

--- a/websites/G/Gronkh.tv/presence.ts
+++ b/websites/G/Gronkh.tv/presence.ts
@@ -1,0 +1,20 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1396486294779068416',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets { // Other default assets can be found at index.d.ts
+  Logo = 'https://i.imgur.com/rZooYzo.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    // smallImageKey: Assets.Play,
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds a Presence for Gronkh.tv, a German livestreaming website primarily known for gaming content. The presence updates dynamically depending on whether the user is watching a video, displaying the title, stream ID, and playback status (play/pause).
It also includes a "Watch Together" button linking directly to the current stream.
- Supports stream pages (/streams/:id)
- Displays stream title and ID in details
- Dynamically updates playback status icon
- Shows accurate start/end timestamps using HTML <video> metadata
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="621" height="799" alt="Screenshot 2025-07-20 220657" src="https://github.com/user-attachments/assets/d421adac-c2e0-49c2-a074-89f0d2f9e69c" />



</details>
