### PR TITLE
feat(MangaDex): add activity

### DIFF
--- a/websites/M/MangaDex/metadata.json
+++ b/websites/M/MangaDex/metadata.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "1067718540221743134",
+    "name": "baka._.afk"
+  },
+  "service": "MangaDex",
+  "description": {
+    "en": "MangaDex is an online manga reader that caters to all languages. MangaDex is made by scanlators, for scanlators, and gives active scanlation groups complete control over their releases. All of the content on our site is uploaded either by users, scanlation groups, and in some instances the publishers themselves."
+  },
+  "url": "mangadex.org",
+  "version": "1.0.0",
+  "logo": "https://mangadex.dev/content/images/2021/08/icon.png",
+  "thumbnail": "https://gqcanimes.com.br/wp-content/uploads/2025/05/mangadex-remove-mais-700-titulos.webp",
+  "color": "#2C2C2C",
+  "category": "anime",
+  "tags": [
+    "manga"
+  ]
+}

--- a/websites/M/MangaDex/presence.ts
+++ b/websites/M/MangaDex/presence.ts
@@ -1,0 +1,84 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1402290319273234462',
+})
+
+let currentPath = window.location.pathname
+let browseTimestamp: number | null = null
+
+const ActivityAssets = {
+  Logo: 'https://mangadex.dev/content/images/2021/08/icon.png',
+  Reading: Assets.Reading,
+  Searching: Assets.Search,
+}
+
+function getChapterData() {
+  const name = document.querySelector('.reader--header-manga')?.textContent?.trim()
+  const chapName = document.querySelector('.reader--header-title')?.textContent?.trim()
+  const chapNum = document.querySelector('.reader--meta.chapter')?.textContent?.trim()
+  return {
+    smallImageKey: ActivityAssets.Reading,
+    details: `Reading: ${name || '...'}`,
+    state: `${chapNum || ''} - ${chapName || '...'}`,
+    buttons: [{ label: 'Read Chapter', url: window.location.href }],
+  }
+}
+
+function getSlicedTitleData(prefix: string, label: string) {
+  return {
+    details: `${prefix}: ${document.title.slice(0, -11)}`,
+    buttons: [{ label, url: window.location.href }],
+  }
+}
+
+const routes = [
+  { path: '/chapter/', data: getChapterData },
+  { path: '/title/', data: () => ({ details: `Viewing title: ${document.querySelector('div.title p')?.textContent?.trim() || '...'}`, buttons: [{ label: 'View Manga', url: window.location.href }] }) },
+  { path: '/titles/feed', data: () => ({ smallImageKey: ActivityAssets.Searching, details: 'Viewing Updates tab' }) },
+  { path: '/titles/follows', data: () => ({ details: 'Viewing Library' }) },
+  { path: '/my/history', data: () => ({ details: 'Viewing History' }) },
+  { path: '/titles', data: () => ({ smallImageKey: ActivityAssets.Searching, details: 'Searching Manga' }) },
+  { path: '/user/', data: () => getSlicedTitleData('Viewing User Profile', 'View User') },
+  { path: '/users', data: () => ({ details: 'Finding Users', smallImageKey: ActivityAssets.Searching }) },
+  { path: '/group/', data: () => getSlicedTitleData('Viewing Group', 'View Group') },
+  { path: '/groups', data: () => ({ details: 'Finding Groups', smallImageKey: ActivityAssets.Searching }) },
+  { path: '/settings', data: () => ({ details: 'Changing Settings' }) },
+]
+
+async function updatePresence() {
+  if (!browseTimestamp) {
+    presence.setActivity()
+    return
+  }
+
+  const path = window.location.pathname
+  const route = routes.find(r => path.includes(r.path))
+
+  const partialData = route
+    ? route.data()
+    : {
+        details: 'Browse MangaDex',
+        state: 'Discovering new titles',
+      }
+
+  const presenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browseTimestamp,
+    ...partialData,
+  }
+
+  presence.setActivity(presenceData)
+}
+
+setInterval(() => {
+  if (window.location.pathname !== currentPath) {
+    currentPath = window.location.pathname
+    browseTimestamp = Math.floor(Date.now() / 1000)
+    updatePresence()
+  }
+}, 1000)
+
+browseTimestamp = Math.floor(Date.now() / 1000)
+presence.on('UpdateData', updatePresence)
+updatePresence()


### PR DESCRIPTION

## Description

This pull request adds a new presence for the manga website `mangadex.org`.

The presence supports:
- Reading a specific chapter, showing manga title, chapter number, and chapter name.
- Viewing a manga's title page.
- Browse manga lists (including updates feed, follows/library, and general search).
- Viewing user and group profiles.
- Checking personal reading history.
- Browse the settings page.
- A general status for Browse other parts of the website.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary>Proof showing the presence is working as expected</summary>
<img width="517" height="216" alt="Screenshot 2025-08-06 124340" src="https://github.com/user-attachments/assets/cbc3b7a9-5b78-4622-994a-35ba9637fc8a" />
<img width="512" height="217" alt="Screenshot 2025-08-06 124310" src="https://github.com/user-attachments/assets/994ab880-b95a-4f68-b874-f0a0e50e63d4" />
<img width="520" height="201" alt="Screenshot 2025-08-06 124225" src="https://github.com/user-attachments/assets/150cfd04-34ba-41c3-80df-d732c27f6709" />
<img width="502" height="207" alt="Screenshot 2025-08-06 124155" src="https://github.com/user-attachments/assets/2722568a-af95-4c39-816c-5af314eedffa" />
<img width="491" height="176" alt="Screenshot 2025-08-06 124045" src="https://github.com/user-attachments/assets/c01c2c9f-b490-4284-8963-729dc46634b3" />

</details>