### PR TITLE
feat(WatchPeopleLive): add activity

### DIFF
--- a/websites/W/WatchPeopleLive/metadata.json
+++ b/websites/W/WatchPeopleLive/metadata.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "792589695590465567",
+    "name": "h2so4_chan"
+  },
+  "service": "WatchPeopleLive",
+  "description": {
+    "en": "TODO"
+  },
+  "url": "watchpeoplelive.tv",
+  "regExp": "([a-z0-9-]+[.])*(watchpeoplelive)[.]tv[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/tlpAcM8.png",
+  "thumbnail": "https://i.imgur.com/szP8amh.png",
+  "color": "#012461",
+  "category": "socials",
+  "tags": [
+    "lifestyle",
+    "music",
+    "social",
+    "daily",
+    "community",
+    "videos"
+  ]
+}

--- a/websites/W/WatchPeopleLive/metadata.json
+++ b/websites/W/WatchPeopleLive/metadata.json
@@ -7,7 +7,7 @@
   },
   "service": "WatchPeopleLive",
   "description": {
-    "en": "TODO"
+    "en": "WatchPeopleLive.tv is a user-driven community platform where members share and watch a wide variety of live or recorded videos and engage in discussions. The site covers diverse topics ranging from everyday life, music, and nature to social issues and current events, offering rich and varied content. While some content can be sensitive or controversial, the platform aims to provide an open space for sharing perspectives and experiences. Whether you're looking to browse interesting videos, join conversations, or discover new topics, WatchPeopleLive.tv is an active and inclusive community."
   },
   "url": "watchpeoplelive.tv",
   "regExp": "([a-z0-9-]+[.])*(watchpeoplelive)[.]tv[/]",

--- a/websites/W/WatchPeopleLive/presence.ts
+++ b/websites/W/WatchPeopleLive/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets } from 'premid'
+import { ActivityType } from 'premid'
 
 const presence = new Presence({
   clientId: '1396529263095582890',
@@ -15,7 +15,7 @@ presence.on('UpdateData', async () => {
     startTimestamp: browsingTimestamp,
     type: ActivityType.Watching,
     // smallImageKey: Assets.Play,
-    details: 'Viewing other pages'
+    details: 'Viewing other pages',
   }
 
   const curPath = document.location.pathname
@@ -42,7 +42,7 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: 'Watch Post',
-          url: document.location.href
+          url: document.location.href,
         },
       ]
     }

--- a/websites/W/WatchPeopleLive/presence.ts
+++ b/websites/W/WatchPeopleLive/presence.ts
@@ -47,7 +47,6 @@ presence.on('UpdateData', async () => {
     else {
       // 其他路径处理
       presenceData.details = `Browsing ${curPath}`
-      presenceData.state = ''
     }
   }
   presence.setActivity(presenceData)

--- a/websites/W/WatchPeopleLive/presence.ts
+++ b/websites/W/WatchPeopleLive/presence.ts
@@ -14,7 +14,6 @@ presence.on('UpdateData', async () => {
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
     type: ActivityType.Watching,
-    // smallImageKey: Assets.Play,
     details: 'Viewing other pages',
   }
 
@@ -29,7 +28,6 @@ presence.on('UpdateData', async () => {
       // 只有板块，没有帖子
       const section = `/${parts[1]}/${parts[2]}` // "/h/nature"
       presenceData.details = `Browsing section: ${section}`
-      presenceData.state = ''
     }
     else if (parts.length >= 6 && parts[1] === 'h' && parts[3] === 'post') {
       // 具体帖子

--- a/websites/W/WatchPeopleLive/presence.ts
+++ b/websites/W/WatchPeopleLive/presence.ts
@@ -1,0 +1,56 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1396529263095582890',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/tlpAcM8.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    type: ActivityType.Watching,
+    // smallImageKey: Assets.Play,
+    details: 'Viewing other pages'
+  }
+
+  const curPath = document.location.pathname
+  if (curPath === '/') {
+    presenceData.details = 'Viewing the main page'
+  }
+  else {
+    // /h/nature/post/352201/new-hole-discovered-hnature
+    const parts = curPath.split('/')
+    if (parts.length === 3 && parts[1] === 'h') {
+      // 只有板块，没有帖子
+      const section = `/${parts[1]}/${parts[2]}` // "/h/nature"
+      presenceData.details = `Browsing section: ${section}`
+      presenceData.state = ''
+    }
+    else if (parts.length >= 6 && parts[1] === 'h' && parts[3] === 'post') {
+      // 具体帖子
+      const section = `/${parts[1]}/${parts[2]}` // "/h/nature"
+      const postId = parts[4]
+      const postTitleRaw = parts[5] ?? ''
+      const postTitle = postTitleRaw.replace(/-/g, ' ')
+      presenceData.details = `Watching Post: ${postTitle}`
+      presenceData.state = `From section "${section}", #${postId}`
+      presenceData.buttons = [
+        {
+          label: 'Watch Post',
+          url: document.location.href
+        },
+      ]
+    }
+    else {
+      // 其他路径处理
+      presenceData.details = `Browsing ${curPath}`
+      presenceData.state = ''
+    }
+  }
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds a new PreMiD presence for [WatchPeopleLive.tv](https://watchpeoplelive.tv/), a content-sharing community focused on real-life footage, discussions, and media. This activity supports detection of user context across the platform:
- Main page (/) displays as “Viewing the main page”.
- Section pages (e.g., /h/Animals) show the current section being browsed.
- Post pages (e.g., /h/nature/post/352201/new-hole-discovered-hnature) display the post title, section, and post ID.
All paths are parsed dynamically from the URL, and titles are humanized by replacing dashes with spaces.
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="617" height="794" alt="Screenshot 2025-07-21 004703" src="https://github.com/user-attachments/assets/3cc91e44-f0ef-41a5-9675-5c1442f8f4bc" />
<img width="610" height="790" alt="Screenshot 2025-07-21 004725" src="https://github.com/user-attachments/assets/a942a210-1fc9-4efa-b466-201b2b200c2f" />
<img width="608" height="797" alt="Screenshot 2025-07-21 004745" src="https://github.com/user-attachments/assets/e6796cf8-bfaf-423c-a99f-67aef9017584" />


</details>
