### PR TITLE
fix(Wplace): add privacy settings

### DIFF
--- a/websites/W/Wplace/metadata.json
+++ b/websites/W/Wplace/metadata.json
@@ -19,5 +19,22 @@
     "place",
     "redditplace",
     "game"
+  ],
+  "settings": [
+    {
+      "id": "coordinatesPrivacy",
+      "title": "Hide Coordinates",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "countryPrivacy",
+      "title": "Hide Country",
+      "icon": "fad fa-user-secret",
+      "value": false,
+      "if": {
+        "coordinatesPrivacy": true
+      }
+    }
   ]
 }

--- a/websites/W/Wplace/metadata.json
+++ b/websites/W/Wplace/metadata.json
@@ -10,7 +10,7 @@
     "en": "Wplace is a collaborative, real-time pixel canvas layered over the world map, where anyone can paint and create art together."
   },
   "url": "wplace.live",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/W/Wplace/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/W/Wplace/assets/thumbnail.png",
   "color": "#1C61E7",

--- a/websites/W/Wplace/metadata.json
+++ b/websites/W/Wplace/metadata.json
@@ -10,7 +10,7 @@
     "en": "Wplace is a collaborative, real-time pixel canvas layered over the world map, where anyone can paint and create art together."
   },
   "url": "wplace.live",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/W/Wplace/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/W/Wplace/assets/thumbnail.png",
   "color": "#1C61E7",

--- a/websites/W/Wplace/presence.ts
+++ b/websites/W/Wplace/presence.ts
@@ -23,6 +23,9 @@ function updateGlobals() {
 }
 
 presence.on('UpdateData', async () => {
+  const coordinatesPrivacy = await presence.getSetting<boolean>('coordinatesPrivacy')
+  const countryPrivacy = !coordinatesPrivacy ? false : await presence.getSetting<boolean>('countryPrivacy')
+
   updateGlobals()
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
@@ -59,9 +62,20 @@ presence.on('UpdateData', async () => {
     }
   }
   else {
-    presenceData.details = zone === 'Unknown'
-      ? `Looking at pixel ${coordinates} (Unknown zone)`
-      : `Looking at pixel ${coordinates} (${zone})`
+    if (coordinatesPrivacy) {
+      if (countryPrivacy) {
+        presenceData.details = `Viewing a pixel`
+      } else {
+        presenceData.details = zone === 'Unknown'
+        ? `Viewing a pixel`
+        : `Viewing a pixel in ${zone}`
+      }
+    }
+    else {
+      presenceData.details = zone === 'Unknown'
+        ? `Looking at pixel ${coordinates} (Unknown zone)`
+        : `Looking at pixel ${coordinates} (${zone})`
+    }
     presenceData.state = getState()
   }
 

--- a/websites/W/Wplace/presence.ts
+++ b/websites/W/Wplace/presence.ts
@@ -65,10 +65,11 @@ presence.on('UpdateData', async () => {
     if (coordinatesPrivacy) {
       if (countryPrivacy) {
         presenceData.details = `Viewing a pixel`
-      } else {
+      }
+      else {
         presenceData.details = zone === 'Unknown'
-        ? `Viewing a pixel`
-        : `Viewing a pixel in ${zone}`
+          ? `Viewing a pixel`
+          : `Viewing a pixel in ${zone}`
       }
     }
     else {


### PR DESCRIPTION
## Description
New privacy settings for wplace: users can now hide their coordinates and country, disabling coordinates disables the country, but they can leave the country displayed without coordinates if they wish (not the other way around because it's useless and it doesn't look good)

<img width="641" height="141" alt="image" src="https://github.com/user-attachments/assets/bbdab0b8-73fb-4e52-8b16-6c7593ca497e" />

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

I just broke my premid extension but trust me it works really well, I also tested using logs

</details>
