### PR TITLE
fix(monkeytype): resolve undefined stats, correct test time, add loading state

### DIFF
--- a/websites/M/Monkeytype/metadata.json
+++ b/websites/M/Monkeytype/metadata.json
@@ -20,7 +20,7 @@
     "www.monkeytype.com",
     "monkeytype.com"
   ],
-  "version": "2.0.24",
+  "version": "2.0.25",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/M/Monkeytype/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Monkeytype/assets/thumbnail.png",
   "color": "#383200",

--- a/websites/M/Monkeytype/presence.ts
+++ b/websites/M/Monkeytype/presence.ts
@@ -100,7 +100,7 @@ presence.on('UpdateData', () => {
 
   if (isLoading) {
     presenceData.details = 'Loading…'
-    presenceData.state = undefined
+    delete presenceData.state
   }
 
   presence.setActivity(presenceData)

--- a/websites/M/Monkeytype/presence.ts
+++ b/websites/M/Monkeytype/presence.ts
@@ -8,6 +8,7 @@ presence.on('UpdateData', () => {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/M/Monkeytype/assets/logo.png',
   }
   presenceData.startTimestamp = time
+  let isLoading = false
   switch (document.location.pathname.toLowerCase()) {
     case '/': {
       presenceData.details = 'Idling'
@@ -27,13 +28,18 @@ presence.on('UpdateData', () => {
           raw: moreStatsElem?.querySelector('.raw .bottom')?.textContent,
           char: moreStatsElem?.querySelector('.key .bottom')?.textContent,
           con: moreStatsElem?.querySelector('.consistency .bottom')?.textContent,
-          time: moreStatsElem?.querySelector('.time .bottom')?.textContent,
+          time: moreStatsElem?.querySelector('.time .bottom .text')?.textContent,
         }
-        presenceData.details = `Finished ${document
-          .querySelector('.testType .bottom')
-          ?.textContent
-          ?.replaceAll('<br>', ' ')}`
-        presenceData.state = `${stats.wpm} wpm ${stats.acc} acc ${stats.raw} raw ${stats.char} ${stats.con} consistency ${stats.time}`
+        if (Object.values(stats).some(v => !v)) {
+          isLoading = true
+        }
+        else{
+          presenceData.details = `Finished ${document
+            .querySelector('.testType .bottom')
+            ?.textContent
+            ?.replaceAll('<br>', ' ')}`
+          presenceData.state = `${stats.wpm} wpm ${stats.acc} acc ${stats.raw} raw ${stats.char} ${stats.con} consistency ${stats.time}`
+        }
       }
       else if (
         document.querySelector('#words letter.correct')
@@ -43,10 +49,10 @@ presence.on('UpdateData', () => {
           document.querySelector('.pageTest #premidTestMode')?.textContent
         }`
         presenceData.state = `${
-          document.querySelector('.pageTest #largeLiveWpmAndAcc #liveWpm')
+          document.querySelector('.pageTest .speed')
             ?.textContent
         } wpm ${
-          document.querySelector('.pageTest #largeLiveWpmAndAcc #liveAcc')
+          document.querySelector('.pageTest .acc')
             ?.textContent
         } acc`
 
@@ -90,6 +96,11 @@ presence.on('UpdateData', () => {
       presenceData.details = 'Checking stats'
       break
     }
+  }
+
+  if (isLoading) {
+    presenceData.details = 'Loading…'
+    presenceData.state = undefined
   }
 
   presence.setActivity(presenceData)

--- a/websites/M/Monkeytype/presence.ts
+++ b/websites/M/Monkeytype/presence.ts
@@ -33,7 +33,7 @@ presence.on('UpdateData', () => {
         if (Object.values(stats).some(v => !v)) {
           isLoading = true
         }
-        else{
+        else {
           presenceData.details = `Finished ${document
             .querySelector('.testType .bottom')
             ?.textContent


### PR DESCRIPTION
## Description
This PR ensures live stats are displayed consistently and accurately.

- Fixed `undefined` values for WPM and accuracy in Monkeytype live stats
- Corrected timestamp to show only the time instead of time + session time to avoid duplicate values
- Added loading state to prevent stats from flashing as `undefined` on reload

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
Original:<br>
<img width="599" height="245" alt="original_livestats" src="https://github.com/user-attachments/assets/de277232-9edb-49ab-9c0f-a41282d1a5d7" />
<img width="595" height="237" alt="original_loading" src="https://github.com/user-attachments/assets/d3638140-ffc6-40af-bf1c-6d124da2c49b" />
<img width="598" height="214" alt="original_stats" src="https://github.com/user-attachments/assets/66dde075-1e11-4946-afc0-02885f271479" /><br>
Fixed:<br>
<img width="587" height="240" alt="fixed_live_stats" src="https://github.com/user-attachments/assets/a28721cd-97bb-4b43-b5bb-6e3b461d2b23" />
<img width="573" height="210" alt="fixed_loading" src="https://github.com/user-attachments/assets/39022763-0ffb-42c4-b9d8-60c5b086c673" />
<img width="586" height="212" alt="fixed_stats" src="https://github.com/user-attachments/assets/f44e6aba-65ef-4a84-b89b-e3259ccf0362" />




</details>
