### PR TITLE
feat(StellaFansub): add activity

### DIFF
--- a/websites/S/StellaFansub/metadata.json
+++ b/websites/S/StellaFansub/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "1328446510454669447",
+    "name": "aldeebarann"
+  },
+  "service": "StellaFansub",
+  "description": {
+    "en": "StellaFansub shows what is being read (main/series/chapter) on Türkiye's most advanced novel site.",
+    "tr": "StellaFansub Türkiyenin en yenilikçi novel sitesinde (ana/seri/bölüm) ne okuduğunuzu gösterir."
+  },
+  "url": "stellafansub.com",
+  "version": "1.0.0",
+  "logo": "https://stellafansub.com/assets/logo.png",
+  "thumbnail": "https://stellafansub.com/backgrounds/sunset.jpg",
+  "color": "#8b5cf6",
+  "category": "anime",
+  "tags": [
+    "novel",
+    "reading",
+    "anime",
+    "turkish"
+  ]
+}

--- a/websites/S/StellaFansub/presence.ts
+++ b/websites/S/StellaFansub/presence.ts
@@ -1,0 +1,99 @@
+// stellafansub/presence.ts
+import { ActivityType } from "premid";
+
+const presence = new Presence({
+  clientId: "1404828900978200586",
+});
+
+const START = Math.floor(Date.now() / 1000);
+
+// Görselleri URL olarak kullanıyoruz (Discord asset şart değil)
+enum Images {
+  Logo = "https://stellafansub.com/assets/logo.png",
+  Listening = "https://stellafansub.com/assets/listening.png",
+}
+
+type PMButton = { label: string; url: string };
+
+interface YTInfo {
+  playing: boolean;
+  title?: string;
+  url?: string;
+}
+
+function readDataset() {
+  const el = document.getElementById("premid-state") as HTMLElement | null;
+  const ds = (el?.dataset || {}) as Record<string, string>;
+
+  const yt: YTInfo = {
+    playing: ds.ytPlaying === "1",
+    title: ds.ytTitle,
+    url: ds.ytUrl,
+  };
+
+  return {
+    ds,
+    yt,
+    path: location.pathname,
+    url: ds.url || location.href,
+    title: ds.title || document.title || "",
+  };
+}
+
+function updatePresence() {
+  const { ds, yt, path, url, title } = readDataset();
+
+  let details = "";
+  let state = "";
+  const buttons: PMButton[] = [];
+
+  if (/^\/reader\/\d+\/\d+/.test(path)) {
+    const chapter = ds.chapter || path.split("/").pop() || "";
+    details = chapter ? `${chapter}. Bölümü okuyor` : "Bölüm okuyor";
+    state = ds.series || title || "Okuma";
+    buttons.push({ label: "Bölümü Aç", url });
+  } else if (/^\/series\//.test(path)) {
+    details = "Seri sayfasına bakıyor";
+    state = ds.series || title || "Seri";
+    buttons.push({ label: "Seri Sayfası", url });
+  } else {
+    details = "Sitede geziniyor";
+    state = ds.title || "Ana sayfa";
+    buttons.push({ label: "Siteyi Aç", url });
+  }
+
+  let smallImageKey: string | undefined;
+  let smallImageText: string | undefined;
+
+  if (yt.playing && yt.url) {
+    smallImageKey = Images.Listening;
+    smallImageText = yt.title || "YouTube";
+    if (buttons.length < 2) buttons.push({ label: "YouTube — Şu An", url: yt.url });
+  }
+
+  const data: PresenceData = {
+    type: ActivityType.Watching,
+    details,
+    state,
+    largeImageKey: Images.Logo,
+    smallImageKey,
+    smallImageText,
+    startTimestamp: START,
+  };
+
+  // PreMiD tuple ister: [btn] ya da [btn1, btn2]
+  if (buttons.length === 1) {
+    data.buttons = [buttons[0]] as [PMButton];
+  } else if (buttons.length >= 2) {
+    data.buttons = [buttons[0], buttons[1]] as [PMButton, PMButton];
+  }
+
+  presence.setActivity(data);
+}
+
+// Değişimleri dinle
+const mo = new MutationObserver(() => updatePresence());
+mo.observe(document.body, { childList: true, subtree: true });
+
+document.addEventListener("DOMContentLoaded", updatePresence);
+window.addEventListener("popstate", updatePresence);

--- a/websites/S/StellaFansub/presence.ts
+++ b/websites/S/StellaFansub/presence.ts
@@ -1,19 +1,18 @@
-// stellafansub/presence.ts
-import { ActivityType } from "premid";
+import { ActivityType } from 'premid';
 
 const presence = new Presence({
-  clientId: "1404828900978200586",
+  clientId: '1404828900978200586',
 });
 
 const START = Math.floor(Date.now() / 1000);
 
-// Görselleri URL olarak kullanıyoruz (Discord asset şart değil)
+// Görselleri URL olarak kullanıyoruz
 enum Images {
-  Logo = "https://stellafansub.com/assets/logo.png",
-  Listening = "https://stellafansub.com/assets/listening.png",
+  Logo = 'https://stellafansub.com/assets/logo.png',
+  Listening = 'https://stellafansub.com/assets/listening.png',
 }
 
