### PR TITLE
feat(Hdfilmcehennemi): add activity

### DIFF
--- a/websites/H/Hdfilmcehennemi/iframe.ts
+++ b/websites/H/Hdfilmcehennemi/iframe.ts
@@ -1,0 +1,14 @@
+const iframe = new iFrame()
+
+iframe.on('UpdateData', () => {
+  const video = document.querySelector<HTMLVideoElement>('video')
+  if (!video || Number.isNaN(video.duration))
+    return
+  iframe.send({
+    iFrameVideoData: {
+      currTime: video.currentTime,
+      dur: video.duration,
+      paused: video.paused || video.ended,
+    },
+  })
+})

--- a/websites/H/Hdfilmcehennemi/metadata.json
+++ b/websites/H/Hdfilmcehennemi/metadata.json
@@ -5,6 +5,12 @@
     "id": "792589695590465567",
     "name": "h2so4_chan"
   },
+  "contributors": [
+    {
+      "name": "xDoritos",
+      "id": "432215088686956565"
+    }
+  ],
   "service": "Hdfilmcehennemi",
   "description": {
     "en": "HDFilmCehennemi provides the latest movies in high definition for Turkish cinema enthusiasts and is the first online platform of its kind. Our platform holds a prominent position in search results for \"watch movies,\" \"watch HD movies,\" and \"HD Movie Cehennemi,\" offering quick access to the newest foreign films and TV series.",
@@ -20,5 +26,7 @@
   "tags": [
     "movie",
     "streaming"
-  ]
+  ],
+  "iframe": true,
+  "iFrameRegExp": "(.*\\.)?hdfilmcehennemi\\.nl"
 }

--- a/websites/H/Hdfilmcehennemi/metadata.json
+++ b/websites/H/Hdfilmcehennemi/metadata.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "792589695590465567",
+    "name": "h2so4_chan"
+  },
+  "service": "Hdfilmcehennemi",
+  "description": {
+    "en": "HDFilmCehennemi provides the latest movies in high definition for Turkish cinema enthusiasts and is the first online platform of its kind. Our platform holds a prominent position in search results for \"watch movies,\" \"watch HD movies,\" and \"HD Movie Cehennemi,\" offering quick access to the newest foreign films and TV series.",
+    "tr": "HDFilmCehennemi, en yeni filmleri Türkiye'deki film severlere nette ilk olarak ve HD kalitede sunar. 'Film izle', 'HD Film izle' ve 'HD Film Cehennemi' kelimeleriyle arama motorlarında öne çıkan platformumuz, en güncel yabancı filmleri ve yabanı dizileri hızlı bir şekilde sizlere ulaştırır. Telif hakkı ihlali düşündüğünüz içerikler için lütfen iletişim sayfamızdan bizimle iletişime geçin."
+  },
+  "url": "hdfilmcehennemi.nl",
+  "regExp": "([a-z0-9-]+[.])*(hdfilmcehennemi)[.]nl[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/rFXu6Em.png",
+  "thumbnail": "https://i.imgur.com/VYm5lcT.png",
+  "color": "#e95900",
+  "category": "videos",
+  "tags": [
+    "movie",
+    "streaming"
+  ]
+}

--- a/websites/H/Hdfilmcehennemi/presence.ts
+++ b/websites/H/Hdfilmcehennemi/presence.ts
@@ -66,7 +66,6 @@ presence.on('UpdateData', async () => {
     }
   }
 
-  // const curURL = document.location.href Replaced at beggining
   if (pathname === '/') {
     presenceData.details = 'Viewing home page'
   }

--- a/websites/H/Hdfilmcehennemi/presence.ts
+++ b/websites/H/Hdfilmcehennemi/presence.ts
@@ -71,7 +71,6 @@ presence.on('UpdateData', async () => {
     presenceData.details = 'Viewing home page'
   }
   else {
-
     const h1 = document.querySelector('h1.section-title')
     if (h1 instanceof HTMLElement) {
       const first = h1.firstChild

--- a/websites/H/Hdfilmcehennemi/presence.ts
+++ b/websites/H/Hdfilmcehennemi/presence.ts
@@ -1,0 +1,74 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  clientId: '1396506033890922496',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/rFXu6Em.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Watching,
+    startTimestamp: browsingTimestamp,
+    // smallImageKey: Assets.Play,
+    endTimestamp: undefined,
+    details: 'Viewing hdfilmcehennemi.nl',
+  }
+
+  const curURL = document.location.href
+  if(document.location.pathname === '/') {
+    presenceData.details = 'Viewing home page'
+  }
+  else {
+    let mainTitle: string | null = null
+    let germanTitle: string | null = null
+    let year: string | null = null
+
+    const h1 = document.querySelector("h1.section-title");
+    if (h1 instanceof HTMLElement) {
+      const first = h1.firstChild;
+      const small = h1.querySelector("small");
+
+      mainTitle = first?.textContent?.trim().replace(/ izle$/, "") ?? null
+
+      const smallText = small?.textContent?.trim() ?? null
+      if (smallText) {
+        const match = smallText.match(/^(.*)\s\((\d{4})\)$/)
+        if (match) {
+          germanTitle = match[1] ?? null
+          year = match[2] ?? null
+        }
+      }
+    }
+
+    // I tried many method but still cannot get the video element 
+    
+    // const el = document.querySelector('video')
+    // if (el instanceof HTMLVideoElement) {
+    //   const timestamps = getTimestamps(el.currentTime, el.duration)
+    //   const isPlaying = !el.paused && !el.ended && el.readyState > 2
+    //   if (isPlaying) {
+    //     presenceData.smallImageKey = Assets.Play
+    //   }
+    //   else {
+    //     presenceData.smallImageKey = Assets.Pause
+    //   }
+    //   presenceData.startTimestamp = timestamps[0]
+    //   presenceData.endTimestamp = timestamps[1]
+    // }
+
+    const detailsText = `${mainTitle} · ${germanTitle} · ${year}`
+    presenceData.details = detailsText
+    presenceData.buttons = [
+      {
+        label: 'Watch Together',
+        url: curURL,
+      },
+    ]
+  }
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
This PR adds playback progress (timestamp) support to the **Hdfilmcehennemi** presence, allowing Discord to display how far the user is into the video.

Special thanks to [@DxriaaaN](https://github.com/DxriaaaN) for assisting with the [iframe integration logic](https://github.com/PreMiD/Activities/commit/7c745c04c247fe1676325a6805bd0f621a06f1d5).  
Their contribution was crucial, as the site uses a nested iframe structure for video playback, which made direct access to the timestamp more complex.

Please let me know if anything needs adjustment. I'm happy to make changes!
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="1920" height="1080" alt="Screenshot 2025-07-25 223044" src="https://github.com/user-attachments/assets/70645c4d-cb5d-4b48-b6fa-7b8269cd204a" />
<img width="1920" height="1080" alt="Screenshot 2025-07-25 223118" src="https://github.com/user-attachments/assets/d76549c0-d4c5-4b48-b540-80129c45be92" />
<img width="502" height="177" alt="image" src="https://github.com/user-attachments/assets/f085c95f-bbdd-465c-879b-f63a2bba61f5" />



</details>
