### PR TITLE
feat(StellaFansub): add presence

### DIFF
--- a/websites/S/StellaFansub/metadata.json
+++ b/websites/S/StellaFansub/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "1328446510454669447",
+    "name": "aldeebarann"
+  },
+  "service": "StellaFansub",
+  "description": {
+    "en": "StellaFansub shows what is being read (main/series/chapter) on Türkiye's most advanced novel site.",
+    "tr": "StellaFansub Türkiyenin en yenilikçi novel sitesinde (ana/seri/bölüm) ne okuduğunuzu gösterir."
+  },
+  "url": "stellafansub.com",
+  "version": "1.0.0",
+  "logo": "https://stellafansub.com/assets/logo.png",
+  "thumbnail": "https://stellafansub.com/backgrounds/sunset.jpg",
+  "color": "#8b5cf6",
+  "category": "anime",
+  "tags": [
+    "novel",
+    "reading",
+    "anime",
+    "turkish"
+  ]
+}

--- a/websites/S/StellaFansub/presence.ts
+++ b/websites/S/StellaFansub/presence.ts
@@ -1,0 +1,99 @@
+// stellafansub/presence.ts
+import { ActivityType } from "premid";
+
+const presence = new Presence({
+  clientId: "1404828900978200586",
+});
+
+const START = Math.floor(Date.now() / 1000);
+
+// Görselleri URL olarak kullanıyoruz (Discord asset şart değil)
+enum Images {
+  Logo = "https://stellafansub.com/assets/logo.png",
+  Listening = "https://stellafansub.com/assets/listening.png",
+}
+
+type PMButton = { label: string; url: string };
+
+interface YTInfo {
+  playing: boolean;
+  title?: string;
+  url?: string;
+}
+
+function readDataset() {
+  const el = document.getElementById("premid-state") as HTMLElement | null;
+  const ds = (el?.dataset || {}) as Record<string, string>;
+
+  const yt: YTInfo = {
+    playing: ds.ytPlaying === "1",
+    title: ds.ytTitle,
+    url: ds.ytUrl,
+  };
+
+  return {
+    ds,
+    yt,
+    path: location.pathname,
+    url: ds.url || location.href,
+    title: ds.title || document.title || "",
+  };
+}
+
+function updatePresence() {
+  const { ds, yt, path, url, title } = readDataset();
+
+  let details = "";
+  let state = "";
+  const buttons: PMButton[] = [];
+
+  if (/^\/reader\/\d+\/\d+/.test(path)) {
+    const chapter = ds.chapter || path.split("/").pop() || "";
+    details = chapter ? `${chapter}. Bölümü okuyor` : "Bölüm okuyor";
+    state = ds.series || title || "Okuma";
+    buttons.push({ label: "Bölümü Aç", url });
+  } else if (/^\/series\//.test(path)) {
+    details = "Seri sayfasına bakıyor";
+    state = ds.series || title || "Seri";
+    buttons.push({ label: "Seri Sayfası", url });
+  } else {
+    details = "Sitede geziniyor";
+    state = ds.title || "Ana sayfa";
+    buttons.push({ label: "Siteyi Aç", url });
+  }
+
+  let smallImageKey: string | undefined;
+  let smallImageText: string | undefined;
+
+  if (yt.playing && yt.url) {
+    smallImageKey = Images.Listening;
+    smallImageText = yt.title || "YouTube";
+    if (buttons.length < 2) buttons.push({ label: "YouTube — Şu An", url: yt.url });
+  }
+
+  const data: PresenceData = {
+    type: ActivityType.Watching,
+    details,
+    state,
+    largeImageKey: Images.Logo,
+    smallImageKey,
+    smallImageText,
+    startTimestamp: START,
+  };
+
+  // PreMiD tuple ister: [btn] ya da [btn1, btn2]
+  if (buttons.length === 1) {
+    data.buttons = [buttons[0]] as [PMButton];
+  } else if (buttons.length >= 2) {
+    data.buttons = [buttons[0], buttons[1]] as [PMButton, PMButton];
+  }
+
+  presence.setActivity(data);
+}
+
+// Değişimleri dinle
+const mo = new MutationObserver(() => updatePresence());
+mo.observe(document.body, { childList: true, subtree: true });
+
+document.addEventListener("DOMContentLoaded", updatePresence);
+window.addEventListener("popstate", updatePresence);


### PR DESCRIPTION
## Description
Added **StellaFansub** Rich Presence activity.  
This activity displays the current series or chapter being read on [stellafansub.com](https://stellafansub.com) in Discord Rich Presence, including title, chapter name, and reading status.  
All required files (`presence.ts`, `metadata.json`, `tsconfig.json`) have been added under `websites/S/StellaFansub`.  
Lint and build checks have been passed locally.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

1. **Activity Settings**
<br>
<img width="1473" height="845" alt="image" src="https://github.com/user-attachments/assets/b501efda-f3fa-43b2-9b37-c4a5d0317ae0" />
<br>
2. **Discord Rich Presence**
<br>
<img width="517" height="82" alt="image" src="https://github.com/user-attachments/assets/0ec271d5-1bc0-4ad0-9341-4ee2fc73b744" />
<br>
<img width="272" height="364" alt="image" src="https://github.com/user-attachments/assets/d34e8c9e-4598-462e-b8fd-a45604f68eb2" />
<br>
<img width="271" height="195" alt="image" src="https://github.com/user-attachments/assets/5ebaac6c-4c29-4aa0-acdb-1acca6e9092e" />
<br>
<img width="268" height="206" alt="image" src="https://github.com/user-attachments/assets/5f725298-d4e4-4b01-b486-5251bf9989ff" />

<br>
3. **Website View**
<br>
<img width="1833" height="870" alt="image" src="https://github.com/user-attachments/assets/b20cf6d6-3cbe-4ef4-838b-b149a0f537fc" />
<br>
<img width="1915" height="937" alt="image" src="https://github.com/user-attachments/assets/9a1d9805-501f-4196-af4e-0ed6008cbe74" />
<br>



</details>