### PR TITLE
feat(AniwatchTV): add activity 

### DIFF
--- a/websites/A/AniwatchTV/metadata.json
+++ b/websites/A/AniwatchTV/metadata.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "834381079795990538",
+    "name": "sauced.on"
+  },
+  "service": "AniwatchTV",
+  "description": {
+    "en": "Free anime streaming site with thousands of picks."
+  },
+  "url": "aniwatchtv.to",
+  "version": "1.0.0",
+  "logo": "https://aniwatchtv.to/images/favicon.png",
+  "thumbnail": "https://aniwatchtv.to/images/anw-min.webp",
+  "color": "#FFDD95",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "aniwatch",
+    "streaming",
+    "free"
+  ]
+}

--- a/websites/A/AniwatchTV/metadata.json
+++ b/websites/A/AniwatchTV/metadata.json
@@ -6,12 +6,13 @@
     "name": "sauced.on"
   },
   "service": "AniwatchTV",
+  "altnames": ["Aniwatch"],
   "description": {
-    "en": "Free anime streaming site with thousands of picks."
+    "en": "The best site to watch anime online for free."
   },
   "url": "aniwatchtv.to",
   "version": "1.0.0",
-  "logo": "https://aniwatchtv.to/images/favicon.png",
+  "logo": "https://i.postimg.cc/VkWpvxpL/favicon-1-1.png",
   "thumbnail": "https://aniwatchtv.to/images/anw-min.webp",
   "color": "#FFDD95",
   "category": "anime",

--- a/websites/A/AniwatchTV/presence.ts
+++ b/websites/A/AniwatchTV/presence.ts
@@ -1,0 +1,77 @@
+import { ActivityType, Assets } from "premid";
+
+const presence = new Presence({
+  clientId: "1399965482609541172",
+});
+
+const browsingTimestamp = Math.floor(Date.now() / 1000);
+
+enum ActivityAssets {
+  Logo = "https://aniwatchtv.to/images/favicon.png", 
+}
+
+presence.on("UpdateData", async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    type: ActivityType.Watching,
+  };
+
+  const { href, pathname, search } = document.location;
+
+  switch (true) {
+    case pathname === "/":
+      presenceData.details = "Browsing AniwatchTV homepage";
+      presenceData.smallImageKey = Assets.Search;
+      break;
+
+    case pathname.startsWith("/search"):
+      presenceData.details = `Searching: ${search.split("=")[1]?.replace(/\+/g, " ")}`;
+      presenceData.smallImageKey = Assets.Search;
+      break;
+
+    case pathname.includes("/watch/"): {
+    const title = document.querySelector<HTMLAnchorElement>(
+      "#ani_detail .anis-watch-detail .anisc-detail h2 a"
+    )?.textContent?.trim();
+
+    const episode = document
+    .querySelector(".server-notice b")
+    ?.textContent
+    ?.trim()
+    ?.match(/\d+/)?.[0]; 
+
+
+    const cover = document.querySelector<HTMLImageElement>(
+      "#ani_detail .film-poster img"
+    )?.src;
+
+    presenceData.details = title ?? "Hidden anime..";
+    presenceData.state = episode ? `Watching ep. ${episode}` : "Watching episodes!";
+    presenceData.largeImageKey = cover ?? ActivityAssets.Logo;
+    presenceData.smallImageKey = ActivityAssets.Logo;
+
+      presenceData.buttons = [
+        {
+          label: "Watch on AniwatchTV",
+          url: href,
+        },
+      ];
+
+      const video = document.querySelector("video") as HTMLVideoElement | null;
+      if (video && !isNaN(video.duration)) {
+        presenceData.startTimestamp = Date.now() - Math.floor(video.currentTime * 1000);
+        presenceData.endTimestamp = Date.now() + Math.floor((video.duration - video.currentTime) * 1000);
+      }
+
+      break;
+    }
+
+    default:
+      presenceData.details = "Browsing AniwatchTV...";
+      presenceData.smallImageKey = Assets.Search;
+      break;
+  }
+
+  presence.setActivity(presenceData);
+});

--- a/websites/A/AniwatchTV/presence.ts
+++ b/websites/A/AniwatchTV/presence.ts
@@ -1,77 +1,75 @@
-import { ActivityType, Assets } from "premid";
+import { ActivityType, Assets } from 'premid'
 
 const presence = new Presence({
-  clientId: "1399965482609541172",
-});
+  clientId: '1399965482609541172'
+})
 
-const browsingTimestamp = Math.floor(Date.now() / 1000);
+const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
-  Logo = "https://aniwatchtv.to/images/favicon.png", 
+  Logo = 'https://i.postimg.cc/VkWpvxpL/favicon-1-1.png' // replace with 512x512 image
 }
 
