### PR TITLE
feat(Sky Sports): add presence

### DIFF
--- a/websites/S/Sky Sports/metadata.json
+++ b/websites/S/Sky Sports/metadata.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "id": "212701689579438080",
+    "name": "bnwkr"
+  },
+  "service": "Sky Sports",
+  "description": {
+    "en": "Sky Sports offers extensive live sports coverage, news, and analysis for fans in the United Kingdom and Ireland."
+  },
+  "url": [
+    "skysports.com",
+    "www.skysports.com"
+  ],
+  "version": "1.0.0",
+  "logo": "https://i.postimg.cc/ydMN5xf2/d0db5f9e1b9ae913b14bdbcc648867fb.png",
+  "thumbnail": "https://e0.365dm.com/17/07/2048x1152/skysports-all-new-rebrand-f1-premier-league-golf-cricket_4001810.jpg",
+  "color": "#000000",
+  "category": "videos",
+  "tags": [
+    "video",
+    "news",
+    "streaming",
+    "sports"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "icon": "fad fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "showButtons",
+      "title": "Show buttons",
+      "icon": "fas fa-compress-arrows-alt",
+      "value": true
+    }
+  ]
+}

--- a/websites/S/Sky Sports/presence.ts
+++ b/websites/S/Sky Sports/presence.ts
@@ -1,0 +1,179 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1013092464212586586',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.postimg.cc/ydMN5xf2/d0db5f9e1b9ae913b14bdbcc648867fb.png',
+}
+
+presence.on('UpdateData', async () => {
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    type: ActivityType.Playing,
+  }
+  const setting = {
+    showButtons: await presence.getSetting<boolean>('showButtons'),
+    privacy: await presence.getSetting<boolean>('privacy'),
+  }
+  const urlpath = document.location.pathname.split('/')
+
+  if (!setting.privacy) {
+    presenceData.startTimestamp = browsingTimestamp
+  }
+
+  if (!urlpath[1]) {
+    presenceData.details = 'Home'
+  }
+  else {
+    if (
+      // News articles
+      urlpath[2] === 'news'
+      || urlpath[2] === 'live-blog'
+    ) {
+      presenceData.details = setting.privacy
+        ? 'Reading article'
+        : 'Reading article:'
+      if (!setting.privacy) {
+        const articleTitle = document.querySelector<HTMLMetaElement>(
+          '[class="sdc-article-header__long-title"]',
+        )
+        presenceData.state = articleTitle?.textContent ?? 'Latest'
+      }
+
+      if (setting.showButtons && !setting.privacy) {
+        presenceData.buttons = [
+          {
+            label: 'Read More',
+            url: document.location.href,
+          },
+        ]
+      }
+    }
+    if (
+      // Live channels
+      urlpath[1] === 'watch'
+      || urlpath[2] === 'watch'
+    ) {
+      presenceData.details = setting.privacy
+        ? 'Viewing live channel'
+        : 'Viewing live:'
+      if (!setting.privacy) {
+        const liveTitle = document.querySelector<HTMLMetaElement>(
+          '[class="watch-channel__title-text"]',
+        )
+        presenceData.state = liveTitle?.textContent ?? 'TV Guide'
+        presenceData.smallImageKey = Assets.Live
+        presenceData.smallImageText = 'Watching live'
+      }
+
+      if (setting.showButtons && !setting.privacy) {
+        presenceData.buttons = [
+          {
+            label: 'Watch Live',
+            url: document.location.href,
+          },
+        ]
+      }
+    }
+    if (urlpath[1] === 'f1') {
+      // F1 presences
+      presenceData.details = 'Reading F1 news'
+      if (urlpath[2] === 'standings') {
+        presenceData.details = 'Viewing F1 standings'
+      }
+      if (urlpath[2] === 'schedule-results') {
+        presenceData.details = 'Viewing F1 schedule & results'
+      }
+      if (urlpath[2] === 'drivers-teams') {
+        presenceData.details = 'Viewing F1 drivers & teams'
+      }
+      if (urlpath[2] === 'opinion') {
+        presenceData.details = 'Reading F1 opinions'
+      }
+      if (urlpath[2] === 'drivers') {
+        presenceData.details = setting.privacy
+          ? 'Viewing F1 drivers'
+          : 'Viewing F1 driver:'
+        if (!setting.privacy) {
+          presenceData.state = document.querySelector<HTMLMetaElement>(
+            '[class="swap-text__target"]',
+          )
+        }
+      }
+      if (urlpath[2] === 'teams') {
+        presenceData.details = setting.privacy
+          ? 'Viewing F1 teams'
+          : 'Viewing F1 team:'
+        if (!setting.privacy) {
+          presenceData.state = document.querySelector<HTMLMetaElement>(
+            '[class="swap-text__target"]',
+          )
+        }
+      }
+    }
+    if (
+      // Scores pages
+      urlpath[1] === 'football-scores-fixtures'
+      || urlpath[1] === 'live-scores'
+      || urlpath[2] === 'scores-fixtures'
+      || urlpath[2] === 'fixtures'
+      || urlpath[2] === 'results'
+    ) {
+      presenceData.details = 'Viewing results & fixtures'
+    }
+    if (urlpath[1] === 'football') {
+      // Football
+      if (urlpath[2] === 'tables') {
+        presenceData.details = 'Viewing football tables'
+      }
+      if (urlpath[2] === 'transfer-centre') {
+        presenceData.details = 'Viewing football transfers'
+      }
+      if (urlpath[2] === 'teams') {
+        presenceData.details = 'Viewing football teams'
+      }
+      if (urlpath[2] === 'competitions') {
+        presenceData.details = 'Viewing football leagues & cups'
+      }
+    }
+    else if (
+      // categories
+      urlpath[1] === 'football'
+      || urlpath[1] === 'cricket'
+      || urlpath[1] === 'golf'
+      || urlpath[1] === 'tennis'
+      || urlpath[1] === 'boxing'
+      || urlpath[1] === 'rugby-union'
+      || urlpath[1] === 'rugby-league'
+      || urlpath[1] === 'darts'
+      || urlpath[1] === 'racing'
+      || urlpath[1] === 'nfl'
+      || urlpath[1] === 'netball'
+      || urlpath[1] === 'mma'
+    ) {
+      presenceData.details = setting.privacy ? 'Reading news' : 'Reading news:'
+      if (!setting.privacy) {
+        const categoryTitle = document.querySelector<HTMLMetaElement>(
+          '[class="sdc-site-localnav__header-title"]',
+        )
+        presenceData.state = categoryTitle?.textContent ?? 'Latest'
+      }
+
+      if (setting.showButtons && !setting.privacy) {
+        presenceData.buttons = [
+          {
+            label: 'View More',
+            url: document.location.href,
+          },
+        ]
+      }
+    }
+  }
+
+  if (presenceData.details)
+    presence.setActivity(presenceData)
+  else presence.clearActivity()
+})


