### PR TITLE
feat(Deezer): extract main artist name for presence data

### DIFF
--- a/websites/D/Deezer/metadata.json
+++ b/websites/D/Deezer/metadata.json
@@ -51,6 +51,12 @@
       "value": true
     },
     {
+      "id": "artistAsTitle",
+      "title": "Show Artist as Title",
+      "icon": "fad fa-user-large",
+      "value": true
+    },
+    {
       "id": "browseInfo",
       "title": "Only show browsing info",
       "icon": "fad fa-magnifying-glass",

--- a/websites/D/Deezer/metadata.json
+++ b/websites/D/Deezer/metadata.json
@@ -24,7 +24,7 @@
     "vi": "Nghe tất cả những bài hát bạn yêu thích mọi lúc, mọi nơi."
   },
   "url": "www.deezer.com",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/D/Deezer/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/D/Deezer/assets/thumbnail.png",
   "color": "#a238ff",

--- a/websites/D/Deezer/presence.ts
+++ b/websites/D/Deezer/presence.ts
@@ -1,4 +1,4 @@
-import { ActivityType, Assets } from 'premid'
+import { ActivityType, Assets, getTimestamps, timestampFromFormat } from 'premid'
 
 const presence = new Presence({
   clientId: '607651992567021580',
@@ -106,11 +106,11 @@ presence.on('UpdateData', async () => {
   const artistLink = document
     .querySelector('[data-testid="item_subtitle"] > a')
     ?.getAttribute('href')
-  const timestamps = presence.getTimestamps(
-    presence.timestampFromFormat(
+  const timestamps = getTimestamps(
+    timestampFromFormat(
       document.querySelector('[data-testid="elapsed_time"]')?.textContent ?? '',
     ),
-    presence.timestampFromFormat(
+    timestampFromFormat(
       document.querySelector('[data-testid="remaining_time"]')?.textContent ?? '',
     ),
   )
@@ -127,7 +127,8 @@ presence.on('UpdateData', async () => {
 
   const mainArtistName = document
     .querySelector('[data-testid="item_subtitle"] > a')
-    ?.textContent?.trim()
+    ?.textContent
+    ?.trim()
   if (mainArtistName)
     presenceData.name = mainArtistName
 
@@ -136,7 +137,7 @@ presence.on('UpdateData', async () => {
       .querySelector('[data-testid="item_cover"]')
       ?.querySelector('img')
       ?.getAttribute('src')
-      ?.replace(/(264x264)|(48x48)/g, '512x512') ?? ActivityAssets.Logo
+      ?.replace(/264x264|48x48/g, '512x512') ?? ActivityAssets.Logo
     : ActivityAssets.Logo
   presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play
   presenceData.smallImageText = paused ? strings.pause : strings.play;

--- a/websites/D/Deezer/presence.ts
+++ b/websites/D/Deezer/presence.ts
@@ -133,10 +133,10 @@ presence.on('UpdateData', async () => {
     .filter((t): t is string => Boolean(t))
     .join(', ')
 
-  presenceData.state = artistAsTitle
-    ? ''
-    : joinedArtists
+  if (!artistAsTitle) {
+    presenceData.state = joinedArtists
       || document.querySelector('[data-testid="item_subtitle"]')?.textContent
+  }
 
   if (artistAsTitle && joinedArtists)
     presenceData.name = joinedArtists

--- a/websites/D/Deezer/presence.ts
+++ b/websites/D/Deezer/presence.ts
@@ -41,11 +41,12 @@ presence.on('UpdateData', async () => {
   let strings = await getStrings()
   let paused = false
 
-  const [buttons, newLang, cover, browseInfo] = await Promise.all([
+  const [buttons, newLang, cover, browseInfo, artistAsTitle] = await Promise.all([
     presence.getSetting<boolean>('buttons'),
     presence.getSetting<string>('lang').catch(() => 'en'),
     presence.getSetting<boolean>('cover'),
     presence.getSetting<boolean>('browseInfo'),
+    presence.getSetting<boolean>('artistAsTitle'),
   ])
   const { pathname, hostname } = document.location
   const remainingTest = document.querySelector(
@@ -121,16 +122,24 @@ presence.on('UpdateData', async () => {
   presenceData.details = document.querySelector(
     '[data-testid="item_title"]',
   )?.textContent
-  presenceData.state = document.querySelector(
-    '[data-testid="item_subtitle"]',
-  )?.textContent
 
-  const mainArtistName = document
-    .querySelector('[data-testid="item_subtitle"] > a')
-    ?.textContent
-    ?.trim()
-  if (mainArtistName)
-    presenceData.name = mainArtistName
+  const artistElements = [
+    ...document.querySelectorAll<HTMLAnchorElement>(
+      '[data-testid="item_subtitle"] a',
+    ),
+  ]
+  const joinedArtists = artistElements
+    .map(a => a.textContent?.trim())
+    .filter((t): t is string => Boolean(t))
+    .join(', ')
+
+  presenceData.state = artistAsTitle
+    ? ''
+    : joinedArtists
+      || document.querySelector('[data-testid="item_subtitle"]')?.textContent
+
+  if (artistAsTitle && joinedArtists)
+    presenceData.name = joinedArtists
 
   presenceData.largeImageKey = cover
     ? document

--- a/websites/D/Deezer/presence.ts
+++ b/websites/D/Deezer/presence.ts
@@ -125,6 +125,12 @@ presence.on('UpdateData', async () => {
     '[data-testid="item_subtitle"]',
   )?.textContent
 
+  const mainArtistName = document
+    .querySelector('[data-testid="item_subtitle"] > a')
+    ?.textContent?.trim()
+  if (mainArtistName)
+    presenceData.name = mainArtistName
+
   presenceData.largeImageKey = cover
     ? document
       .querySelector('[data-testid="item_cover"]')


### PR DESCRIPTION
## Description
This PR updates the main presence status for the Deezer activity to show the artist being listened to, mirroring Discord's native Spotify integration.

Previously, the status in the user list was always static and simply showed "Listening to **Deezer**".

With this change, the status now dynamically displays the main artist. For example, when listening to the song "Type Shit":

**Before:**
> Listening to **Deezer**

**After:**
> Listening to **Future**

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="278" height="191" alt="image" src="https://github.com/user-attachments/assets/848331eb-616e-4dc3-85c5-4aeaa12ea7ac" />
<img width="242" height="95" alt="image" src="https://github.com/user-attachments/assets/d0021ef4-3db8-4645-a34e-1bdad0c2f6b2" />
</details>
