### PR TITLE
fix(AnimeKai): Update iFrameRegExp to match new video player domain

### DIFF
--- a/websites/A/AnimeKai/metadata.json
+++ b/websites/A/AnimeKai/metadata.json
@@ -10,16 +10,14 @@
     "en": "AnimeKai is the best website to watch anime online for free, watch anime with DUB, SUB in HD."
   },
   "url": ["animekai.to", "animekai.bz", "animekai.cc", "animekai.ac"],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeKai/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeKai/assets/thumbnail.png",
   "color": "#40b15d",
   "category": "anime",
-  "tags": [
-    "anime"
-  ],
+  "tags": ["anime"],
   "iframe": true,
-  "iFrameRegExp": "megaup[.]cc",
+  "iFrameRegExp": "megaup[.]site",
   "settings": [
     {
       "id": "buttons",

--- a/websites/A/AnimeKai/presence.ts
+++ b/websites/A/AnimeKai/presence.ts
@@ -188,7 +188,7 @@ presence.on('UpdateData', async () => {
       }
       case '/user/sync': {
         presenceData.details = 'Syncing with AL'
-        presenceData.smallImageKey = Assets.Live
+        presenceData.smallImageKey = Assets.Repeat
         break
       }
       case '/user/notifications': {


### PR DESCRIPTION
## FIx:
- The video host changed their domain from megaup.cc to megaup.site, causing the presence to stop capturing video data. Updated iFrameRegExp to match the new domain.
## Small change:
- One asset change for case '/user/sync' in ```presence.ts```.

## Acknowledgements
- [✅] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [✅] I linted the code by running `npm run lint`
- [✅] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)