### PR TITLE
feat(mapple.tv): add new activity for mapple.tv

### DIFF
--- a/websites/M/Mapple.tv/metadata.json
+++ b/websites/M/Mapple.tv/metadata.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "756072844584288316",
+    "name": "casper"
+  },
+  "service": "Mapple.tv",
+  "description": {
+    "en": "Shows what you're watching on mapple.tv"
+  },
+  "url": "mapple.tv",
+  "version": "1.0.0",
+  "logo": "https://i.ibb.co/9PPkt6L/mappletv.png",
+  "thumbnail": "https://i.ibb.co/Lhxcqm84/thumbnail.jpg",
+  "color": "#000000",
+  "category": "videos",
+  "tags": ["streaming", "movies", "tv", "entertainment", "media", "sports", "video", "audiobook"],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "description": "Hide all content details",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "browse",
+      "title": "Show Browsing Status",
+      "description": "Display when you're browsing MappleTV content",
+      "icon": "fad fa-book-reader",
+      "value": true
+    },
+    {
+      "id": "live",
+      "title": "Show Livestreams",
+      "description": "Display when you're watching live TV channels",
+      "icon": "fad fa-podcast",
+      "value": true
+    },
+    {
+      "id": "movies",
+      "title": "Show Movie Titles",
+      "description": "Display specific movie titles you're watching",
+      "icon": "fad fa-film",
+      "value": true
+    },
+    {
+      "id": "tvshows",
+      "title": "Show TV Show Titles",
+      "description": "Display specific TV show titles you're watching",
+      "icon": "fad fa-tv",
+      "value": true
+    },
+    {
+      "id": "audiobooks",
+      "title": "Show Audiobook Titles",
+      "description": "Display specific audiobook titles and authors",
+      "icon": "fad fa-headphones",
+      "value": true
+    },
+    {
+      "id": "sports",
+      "title": "Show Sports Titles",
+      "description": "Display the specific sports event you're watching",
+      "icon": "fad fa-basketball-ball",
+      "value": true
+    }
+  ]
+}