-type PMButton = { label: string; url: string };
+type Btn = { label: string; url: string };
 
 interface YTInfo {
   playing: boolean;
@@ -21,12 +20,18 @@ interface YTInfo {
   url?: string;
 }
 
-function readDataset() {
-  const el = document.getElementById("premid-state") as HTMLElement | null;
+function readDataset(): {
+  ds: Record<string, string>;
+  yt: YTInfo;
+  path: string;
+  url: string;
+  title: string;
+} {
+  const el = document.getElementById('premid-state') as HTMLElement | null;
   const ds = (el?.dataset || {}) as Record<string, string>;
 
   const yt: YTInfo = {
-    playing: ds.ytPlaying === "1",
+    playing: ds.ytPlaying === '1',
     title: ds.ytTitle,
     url: ds.ytUrl,
   };
@@ -34,32 +39,32 @@ function readDataset() {
   return {
     ds,
     yt,
-    path: location.pathname,
-    url: ds.url || location.href,
-    title: ds.title || document.title || "",
+    path: window.location.pathname,
+    url: ds.url || window.location.href,
+    title: ds.title || document.title || '',
   };
 }
 
-function updatePresence() {
+function updatePresence(): void {
   const { ds, yt, path, url, title } = readDataset();
 
-  let details = "";
-  let state = "";
-  const buttons: PMButton[] = [];
+  let details = '';
+  let state = '';
+  const buttons: Btn[] = [];
 
   if (/^\/reader\/\d+\/\d+/.test(path)) {
-    const chapter = ds.chapter || path.split("/").pop() || "";
-    details = chapter ? `${chapter}. Bölümü okuyor` : "Bölüm okuyor";
-    state = ds.series || title || "Okuma";
-    buttons.push({ label: "Bölümü Aç", url });
+    const chapter = ds.chapter || path.split('/').pop() || '';
+    details = chapter ? `${chapter}. Bölümü okuyor` : 'Bölüm okuyor';
+    state = ds.series || title || 'Okuma';
+    buttons.push({ label: 'Bölümü Aç', url });
   } else if (/^\/series\//.test(path)) {
-    details = "Seri sayfasına bakıyor";
-    state = ds.series || title || "Seri";
-    buttons.push({ label: "Seri Sayfası", url });
+    details = 'Seri sayfasına bakıyor';
+    state = ds.series || title || 'Seri';
+    buttons.push({ label: 'Seri Sayfası', url });
   } else {
-    details = "Sitede geziniyor";
-    state = ds.title || "Ana sayfa";
-    buttons.push({ label: "Siteyi Aç", url });
+    details = 'Sitede geziniyor';
+    state = ds.title || 'Ana sayfa';
+    buttons.push({ label: 'Siteyi Aç', url });
   }
 
   let smallImageKey: string | undefined;
@@ -67,8 +72,10 @@ function updatePresence() {
 
   if (yt.playing && yt.url) {
     smallImageKey = Images.Listening;
-    smallImageText = yt.title || "YouTube";
-    if (buttons.length < 2) buttons.push({ label: "YouTube — Şu An", url: yt.url });
+    smallImageText = yt.title || 'YouTube';
+    if (buttons.length < 2) {
+      buttons.push({ label: 'YouTube — Şu An', url: yt.url });
+    }
   }
 
   const data: PresenceData = {
@@ -81,19 +88,21 @@ function updatePresence() {
     startTimestamp: START,
   };
 
-  // PreMiD tuple ister: [btn] ya da [btn1, btn2]
+  // PreMiD, butonları 1 veya 2 öğeli tuple bekler
   if (buttons.length === 1) {
-    data.buttons = [buttons[0]] as [PMButton];
+    data.buttons = [buttons[0]] as [Btn];
   } else if (buttons.length >= 2) {
-    data.buttons = [buttons[0], buttons[1]] as [PMButton, PMButton];
+    data.buttons = [buttons[0], buttons[1]] as [Btn, Btn];
   }
 
   presence.setActivity(data);
 }
 
-// Değişimleri dinle
-const mo = new MutationObserver(() => updatePresence());
+// DOM değişimlerini dinle
+const mo = new MutationObserver(() => {
+  updatePresence();
+});
 mo.observe(document.body, { childList: true, subtree: true });
 
-document.addEventListener("DOMContentLoaded", updatePresence);
-window.addEventListener("popstate", updatePresence);
+document.addEventListener('DOMContentLoaded', updatePresence);
+window.addEventListener('popstate', updatePresence);


### PR DESCRIPTION
## Description
Added **StellaFansub** Rich Presence activity.  
This activity displays the current series or chapter being read on [stellafansub.com](https://stellafansub.com) in Discord Rich Presence, including title, chapter name, and reading status.  
All required files (`presence.ts`, `metadata.json`, `tsconfig.json`) have been added under `websites/S/StellaFansub`.  
Lint and build checks have been passed locally.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<br>
<img width="268" height="211" alt="image" src="https://github.com/user-attachments/assets/8ffe258e-2ed0-42de-9efb-83a11e05275c" />
<br>
<img width="408" height="585" alt="image" src="https://github.com/user-attachments/assets/d5b0c7d8-f978-4311-88cd-4003a454b9e6" />
<br>
<img width="884" height="371" alt="image" src="https://github.com/user-attachments/assets/1d71e81a-4ba7-4da5-bef0-7714f01cf078" />
<br>
<img width="1209" height="758" alt="image" src="https://github.com/user-attachments/assets/b586ed66-9eb6-4de3-a8ce-ff54cfe50ec9" />



</details>