### PR TITLE
feat(NOW TV): add presence

### DIFF
--- a/websites/N/NOW TV/metadata.json
+++ b/websites/N/NOW TV/metadata.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "212701689579438080",
+    "name": "bnwkr"
+  },
+  "service": "NOW TV",
+  "description": {
+    "en": "Stream the world's best entertainment, movies and sport, brought to you by Sky."
+  },
+  "url": [
+    "nowtv.com",
+    "www.nowtv.com"
+  ],
+  "version": "1.0.0",
+  "logo": "https://m.media-amazon.com/images/I/61sDr8btlTL.png",
+  "thumbnail": "https://m.media-amazon.com/images/I/61sDr8btlTL.png",
+  "color": "#000000",
+  "category": "videos",
+  "tags": [
+    "video",
+    "streaming"
+  ],
+    "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    }
+  ]
+}

--- a/websites/N/NOW TV/metadata.json
+++ b/websites/N/NOW TV/metadata.json
@@ -15,7 +15,7 @@
   ],
   "version": "1.0.0",
   "logo": "https://m.media-amazon.com/images/I/61sDr8btlTL.png",
-  "thumbnail": "https://m.media-amazon.com/images/I/61sDr8btlTL.png",
+  "thumbnail": "https://cdn.sdccdn.com/img/now-tv-savings-banner.jpeg",
   "color": "#000000",
   "category": "videos",
   "tags": [

--- a/websites/N/NOW TV/presence.ts
+++ b/websites/N/NOW TV/presence.ts
@@ -14,7 +14,7 @@ presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
-    type: ActivityType.Watching
+    type: ActivityType.Watching,
   }
   const { pathname: path } = document.location
   const privacyMode = await presence.getSetting<boolean>('privacy')

--- a/websites/N/NOW TV/presence.ts
+++ b/websites/N/NOW TV/presence.ts
@@ -1,0 +1,92 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1408037363665338519',
+})
+
+enum ActivityAssets {
+  Logo = 'https://m.media-amazon.com/images/I/61sDr8btlTL.png',
+}
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp
+  }
+  const { pathname: path } = document.location
+  const privacyMode = await presence.getSetting<boolean>('privacy')
+  const video = document.querySelector<HTMLVideoElement>('video')
+  const { href, pathname } = document.location
+  const search = document.querySelector<HTMLInputElement>('[data-testid="search-input"]')
+  if (privacyMode) {
+    presenceData.details = 'Watching NOW TV'
+  }
+  else if (search) {
+    presenceData.details = 'Searching for'
+    presenceData.state = search.value
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (video?.duration) {
+    const title = document.querySelector<HTMLMetaElement>(
+      '[class="item playback-metadata__container-title"]',
+    )
+    const episodeDetails = document.querySelector<HTMLMetaElement>(
+      '[class="item playback-metadata__container-episode-metadata-info"]',
+    )
+    const largePhoto = document.querySelector<HTMLMetaElement>(
+      '[class="aspect-ratio-image__img"]',
+    )
+
+    presenceData.details = title
+    presenceData.state = episodeDetails
+    presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play;
+    [presenceData.startTimestamp, presenceData.endTimestamp] = presence.getTimestampsfromMedia(video)
+
+    if (path.startsWith('/watch/playback/live/')) {
+      delete presenceData.startTimestamp
+      delete presenceData.endTimestamp
+      presenceData.smallImageKey = Assets.Live
+      presenceData.smallImageText = 'Live'
+      }
+
+    if (video.paused) {
+      delete presenceData.startTimestamp
+      delete presenceData.endTimestamp
+      presenceData.smallImageKey = Assets.Pause
+      presenceData.smallImageText = 'Paused'
+    }
+  }
+  else if (path.startsWith('/')) {
+        presenceData.details = 'Browsing NOW TV'
+      }
+  else if (path.startsWith('/watch/home')) {
+        presenceData.details = 'Browsing NOW TV'
+        presenceData.state = 'Home'
+      }
+  else if (path.startsWith('/watch/tv/highlights')) {
+        presenceData.details = 'Browsing Sky Entertainment'
+        presenceData.state = 'Looking at TV shows'
+        }
+  else if (path.startsWith('/watch/movies/highlights')) {
+        presenceData.details = 'Browsing Sky Cinema'
+        presenceData.state = 'Looking at movies'
+        }
+  else if (path.startsWith('/watch/sports/highlights')) {
+        presenceData.details = 'Browsing Sky Sports'
+        presenceData.state = 'Looking at sports'
+        }
+  else if (path.startsWith('/watch/hayu')) {
+        presenceData.details = 'Browsing Hayu'
+        presenceData.state = 'Looking at TV shows'
+        }
+  else if (path.startsWith('/watch/my-stuff')) {
+        presenceData.details = 'Browsing NOW TV'
+        presenceData.state = 'Looking at watchlist'
+        }
+
+  if (presenceData.details)
+    presence.setActivity(presenceData)
+  else presence.setActivity()
+  })

