### PR TITLE
fix(Twitch): fix streamer title in mod view

### DIFF
--- a/websites/T/Twitch/metadata.json
+++ b/websites/T/Twitch/metadata.json
@@ -46,7 +46,7 @@
     "devstatus.twitch.tv",
     "status.twitch.tv"
   ],
-  "version": "3.3.0",
+  "version": "3.3.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/T/Twitch/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/Twitch/assets/thumbnail.png",
   "color": "#9146FF",

--- a/websites/T/Twitch/presence.ts
+++ b/websites/T/Twitch/presence.ts
@@ -453,7 +453,19 @@ presence.on('UpdateData', async () => {
 
       if (path.includes('/moderator/')) {
         presenceData.details = strings.modStreamer
-        presenceData.state = getElement('.stream-info-card p > a')
+
+        // the title on top of the display box
+        let streamerinfo = document.querySelector('[data-a-target="player-info-title"]')?.textContent
+
+        // "Streamername's Mod View - Twitch"
+        if (!streamerinfo) {
+          streamerinfo = document.title.split('\'s')[0]
+        }
+
+        // fallback, broken? Maybe just on my browser
+        if (!streamerinfo) {
+          presenceData.state = getElement('.stream-info-card p > a')
+        }
 
         if (getElement('.modview-dock-widget p') !== 'Offline') {
           presenceData.smallImageKey = Assets.Live

--- a/websites/T/Twitch/presence.ts
+++ b/websites/T/Twitch/presence.ts
@@ -464,8 +464,10 @@ presence.on('UpdateData', async () => {
 
         // fallback, broken? Maybe just on my browser
         if (!streamerinfo) {
-          presenceData.state = getElement('.stream-info-card p > a')
+          streamerinfo = getElement('.stream-info-card p > a')
         }
+
+        presenceData.state = streamerinfo
 
         if (getElement('.modview-dock-widget p') !== 'Offline') {
           presenceData.smallImageKey = Assets.Live


### PR DESCRIPTION
## Description
When in Twitch's mod view, the name of the streamer is not visible, this fixes that, as well as closes https://github.com/PreMiD/Activities/issues/9802

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

Before
<img width="273" height="95" alt="image" src="https://github.com/user-attachments/assets/a1f34fcf-0714-46f2-b845-0565da1d5fe2" />

After
<img width="392" height="142" alt="image" src="https://github.com/user-attachments/assets/2c4c2a5d-dc41-4ee7-9051-f93644bd106a" />

</details>
