### PR TITLE
feat(TruckersFM): update xpath back to ID's

### DIFF
--- a/websites/T/TruckersFM/metadata.json
+++ b/websites/T/TruckersFM/metadata.json
@@ -21,7 +21,7 @@
     "nl": "TruckersFM is het #1 station voor de simulatiegemeenschap, opgericht in 2015. Ze bieden 24/7 entertainment, of je nu in de cabine bent of onderweg. Je kunt overal naar hen luisteren, met een breed scala aan shows, waaronder hun eigen wekelijkse hitlijstshow, The Most Played Chart."
   },
   "url": "truckers.fm",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "logo": "https://i.imgur.com/R5xHjtR.png",
   "thumbnail": "https://i.imgur.com/XkJDUo5.png",
   "color": "#C82372",

--- a/websites/T/TruckersFM/metadata.json
+++ b/websites/T/TruckersFM/metadata.json
@@ -21,9 +21,9 @@
     "nl": "TruckersFM is het #1 station voor de simulatiegemeenschap, opgericht in 2015. Ze bieden 24/7 entertainment, of je nu in de cabine bent of onderweg. Je kunt overal naar hen luisteren, met een breed scala aan shows, waaronder hun eigen wekelijkse hitlijstshow, The Most Played Chart."
   },
   "url": "truckers.fm",
-  "version": "1.4.24",
-  "logo": "https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/logo.png",
-  "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/thumbnail.png",
+  "version": "1.4.25",
+  "logo": "https://i.imgur.com/R5xHjtR.png",
+  "thumbnail": "https://i.imgur.com/XkJDUo5.png",
   "color": "#C82372",
   "category": "music",
   "tags": [

--- a/websites/T/TruckersFM/presence.ts
+++ b/websites/T/TruckersFM/presence.ts
@@ -5,26 +5,23 @@ const presence = new Presence({
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
-function getElementByXPath(xpath: string): Element | null {
-  const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
-  return result.singleNodeValue as Element | null
-}
-
 presence.on('UpdateData', () => {
   const presenceData: PresenceData = {
-    largeImageKey: (getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[1]/img') as HTMLImageElement)?.src || 'https://i.imgur.com/R5xHjtR.png',
+    largeImageKey: (document.getElementById('song-art') as HTMLImageElement)?.src || 'https://i.imgur.com/R5xHjtR.png',
     startTimestamp: browsingTimestamp,
     type: ActivityType.Listening,
   }
 
-  const artistElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[2]/div[1]/div[2]')
-  const titleElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[2]/div[1]/div[1]')
-  const presenterElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[2]/div/div[2]/div/div[1]/div[2]/div[1]')
+  const artistElement = document.getElementById('song-artist')
+  const titleElement = document.getElementById('song-title')
+  const presenterElement = document.getElementById('show-name')
 
-  presenceData.details = `${
-    artistElement?.textContent
-  } - ${titleElement?.textContent}`
-  presenceData.state = presenterElement?.textContent ?? 'AutoDJ'
+  const artist = artistElement?.textContent?.trim() || 'TruckersFM'
+  const title = titleElement?.textContent?.trim() || 'Loading...'
+  const presenter = presenterElement?.textContent?.trim() || 'TruckersFM'
+
+  presenceData.details = `${artist} - ${title}`
+  presenceData.state = presenter
   presenceData.smallImageKey = 'https://i.imgur.com/R5xHjtR.png'
   presenceData.smallImageText = 'TruckersFM'
 

--- a/websites/T/TruckersFM/presence.ts
+++ b/websites/T/TruckersFM/presence.ts
@@ -5,18 +5,27 @@ const presence = new Presence({
 })
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
+function getElementByXPath(xpath: string): Element | null {
+  const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
+  return result.singleNodeValue as Element | null
+}
+
 presence.on('UpdateData', () => {
   const presenceData: PresenceData = {
-    largeImageKey: document.querySelector<HTMLImageElement>('.album-art')?.src || 'https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/logo.png',
+    largeImageKey: (getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[1]/img') as HTMLImageElement)?.src || 'https://i.imgur.com/R5xHjtR.png',
     startTimestamp: browsingTimestamp,
     type: ActivityType.Listening,
   }
 
+  const artistElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[2]/div[1]/div[2]')
+  const titleElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[1]/div/div[2]/div[1]/div[1]')
+  const presenterElement = getElementByXPath('/html/body/div[1]/div/div[1]/div[3]/div[1]/div/div[2]/div/div[2]/div/div[1]/div[2]/div[1]')
+
   presenceData.details = `${
-    document.querySelector('.player-artist-text')?.textContent
-  } - ${document.querySelector('.player-title-text')?.textContent}`
-  presenceData.state = document.querySelector('.live-name')?.textContent ?? 'AutoDJ'
-  presenceData.smallImageKey = 'https://cdn.rcd.gg/PreMiD/websites/T/TruckersFM/assets/logo.png'
+    artistElement?.textContent
+  } - ${titleElement?.textContent}`
+  presenceData.state = presenterElement?.textContent ?? 'AutoDJ'
+  presenceData.smallImageKey = 'https://i.imgur.com/R5xHjtR.png'
   presenceData.smallImageText = 'TruckersFM'
 
   presence.setActivity(presenceData)


### PR DESCRIPTION
## Description
After speaking with the developers at TruckersFM - they added IDs back to the relevant elements that PreMiD requires because XPath was unstable and kept changing as development progressed. This means I have updated the presence accordingly, I've also noticed that in my last PR there were image changes and they have not been updated on the store.

This new branding should be reflected as soon as possible, as we're no longer using the old logo and banner, so I've re-included the Imgur links in the PR.

## Acknowledgements
- [ X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [ X] I linted the code by running `npm run lint`
- [ X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="635" height="307" alt="image" src="https://github.com/user-attachments/assets/d1368d7a-945d-4fd7-b86a-3ff2c0dc41ee" />



</details>
