### PR TITLE
feat/fix(TruckersFM): change classes to xpath & new branding

### DIFF
--- a/websites/T/TruckersFM/metadata.json
+++ b/websites/T/TruckersFM/metadata.json
@@ -21,9 +21,9 @@
     "nl": "TruckersFM is het #1 station voor de simulatiegemeenschap, opgericht in 2015. Ze bieden 24/7 entertainment, of je nu in de cabine bent of onderweg. Je kunt overal naar hen luisteren, met een breed scala aan shows, waaronder hun eigen wekelijkse hitlijstshow, The Most Played Chart."
   },
   "url": "truckers.fm",
-  "version": "1.4.24",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/thumbnail.png",
+  "version": "1.4.25",
+  "logo": "https://i.imgur.com/R5xHjtR.png",
+  "thumbnail": "https://i.imgur.com/XkJDUo5.png",
   "color": "#C82372",
   "category": "music",
   "tags": [

--- a/websites/T/TruckersFM/presence.ts
+++ b/websites/T/TruckersFM/presence.ts
@@ -5,18 +5,27 @@ const presence = new Presence({
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
+function getElementByXPath(xpath: string): Element | null {
+  const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+  return result.singleNodeValue as Element | null
+}
+
 presence.on('UpdateData', () => {
   const presenceData: PresenceData = {
-    largeImageKey: document.querySelector<HTMLImageElement>('.album-art')?.src || 'https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/logo.png',
+    largeImageKey: (getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[1]/img') as HTMLImageElement)?.src || 'https://i.imgur.com/R5xHjtR.png',
     startTimestamp: browsingTimestamp,
     type: ActivityType.Listening,
   }
 
+  const artistElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[2]/div[1]/div[2]')
+  const titleElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[2]/div[1]/div[1]')
+  const presenterElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[2]/div/div[2]/div/div[1]/div[2]/div[1]')
+
   presenceData.details = `${
-    document.querySelector('.player-artist-text')?.textContent
-  } - ${document.querySelector('.player-title-text')?.textContent}`
-  presenceData.state = document.querySelector('.live-name')?.textContent ?? 'AutoDJ'
-  presenceData.smallImageKey = 'https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/logo.png'
+    artistElement?.textContent
+  } - ${titleElement?.textContent}`
+  presenceData.state = presenterElement?.textContent ?? 'AutoDJ'
+  presenceData.smallImageKey = 'https://i.imgur.com/R5xHjtR.png'
   presenceData.smallImageText = 'TruckersFM'
 
   presence.setActivity(presenceData)


### PR DESCRIPTION
## Description
TruckersFM recently had a new rebrand including a new logo and a new banner. As a result of this, I have updated the branding. They have also launched a new website, which no longer used CSS classes that I could easily identify with, so I have also updated the code to use full XPath's as I'm not 100% sure on PreMiD's stances on fetching external APIs inside of presences.

## Acknowledgements
- [ ✅] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [✅ ] I linted the code by running `npm run lint`
- [ ✅] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="633" height="234" alt="image" src="https://github.com/user-attachments/assets/7ea46d1b-c071-4100-a870-1363e25fa275" />

I would upload two but it's the same presence. 


</details>