--- a/websites/N/NOW TV/presence.ts
+++ b/websites/N/NOW TV/presence.ts
@@ -24,68 +24,70 @@ presence.on('UpdateData', async () => {
   if (privacyMode) {
     presenceData.details = 'Watching NOW TV'
   }
-  if (path.startsWith('/watch/home')) {
+  else {
+    if (path.startsWith('/watch/home')) {
         presenceData.details = 'Browsing NOW TV'
         presenceData.state = 'Home'
       }
-  if (path.startsWith('/watch/tv/highlights')) {
+    if (path.startsWith('/watch/tv/highlights')) {
         presenceData.details = 'Browsing Sky Entertainment'
         presenceData.state = 'Looking at TV shows'
         }
-  if (path.startsWith('/watch/movies/highlights')) {
+    if (path.startsWith('/watch/movies/highlights')) {
         presenceData.details = 'Browsing Sky Cinema'
         presenceData.state = 'Looking at movies'
         }
-  if (path.startsWith('/watch/sports/highlights')) {
+    if (path.startsWith('/watch/sports/highlights')) {
         presenceData.details = 'Browsing Sky Sports'
         presenceData.state = 'Looking at sports'
         }
-  if (path.startsWith('/watch/hayu')) {
+    if (path.startsWith('/watch/hayu')) {
         presenceData.details = 'Browsing Hayu'
         presenceData.state = 'Looking at TV shows'
         }
-  if (path.startsWith('/watch/my-stuff')) {
+    if (path.startsWith('/watch/my-stuff')) {
         presenceData.details = 'Browsing NOW TV'
         presenceData.state = 'Looking at watchlist'
         }
-  else if (search) {
-    presenceData.details = 'Searching for'
-    presenceData.state = search.value
-    presenceData.smallImageKey = Assets.Search
-  }
-  else if (video?.duration) {
-    const title = document.querySelector<HTMLMetaElement>(
-      '[class="item playback-metadata__container-title"]',
-    )
-    const episodeDetails = document.querySelector<HTMLMetaElement>(
-      '[class="item playback-metadata__container-episode-metadata-info"]',
-    )
+    if (search) {
+      presenceData.details = 'Searching for'
+      presenceData.state = search.value
+      presenceData.smallImageKey = Assets.Search
+    }
+    if (video?.duration) {
+      const title = document.querySelector<HTMLMetaElement>(
+        '[class="item playback-metadata__container-title"]',
+      )
+      const episodeDetails = document.querySelector<HTMLMetaElement>(
+        '[class="item playback-metadata__container-episode-metadata-info"]',
+      )
 
-    presenceData.details = title
-    presenceData.state = episodeDetails
-    presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play;
-    [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
+      presenceData.details = title
+      presenceData.state = episodeDetails
+      presenceData.smallImageKey = video.paused ? Assets.Pause : Assets.Play;
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(video)
 
-    if (path.startsWith('/watch/playback/live/')) {
-      delete presenceData.startTimestamp
-      delete presenceData.endTimestamp
-      const liveTitle = document.querySelector<HTMLMetaElement>('[class="playback-now-next-item-title"]');
-      const liveChannel = document.querySelector<HTMLMetaElement>('[class="playback-now-next-item-main-wrapper main"]')?.getAttribute('data-testid');
-      presenceData.smallImageKey = Assets.Live
-      presenceData.smallImageText = 'Live'
-      presenceData.details = liveTitle
-      presenceData.state = `Watching live on ${liveChannel}`
+      if (path.startsWith('/watch/playback/live/')) {
+        delete presenceData.startTimestamp
+        delete presenceData.endTimestamp
+        const liveTitle = document.querySelector<HTMLMetaElement>('[class="playback-now-next-item-title"]');
+        const liveChannel = document.querySelector<HTMLMetaElement>('[class="playback-now-next-item-main-wrapper main"]')?.getAttribute('data-testid');
+        presenceData.smallImageKey = Assets.Live
+        presenceData.smallImageText = 'Live'
+        presenceData.details = liveTitle
+        presenceData.state = `Watching live on ${liveChannel}`
+        }
+
+      if (!episodeDetails) {
+        presenceData.state = "Watching a movie"
       }
 
-    if (!episodeDetails) {
-      presenceData.state = "Watching a movie"
-    }
-
-    if (video.paused) {
-      delete presenceData.startTimestamp
-      delete presenceData.endTimestamp
-      presenceData.smallImageKey = Assets.Pause
-      presenceData.smallImageText = 'Paused'
+      if (video.paused) {
+        delete presenceData.startTimestamp
+        delete presenceData.endTimestamp
+        presenceData.smallImageKey = Assets.Pause
+        presenceData.smallImageText = 'Paused'
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Added a new presence for NOW TV, the streaming service used to watch Sky Sports, Cinema, Entertainment and more in the United Kingdom.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="425" height="600" alt="image" src="https://github.com/user-attachments/assets/efb3960d-d56a-4f66-a350-d2a011e8c189" />
<img width="424" height="165" alt="image" src="https://github.com/user-attachments/assets/f5a512ef-3a2e-4e63-bcea-39fd03e3f6c2" />
<img width="424" height="169" alt="image" src="https://github.com/user-attachments/assets/0ea704e1-9187-4e73-9eb5-ca5163b56e05" />
<img width="417" height="168" alt="image" src="https://github.com/user-attachments/assets/dadf1c96-1166-4090-89cc-e8160e86992d" />
<img width="429" height="167" alt="image" src="https://github.com/user-attachments/assets/191ae25f-202c-4e2e-ba93-841067509500" />
<img width="422" height="167" alt="image" src="https://github.com/user-attachments/assets/67088104-9fd5-4344-80fe-940ab942e96b" />

Privacy mode:
<img width="401" height="90" alt="image" src="https://github.com/user-attachments/assets/6d033c80-c1dd-4dd7-9b63-d7f9931af7cb" />
<img width="427" height="164" alt="image" src="https://github.com/user-attachments/assets/b9bebbfd-f557-4a85-aeb9-82af2eb835fb" />



</details>
