### PR TITLE
feat(Dicoding): add activity

### DIFF
--- a/websites/D/Dicoding/metadata.json
+++ b/websites/D/Dicoding/metadata.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "762992235385716756",
+    "name": ".peii"
+  },
+  "service": "Dicoding",
+  "altnames": ["Dicoding Indonesia"],
+  "description": {
+    "en": "Learn to code with industry-level curriculum from Dicoding.",
+    "id": "Belajar ngoding dengan kurikulum standar industri dari Dicoding."
+  },
+  "url": ["dicoding.com", "www.dicoding.com"],
+  "regExp": "([a-z0-9-]+[.])*dicoding[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/L87Fab1.jpeg",
+  "thumbnail": "https://i.imgur.com/75Tde61l.png",
+  "color": "#2C7BE5",
+  "category": "other",
+  "tags": ["education", "programming", "courses", "events", "blog"]
+
+}

--- a/websites/D/Dicoding/presence.ts
+++ b/websites/D/Dicoding/presence.ts
@@ -14,7 +14,9 @@ function textFrom(sel: string): string | null {
 
 function meta(prop: string): string | null {
   return (
-    (document.querySelector(`meta[property="${prop}"]`) as HTMLMetaElement)?.content?.trim() || null
+    document.querySelector<HTMLMetaElement>(`meta[property="${prop}"]`)
+      ?.content
+      ?.trim() || null
   )
 }
 

--- a/websites/D/Dicoding/presence.ts
+++ b/websites/D/Dicoding/presence.ts
@@ -1,0 +1,125 @@
+import { Assets } from 'premid'
+
+const presence = new Presence({ clientId: '1409048810646405152' })
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/L87Fab1.jpeg',
+}
+
+function textFrom(sel: string): string | null {
+  const el = document.querySelector(sel)
+  return el?.textContent?.trim() || null
+}
+
+function meta(prop: string): string | null {
+  return (
+    (document.querySelector(`meta[property="${prop}"]`) as HTMLMetaElement)?.content?.trim() || null
+  )
+}
+
+function getHeadTitle(opts?: {
+  preferOG?: boolean
+  strip?: (string | RegExp)[]
+}): string | null {
+  const preferOG = opts?.preferOG ?? true
+  const strip
+    = opts?.strip ?? [/ - Dicoding( Indonesia)?$/i, / \| Dicoding( Indonesia)?$/i]
+
+  const og = meta('og:title')
+  const tw = (document.querySelector(
+    'meta[name=\'twitter:title\']',
+  ) as HTMLMetaElement)?.content?.trim()
+  const tag
+    = document.title?.trim()
+      || document.querySelector('head > title')?.textContent?.trim()
+      || ''
+
+  let t = preferOG ? og || tw || tag : tag || og || tw
+  if (!t)
+    return null
+
+  for (const s of strip) t = t.replace(s as any, '')
+  return t.trim() || null
+}
+
+presence.on('UpdateData', async () => {
+  const { host, pathname } = document.location
+  if (!host.endsWith('dicoding.com')) {
+    await presence.clearActivity()
+    return
+  }
+
+  const route = pathname.split('/')
+  const title = (getHeadTitle() || 'Untitled Page').slice(0, 128)
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  switch (route[1]) {
+    case '':
+      Object.assign(presenceData, {
+        details: 'Browsing home',
+      })
+      break
+
+    case 'courses':
+    case 'academies':
+      if (route[3] === 'corridor') {
+        presenceData.details = textFrom('h3') || 'Dicoding Corridor'
+        presenceData.state = 'Corridor'
+        presenceData.smallImageKey = Assets.Viewing
+      }
+      else if (route[3] === 'tutorials') {
+        presenceData.details = title
+        presenceData.smallImageKey = Assets.Reading
+      }
+      else if (route[2] === 'subscriptions') {
+        presenceData.details = 'Viewing my subscriptions'
+      }
+      else if (route[2] === 'my') {
+        presenceData.details = 'Viewing my courses'
+      }
+      else {
+        presenceData.details = `Browsing courses: ${title}`
+        presenceData.state = 'Courses catalog'
+      }
+      break
+
+    case 'blog':
+      presenceData.state = 'Dicoding Blog'
+      presenceData.details
+        = route[2] && route.length >= 3
+          ? `Reading article: ${title}`
+          : `Browsing blog: ${title}`
+      break
+
+    case 'events':
+      Object.assign(presenceData, {
+        details:
+          route[2] && route.length >= 3
+            ? `Viewing event: ${title}`
+            : `Browsing events: ${title}`,
+        state: route[2] ? 'Event page' : 'Events list',
+      })
+      break
+
+    case 'dashboard':
+      presenceData.details = 'Working in dashboard'
+      presenceData.state = 'My Account'
+      break
+
+    default:
+      presenceData.details = `Browsing${title === 'Dicoding Indonesia' ? '...' : `: ${title}`}`
+      break
+  }
+
+  if (presenceData.details) {
+    await presence.setActivity(presenceData)
+  }
+  else {
+    await presence.clearActivity()
+  }
+})


### PR DESCRIPTION
## Description
Add new Dicoding activity integration.
This activity displays the current course/module being viewed by the user.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="459" height="168" alt="image" src="https://github.com/user-attachments/assets/6c09df2a-8af5-4a78-affc-a647d2105c5f" />
<img width="452" height="159" alt="image" src="https://github.com/user-attachments/assets/d6e9180f-2c0d-4c59-a0af-a34d96ee140b" />
<img width="460" height="162" alt="image" src="https://github.com/user-attachments/assets/01f7a1e0-e091-462b-9373-8cd48eb6370f" />
<img width="451" height="157" alt="image" src="https://github.com/user-attachments/assets/bbc88e36-d829-44c0-a613-28337b3180ac" />

</details>