### PR DESCRIPTION
## Description
Added a new presence for Sky Sports, a sports news coverage and streaming website that allows users to watch Live TV through a dedicated player downloadable through the site. The presence has support for all news categories and previewing live channels.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="425" height="600" alt="image" src="https://github.com/user-attachments/assets/7e631286-8323-4cee-9fbd-29ac361ae440" />
<img width="418" height="249" alt="image" src="https://github.com/user-attachments/assets/5ac0a621-7511-427c-92c8-ff2bc14a4b0e" />
<img width="420" height="171" alt="image" src="https://github.com/user-attachments/assets/c4f655c6-cb15-4950-bf07-c2370aee6e6e" />
<img width="421" height="180" alt="image" src="https://github.com/user-attachments/assets/e9eedacb-8911-4fd1-a5c6-be3b7a97e30a" />
<img width="419" height="244" alt="image" src="https://github.com/user-attachments/assets/e2f38c8a-ce2a-4137-b27b-ad6abaf64ab9" />
<img width="418" height="249" alt="image" src="https://github.com/user-attachments/assets/590d4d91-9859-4322-86a0-7d713044d7d7" />
<img width="420" height="169" alt="image" src="https://github.com/user-attachments/assets/321e33e7-0b3a-404a-8e84-76dabcfa3baf" />

Privacy mode:
<img width="425" height="600" alt="image" src="https://github.com/user-attachments/assets/77de618f-d6c4-4d7d-9a71-a11cf138f16c" />
<img width="432" height="169" alt="image" src="https://github.com/user-attachments/assets/2e6091a2-e6a8-4579-8497-9ee713dfb0fe" />
<img width="425" height="164" alt="image" src="https://github.com/user-attachments/assets/d07ee620-002b-4a9b-8bb9-5709497709ce" />



</details>
