### PR TITLE
feat(Mangafire): add activity

### DIFF
--- a/websites/M/Mangafire/metadata.json
+++ b/websites/M/Mangafire/metadata.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "792589695590465567",
+    "name": "h2so4_chan"
+  },
+  "service": "Mangafire",
+  "description": {
+    "en": "Mangafire.to is a free and user-friendly website where you can read thousands of manga titles online. It features a clean interface, fast loading times, and an extensive library of genres—from action and romance to slice of life and fantasy. No registration is required, and new chapters are updated frequently to keep you reading nonstop."
+  },
+  "url": "mangafire.to",
+  "regExp": "([a-z0-9-]+[.])*(mangafire)[.]to[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/GP6ci4C.png",
+  "thumbnail": "https://i.imgur.com/mBTrR0C.png",
+  "color": "#5c74e7",
+  "category": "other",
+  "tags": [
+    "manga"
+  ]
+}

--- a/websites/M/Mangafire/presence.ts
+++ b/websites/M/Mangafire/presence.ts
@@ -1,0 +1,126 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1396802813484597320',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/GP6ci4C.png',
+}
+
+const Fields = {
+  defaultDetails: 'Mangafire.to',
+  aboutState: 'Viewing about page',
+  defaultState: 'Viewing other pages',
+  homeState: 'Viewing home page',
+  typeState: 'Viewing by type',
+  filterDetails: 'Filtering Manga',
+  filterState: 'Filtering Manga',
+  newestState: 'Viewing new release Manga',
+  updatedState: 'Viewing recently updated Manga',
+  addedState: 'Viewing recently added Manga',
+  readingState: 'Reading The Manga...',
+}
+
+async function getMangaCoverImage(): Promise<string | null> {
+  const curPath = document.location.pathname
+
+  // 情况 1: 当前就是 /manga/{title}
+  if (/^\/manga\/[^/]+\/?$/.test(curPath)) {
+    const img = document.querySelector('.poster img[itemprop="image"]') as HTMLImageElement
+    return img?.src || null
+  }
+
+  // 情况 2: 当前是 /read/{title}/xxx，提取 title 并跳转抓图
+  if (/^\/read\/[^/]+\//.test(curPath)) {
+    const match = curPath.match(/^\/read\/([^/]+)\//)
+    const mangaTitle = match?.[1]
+
+    if (!mangaTitle)
+      return null
+
+    // 构造 /manga/{title} 页面地址
+    const mangaUrl = `/manga/${mangaTitle}`
+
+    try {
+      const res = await fetch(mangaUrl)
+      const html = await res.text()
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(html, 'text/html')
+      const img = doc.querySelector('.poster img[itemprop="image"]') as HTMLImageElement
+
+      return img?.src || null
+    }
+    catch (err) {
+      console.error('封面获取失败', err)
+      return null
+    }
+  }
+
+  return null
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Watching,
+    startTimestamp: browsingTimestamp,
+    details: Fields.defaultDetails,
+    state: Fields.defaultState,
+    // smallImageKey: Assets.Play,
+  }
+
+  const curURL = document.location.pathname
+  if (curURL === '/') {
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = Fields.aboutState
+  }
+  else if (curURL === '/home') {
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = Fields.homeState
+  }
+  else if (curURL.startsWith('/type') || curURL.includes('genre')) {
+    const match = curURL.match(/^\/(?:type|genre)\/([^/]+)\/?$/)
+    const mangaType = match?.[1] ?? 'Unknow Type/Genre'
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = `Viewing ${mangaType} Manga`
+  }
+  else if (curURL.startsWith('/filter')) {
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = Fields.filterState
+  }
+  else if (curURL.startsWith('/newest')) {
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = Fields.newestState
+  }
+  else if (curURL.startsWith('/updated')) {
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = Fields.updatedState
+  }
+  else if (curURL.startsWith('/added')) {
+    presenceData.details = Fields.defaultDetails
+    presenceData.state = Fields.addedState
+  }
+  else if (curURL.startsWith('/manga')) {
+    const infoDiv = document.querySelector('div.info')
+    const status = infoDiv?.querySelector('p')?.textContent?.trim() || ''
+    const title = infoDiv?.querySelector('h1[itemprop="name"]')?.textContent?.trim() || ''
+    const authorAnchors = document.querySelectorAll('a[itemprop="author"]')
+    const authors = Array.from(authorAnchors).map(a => a.textContent?.trim())
+    const logoUrl = await getMangaCoverImage()
+    presenceData.largeImageKey = logoUrl
+    presenceData.details = title
+    presenceData.state = `${status} ${authors ? `· ${authors}` : ''}`
+  }
+  else if (curURL.startsWith('/read')) {
+    presenceData.smallImageKey = Assets.Reading
+    const titleAnchor = document.querySelector('.head > a')
+    const mangaTitle = titleAnchor?.textContent?.trim() || ''
+    const logoUrl = await getMangaCoverImage()
+    presenceData.largeImageKey = logoUrl
+    presenceData.details = mangaTitle
+    presenceData.state = Fields.readingState
+  }
+  presence.setActivity(presenceData)
+})

--- a/websites/M/Mangafire/presence.ts
+++ b/websites/M/Mangafire/presence.ts
@@ -28,7 +28,7 @@ async function getMangaCoverImage(): Promise<string | null> {
 
   // 情况 1: 当前就是 /manga/{title}
   if (/^\/manga\/[^/]+\/?$/.test(curPath)) {
-    const img = document.querySelector('.poster img[itemprop="image"]') as HTMLImageElement
+    const img = document.querySelector<HTMLImageElement>('.poster img[itemprop="image"]')
     return img?.src || null
   }
 

--- a/websites/M/Mangafire/presence.ts
+++ b/websites/M/Mangafire/presence.ts
@@ -48,7 +48,7 @@ async function getMangaCoverImage(): Promise<string | null> {
       const html = await res.text()
       const parser = new DOMParser()
       const doc = parser.parseFromString(html, 'text/html')
-      const img = doc.querySelector('.poster img[itemprop="image"]') as HTMLImageElement
+      const img = doc.querySelector<HTMLImageElement>('.poster img[itemprop="image"]')
 
       return img?.src || null
     }


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This plugin adds [Mangafire.to](https://mangafire.to/) support to PreMiD, allowing users to display their manga reading activity in their Discord Rich Presence.
It detects and updates your activity based on the page you're currently viewing, including:
- Home, type/genre, filter, and update pages
- Manga detail pages, showing the title, authors, and status
- Reading pages, displaying the current manga being read
It also dynamically fetches manga cover images to display in your activity, offering a more immersive and personalized presence.
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="1920" height="1080" alt="Screenshot 2025-07-21 204430" src="https://github.com/user-attachments/assets/c74f065f-4d7e-4cf5-a821-b166823f6089" />
<img width="1920" height="1080" alt="Screenshot 2025-07-21 204443" src="https://github.com/user-attachments/assets/751f3f81-1725-4fd8-bf98-9898c09b3624" />
<img width="1920" height="1080" alt="Screenshot 2025-07-21 204459" src="https://github.com/user-attachments/assets/e921e898-2240-4360-ac7f-705ea6b72bd8" />
<img width="1920" height="1064" alt="Screenshot 2025-07-21 204510" src="https://github.com/user-attachments/assets/cd81ee9e-c11f-41de-bd14-52a32f78c7ab" />

</details>

