### PR TITLE
feat(Bun): add new domain

### DIFF
--- a/websites/B/Bun/metadata.json
+++ b/websites/B/Bun/metadata.json
@@ -9,8 +9,8 @@
   "description": {
     "en": "A fast all-in-one JavaScript runtime"
   },
-  "url": "bun.sh",
-  "version": "1.0.1",
+  "url": ["bun.sh", "bun.com"],
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/B/Bun/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/B/Bun/assets/thumbnail.png",
   "color": "#000000",


### PR DESCRIPTION
## Description

The Bun now has a new domain https://bun.com.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

No needed.