--- a/websites/M/Mapple.tv/presence.ts
+++ b/websites/M/Mapple.tv/presence.ts
@@ -1,0 +1,184 @@
+import { Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1400642676487098519',
+})
+
+function getAction(): string {
+  const href = window.location.href
+  if (href.includes('/movie'))
+    return 'movie'
+  if (href.includes('/tv'))
+    return 'tv'
+  if (href.includes('/live-tv'))
+    return 'live'
+  if (href.includes('/watch/channel/'))
+    return 'live'
+  if (href.includes('/sports'))
+    return 'sports'
+  if (href.includes('/audiobooks'))
+    return 'audiobooks'
+  if (href.includes('/listen/'))
+    return 'audiobooks'
+  return 'home'
+}
+
+function getText(selector: string): string {
+  return document.querySelector(selector)?.textContent?.trim() || ''
+}
+
+function getStatus(): string {
+  const url = window.location.href
+
+  // Sports: extract from h2 element
+  if (url.includes('/sports/')) {
+    const h2 = document.querySelector('h2.text-transparent') as HTMLElement
+    return h2?.textContent?.trim() || 'Browsing'
+  }
+
+  // Get content from meta tag
+  const meta = document.querySelector(
+    'meta[name="twitter:title"]',
+  ) as HTMLMetaElement
+  const rawTitle = meta?.content?.trim()
+  if (!rawTitle)
+    return 'Browsing'
+
+  // Audiobooks: extract book title and author
+  if (url.includes('/audiobooks') || url.includes('/listen/')) {
+    const cleanedTitle = rawTitle.replace(/\s*–\s*MappleTV$/i, '')
+    const titleMatch = cleanedTitle.match(/"([^"]+)"/)
+    const byIndex = cleanedTitle.toLowerCase().indexOf(' by ')
+    const author = byIndex !== -1 ? cleanedTitle.slice(byIndex + 4).trim() : 'Unknown Author'
+    const book = titleMatch?.[1]?.trim() || 'Unknown Title'
+    return `${book} by ${author}`
+  }
+
+  // Live TV: remove 'Streaming - ' prefix
+  if (url.includes('/watch/channel/')) {
+    return rawTitle.replace(/^Streaming\s*-\s*/i, '').trim()
+  }
+
+  return `${rawTitle}`
+}
+
+const constructAction: Record<string, string> = {
+  movie: 'Watching a Movie',
+  tv: 'Watching a TV Series',
+  live: 'Streaming Live TV',
+  sports: 'Watching Sports',
+  audiobooks: 'Listening to an Audiobook',
+  home: 'Browsing',
+}
+
+async function updatePresence() {
+  const action = getAction()
+
+  const [
+    privacy,
+    showBrowsing,
+    showLive,
+    showMovies,
+    showTVShows,
+    showAudiobooks,
+    showSports,
+  ] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('browse'),
+    presence.getSetting<boolean>('live'),
+    presence.getSetting<boolean>('movies'),
+    presence.getSetting<boolean>('tvshows'),
+    presence.getSetting<boolean>('audiobooks'),
+    presence.getSetting<boolean>('sports'),
+  ])
+
+  // Privacy mode enabled — show nothing except icon + timestamps (if any)
+  if (privacy) {
+    const presenceData: PresenceData = {
+      largeImageKey: 'https://i.ibb.co/9PPkt6L/mappletv.png',
+    }
+
+    const video = document.querySelector('video')
+    if (video && getStatus().toLowerCase() !== 'pause') {
+      const [start, end] = getTimestampsFromMedia(video)
+      presenceData.startTimestamp = start
+      presenceData.endTimestamp = end
+      presenceData.smallImageKey = Assets.Play
+    }
+    else if (video) {
+      presenceData.smallImageKey = Assets.Pause
+    }
+
+    presence.setActivity(presenceData)
+    return
+  }
+
+  const presenceData: PresenceData = {
+    largeImageKey: 'https://i.ibb.co/9PPkt6L/mappletv.png',
+    details: constructAction[action],
+  }
+
+  // Show 'Browsing' only if it's allowed
+  if (!['movie', 'tv', 'sports', 'live', 'audiobooks'].includes(action)) {
+    if (showBrowsing) {
+      presenceData.details = 'Home'
+      presenceData.startTimestamp = Math.floor(Date.now() / 1000)
+    }
+    else {
+      presenceData.details = ''
+    }
+    presence.setActivity(presenceData)
+    return
+  }
+
+  const allowDetail
+    = (action === 'movie' && showMovies)
+      || (action === 'tv' && showTVShows)
+      || (action === 'live' && showLive)
+      || (action === 'audiobooks' && showAudiobooks)
+      || (action === 'sports' && showSports)
+
+  const video = document.querySelector('video')
+  if (video && getStatus().toLowerCase() !== 'pause') {
+    const [start, end] = getTimestampsFromMedia(video)
+    presenceData.startTimestamp = start
+    presenceData.endTimestamp = end
+    presenceData.smallImageKey = Assets.Play
+  }
+  else if (video) {
+    presenceData.smallImageKey = Assets.Pause
+  }
+
+  if (allowDetail) {
+    const subtitle
+      = getText('.player-title-bar') || getText('[class*=player-title-bar]')
+    presenceData.state = `${getStatus()}${subtitle ? ` | ${subtitle}` : ''}`
+  }
+
+  presence.setActivity(presenceData)
+}
+
+function hookUrlChange(callback: () => void) {
+  const pushState = history.pushState
+  const replaceState = history.replaceState
+
+  history.pushState = function (...args) {
+    pushState.apply(this, args)
+    callback()
+  }
+
+  history.replaceState = function (...args) {
+    replaceState.apply(this, args)
+    callback()
+  }
+
+  window.addEventListener('popstate', callback)
+
+  const observer = new MutationObserver(() => {
+    callback()
+  })
+  observer.observe(document.body, { childList: true, subtree: true })
+}
+
+presence.on('UpdateData', updatePresence)
+hookUrlChange(updatePresence)


### PR DESCRIPTION
## Description

Added a new PreMiD presence for `mapple.tv` with support for dynamic content detection (single-page application behavior).
The presence updates based on URL patterns for movies, TV shows, livestreams, sports, and audiobooks.
It extracts the media title dynamically from the page and displays it according to user privacy settings.

Also added granular settings:

* Privacy Mode (hides all specific activity)
* Show Browsing Status (e.g., on homepage or browsing pages)
* Show Livestreams
* Show Movies
* Show TV Shows
* Show Sports
* Show Audiobooks

## Acknowledgements

* [x] I read the [[Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
* [x] I linted the code by running `npm run lint`
* [x] The PR title follows the repo's [[commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary> Proof showing the creation/modification is working as expected </summary>

</details>