### PR TITLE
fix(premid): move StatusDisplayType to 'premid' module

### DIFF
--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -4,19 +4,6 @@ import type GeneralStrings from '../../websites/general.json'
 declare global {
 
   /**
-   * Status display types for Rich Presence
-   * @since 2.8.0
-   */
-  enum StatusDisplayType {
-    /** Display the activity name - e.g. "Listening to Spotify" */
-    Name = 0,
-    /** Display the state field - e.g. "Listening to Rick Astley" */
-    State = 1,
-    /** Display the details field - e.g. "Listening to Never Gonna Give You Up" */
-    Details = 2,
-  }
-
-  /**
    * Interface which holds keys usable for `Presence#getStrings` for type hints.
    *
    * Can be extended with code like this:
@@ -445,7 +432,7 @@ declare global {
    * Useful tools for developing presences
    * @link https://docs.premid.app/en/dev/presence/class
    */
-  declare class Presence {
+  class Presence {
     private clientId
     private injectOnComplete
     private internalPresence
@@ -701,11 +688,11 @@ declare global {
   /**
    * Minimum amount of time in ms between slide updates
    */
-  declare const MIN_SLIDE_TIME: number
+  const MIN_SLIDE_TIME: number
   /**
    * Represents a slideshow slide
    */
-  declare class SlideshowSlide {
+  class SlideshowSlide {
     id: string
     data: PresenceData
     private _interval
@@ -729,7 +716,7 @@ declare global {
    * Controller for alternating between multiple sets of
    * presence data at specific intervals
    */
-  declare class Slideshow {
+  class Slideshow {
     private index
     private slides
     currentSlide: PresenceData
@@ -781,7 +768,7 @@ declare global {
    * Is used to gather information from iFrames
    * @link https://docs.premid.app/en/dev/presence/iframe
    */
-  declare class iFrame {
+  class iFrame {
     _events: any
     /**
      * Send data from iFrames back to the presence script

--- a/premid/src/index.ts
+++ b/premid/src/index.ts
@@ -2,6 +2,19 @@ export * from './functions/getTimestamps.js'
 export * from './functions/getTimestampsFromMedia.js'
 export * from './functions/timestampFromFormat.js'
 
+/**
+ * Status display types for Rich Presence
+ * @since 2.8.0
+ */
+export enum StatusDisplayType {
+  /** Display the activity name - e.g. "Listening to Spotify" */
+  Name = 0,
+  /** Display the state field - e.g. "Listening to Rick Astley" */
+  State = 1,
+  /** Display the details field - e.g. "Listening to Never Gonna Give You Up" */
+  Details = 2,
+}
+
 export enum ActivityType {
   /**
    * Playing {name}


### PR DESCRIPTION
The extension does not seem to define this variable, it should be embedded in the presence code directly according to project maintainers

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Since the variable isn't defined in the extension, provide it as an export in the 'premid' module. This enables the type to be embedded directly in the compiled presence code

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