-presence.on("UpdateData", async () => {
+presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
-    type: ActivityType.Watching,
-  };
+    type: ActivityType.Watching
+  }
 
-  const { href, pathname, search } = document.location;
+  const { href, pathname, search } = document.location
 
   switch (true) {
-    case pathname === "/":
-      presenceData.details = "Browsing AniwatchTV homepage";
-      presenceData.smallImageKey = Assets.Search;
-      break;
+    case pathname === '/':
+      presenceData.details = 'Browsing AniwatchTV homepage'
+      presenceData.smallImageKey = Assets.Search
+      break
 
-    case pathname.startsWith("/search"):
-      presenceData.details = `Searching: ${search.split("=")[1]?.replace(/\+/g, " ")}`;
-      presenceData.smallImageKey = Assets.Search;
-      break;
+    case pathname.startsWith('/search'):
+      presenceData.details = `Searching: ${search.split('=')[1]?.replace(/\+/g, ' ')}`
+      presenceData.smallImageKey = Assets.Search
+      break
 
-    case pathname.includes("/watch/"): {
-    const title = document.querySelector<HTMLAnchorElement>(
-      "#ani_detail .anis-watch-detail .anisc-detail h2 a"
-    )?.textContent?.trim();
+    case pathname.includes('/watch/'): {
+      const title = document
+        .querySelector<HTMLAnchorElement>('#ani_detail .anis-watch-detail .anisc-detail h2 a')
+        ?.textContent?.trim()
 
-    const episode = document
-    .querySelector(".server-notice b")
-    ?.textContent
-    ?.trim()
-    ?.match(/\d+/)?.[0]; 
+      const episode = document
+        .querySelector('.server-notice b')
+        ?.textContent
+        ?.trim()
+        ?.match(/\d+/)?.[0]
 
+      const cover = document.querySelector<HTMLImageElement>('#ani_detail .film-poster img')?.src
 
-    const cover = document.querySelector<HTMLImageElement>(
-      "#ani_detail .film-poster img"
-    )?.src;
-
-    presenceData.details = title ?? "Hidden anime..";
-    presenceData.state = episode ? `Watching ep. ${episode}` : "Watching episodes!";
-    presenceData.largeImageKey = cover ?? ActivityAssets.Logo;
-    presenceData.smallImageKey = ActivityAssets.Logo;
+      presenceData.details = title ?? 'Hidden anime...'
+      presenceData.state = episode ? `Watching ep. ${episode}` : 'Watching episodes!'
+      presenceData.largeImageKey = cover ?? ActivityAssets.Logo
+      presenceData.smallImageKey = ActivityAssets.Logo
 
       presenceData.buttons = [
         {
-          label: "Watch on AniwatchTV",
-          url: href,
-        },
-      ];
+          label: 'Watch on AniwatchTV',
+          url: href
+        }
+      ]
 
-      const video = document.querySelector("video") as HTMLVideoElement | null;
-      if (video && !isNaN(video.duration)) {
-        presenceData.startTimestamp = Date.now() - Math.floor(video.currentTime * 1000);
-        presenceData.endTimestamp = Date.now() + Math.floor((video.duration - video.currentTime) * 1000);
+      const video = document.querySelector('video') as HTMLVideoElement | null
+      if (video && !Number.isNaN(video.duration)) {
+        presenceData.startTimestamp = Date.now() - Math.floor(video.currentTime * 1000)
+        presenceData.endTimestamp =
+          Date.now() + Math.floor((video.duration - video.currentTime) * 1000)
       }
 
-      break;
+      break
     }
 
     default:
-      presenceData.details = "Browsing AniwatchTV...";
-      presenceData.smallImageKey = Assets.Search;
-      break;
+      presenceData.details = 'Browsing AniwatchTV...'
+      presenceData.smallImageKey = Assets.Search
+      break
   }
 
-  presence.setActivity(presenceData);
-});
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
# Description
Rich Precense for AniwatchTV.to : anime streaming service with thousands of animes.
It has the ability to detect and show: Anime title, poster art, episodes, searching, etc.

# Acknowledgements

- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X]  I linted the code by running npm run lint
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

# Screenshots
<details>
<summary>Proof showing the creation/modification is working as expected</summary>
<br>
<img width="511" height="57" alt="image" src="https://github.com/user-attachments/assets/b8ca17bf-7187-4eb1-97c1-41d9d0bf91a4" />
<img width="311" height="483" alt="image" src="https://github.com/user-attachments/assets/6b750116-5872-4e73-81ad-9134b2e1e816" />
<img width="311" height="480" alt="image" src="https://github.com/user-attachments/assets/48b43327-30c6-4619-90ce-41f7ec32e9e4" />
</details>

