### PR TITLE
feat(NeetCode): add activity 

### DIFF
--- a/websites/N/NeetCode/metadata.json
+++ b/websites/N/NeetCode/metadata.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.15",
+  "apiVersion": 1,
+  "author": {
+    "name": "m.liminal",
+    "id": "512996440486969345"
+  },
+  "contributors": [],
+  "service": "NeetCode",
+  "altnames": ["NeetCode.io", "Neet Code"],
+  "description": {
+    "en": "NeetCode is a platform for coding interview preparation with curated problems, video explanations, and roadmaps for software engineering interviews.",
+    "id": "NeetCode adalah platform persiapan wawancara coding dengan masalah yang dikurasi, penjelasan video, dan roadmap untuk wawancara software engineering.",
+    "ja": "NeetCodeは、厳選された問題、ビデオ解説、ソフトウェアエンジニアリング面接のためのロードマップを提供するコーディング面接準備プラットフォームです。",
+    "ko": "NeetCode는 엄선된 문제, 비디오 설명, 소프트웨어 엔지니어링 인터뷰를 위한 로드맵을 제공하는 코딩 인터뷰 준비 플랫폼입니다.",
+    "zh": "NeetCode是一个编程面试准备平台，提供精选题目、视频解析和软件工程面试路线图。"
+  },
+  "url": "neetcode.io",
+  "regExp": "([a-z0-9-]+[.])*neetcode[.]io[/]",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/NdI18uv.png",
+  "thumbnail": "https://i.imgur.com/mHvn6sX.png",
+  "color": "#10B981",
+  "category": "other",
+  "tags": [
+    "coding",
+    "programming",
+    "softwareengineering",
+    "computerscience",
+    "algorithms",
+    "datastructures",
+    "leetcode",
+    "codinginterview",
+    "interviewprep",
+    "dsa",
+    "competitiveprogramming",
+    "systemdesign",
+    "dynamicprogramming",
+    "codingchallenges",
+    "codingpractice",
+    "onlinejudge",
+    "technicalinterviews",
+    "codingproblems",
+    "problemsolving"
+  ],
+  "settings": [
+    {
+      "id": "showTimestamp",
+      "title": "Show Timestamp",
+      "icon": "fas fa-clock",
+      "value": true,
+      "description": "Show elapsed time since the activity started"
+    },
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "icon": "fas fa-external-link-alt",
+      "value": true,
+      "description": "Display buttons to visit the current page"
+    },
+    {
+      "id": "showProgress",
+      "title": "Show Course Progress",
+      "icon": "fas fa-chart-line",
+      "value": false,
+      "description": "Display progress information for courses and lessons"
+    }
+  ]
+}

--- a/websites/N/NeetCode/metadata.json
+++ b/websites/N/NeetCode/metadata.json
@@ -42,28 +42,5 @@
     "technicalinterviews",
     "codingproblems",
     "problemsolving"
-  ],
-  "settings": [
-    {
-      "id": "showTimestamp",
-      "title": "Show Timestamp",
-      "icon": "fas fa-clock",
-      "value": true,
-      "description": "Show elapsed time since the activity started"
-    },
-    {
-      "id": "showButtons",
-      "title": "Show Buttons",
-      "icon": "fas fa-external-link-alt",
-      "value": true,
-      "description": "Display buttons to visit the current page"
-    },
-    {
-      "id": "showProgress",
-      "title": "Show Course Progress",
-      "icon": "fas fa-chart-line",
-      "value": false,
-      "description": "Display progress information for courses and lessons"
-    }
   ]
 }

--- a/websites/N/NeetCode/presence.ts
+++ b/websites/N/NeetCode/presence.ts
@@ -5,7 +5,7 @@ const presence = new Presence({
 const browsingTimestamp: number = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
-  Logo = 'https://yt3.googleusercontent.com/9upX2EgqFhcGT3eeW-gPNHuAs5qMh66ULqXsCRHIHN7GkhPS_U3v78zXHbH7-fdrTWyQp90I=s900-c-k-c0x00ffffff-no-rj',
+  Logo = 'https://i.imgur.com/NdI18uv.png',
 }
 
 presence.on('UpdateData', async () => {

--- a/websites/N/NeetCode/presence.ts
+++ b/websites/N/NeetCode/presence.ts
@@ -1,0 +1,142 @@
+const presence = new Presence({
+  clientId: '1411956301537480746',
+})
+
+const browsingTimestamp: number = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://yt3.googleusercontent.com/9upX2EgqFhcGT3eeW-gPNHuAs5qMh66ULqXsCRHIHN7GkhPS_U3v78zXHbH7-fdrTWyQp90I=s900-c-k-c0x00ffffff-no-rj',
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname, search }: Location = document.location
+  const urlParams = new URLSearchParams(search)
+
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (pathname === '/' || pathname === '/home') {
+    presenceData.details = 'Browsing NeetCode'
+    presenceData.state = 'Homepage'
+  }
+  else if (pathname.includes('/courses/lessons/')) {
+    presenceData.details = 'Learning on NeetCode'
+
+    // Extract lesson name from URL
+    const lessonMatch: RegExpMatchArray | null = pathname.match(/\/courses\/lessons\/([^/]+)/)
+    if (lessonMatch?.[1]) {
+      const lessonName: string = lessonMatch[1]
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (letter: string) => letter.toUpperCase())
+      presenceData.state = `Lesson: ${lessonName}`
+    }
+    else {
+      presenceData.state = 'Watching Lesson'
+    }
+  }
+  else if (pathname.includes('/courses')) {
+    presenceData.details = 'Learning on NeetCode'
+
+    // Extract course name from URL
+    const courseMatch: RegExpMatchArray | null = pathname.match(/\/courses\/([^/]+)/)
+    if (courseMatch?.[1]) {
+      const courseName: string = courseMatch[1]
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (letter: string) => letter.toUpperCase())
+      presenceData.state = `Course: ${courseName}`
+    }
+    else {
+      presenceData.state = 'Exploring Courses'
+    }
+  }
+  else if (pathname.includes('/practice')) {
+    presenceData.details = 'Practicing on NeetCode'
+
+    const tab: string | null = urlParams.get('tab')
+    if (tab) {
+      switch (tab) {
+        case 'coreSkills':
+          presenceData.state = 'Core Skills'
+          break
+        case 'blind75':
+          presenceData.state = 'Blind 75'
+          break
+        case 'neetcode150':
+          presenceData.state = 'NeetCode 150'
+          break
+        case 'neetcode250':
+          presenceData.state = 'NeetCode 250'
+          break
+        case 'allNC':
+          presenceData.state = 'All Problems'
+          break
+        case 'systemDesign':
+          presenceData.state = 'System Design'
+          break
+        default:
+          presenceData.state = 'Practice Problems'
+      }
+    }
+    else {
+      presenceData.state = 'Practice Problems'
+    }
+  }
+  else if (pathname.includes('/problems/')) {
+    presenceData.details = 'Solving Problems'
+
+    // Extract problem name from URL
+    const problemMatch: RegExpMatchArray | null = pathname.match(/\/problems\/([^/]+)/)
+    if (problemMatch?.[1]) {
+      const problemName: string = problemMatch[1]
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (letter: string) => letter.toUpperCase())
+      presenceData.state = problemName
+
+      // Check if it's part of a specific list
+      const list: string | null = urlParams.get('list')
+      if (list) {
+        switch (list) {
+          case 'neetcode150':
+            presenceData.details = 'NeetCode 150'
+            break
+          case 'blind75':
+            presenceData.details = 'Blind 75'
+            break
+          case 'neetcode250':
+            presenceData.details = 'NeetCode 250'
+            break
+        }
+      }
+    }
+    else {
+      presenceData.state = 'Coding Challenge'
+    }
+  }
+  else if (pathname.includes('/quiz/')) {
+    presenceData.details = 'Taking Quiz'
+
+    // Extract quiz name from URL
+    const quizMatch: RegExpMatchArray | null = pathname.match(/\/quiz\/([^/]+)/)
+    if (quizMatch?.[1]) {
+      const quizName: string = quizMatch[1]
+        .replace(/-/g, ' ')
+        .replace(/\b\w/g, (letter: string) => letter.toUpperCase())
+      presenceData.state = `Quiz: ${quizName}`
+    }
+    else {
+      presenceData.state = 'Interactive Quiz'
+    }
+  }
+  else if (pathname.includes('/roadmap')) {
+    presenceData.details = 'Planning on NeetCode'
+    presenceData.state = 'Following the Roadmap'
+  }
+  else {
+    presenceData.details = 'Browsing NeetCode'
+    presenceData.state = 'Exploring'
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
Added Discord Rich Presence support for NeetCode.io, a coding interview preparation platform that helps developers prepare for technical interviews.

**Features implemented:**
- Homepage and general browsing detection
- Course viewing with dynamic course names extracted from URLs
- Individual lesson support with lesson titles
- Practice problems with category detection (Blind 75, NeetCode 150, NeetCode 250, Core Skills, System Design, etc.)
- Individual problem solving with problem names
- Quiz taking with quiz titles extracted from URLs
- Roadmap following detection
- Multi-language descriptions (English, Japanese, Korean, Indonesian, Chinese)
- Proper URL matching and content extraction for all major NeetCode sections

**Supported pages:**
- Homepage (`/`, `/home`)
- Courses (`/courses/*`) 
- Lessons (`/courses/lessons/*`)
- Practice (`/practice` with tab parameters)
- Problems (`/problems/*` with optional list parameters)
- Quizzes (`/quiz/*`)
- Roadmap (`/roadmap`)

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![NeetCode Homepage](https://github.com/user-attachments/assets/d210af67-9420-4cda-9075-be5cb4e2d091)

![Viewing a Course](https://github.com/user-attachments/assets/ac009829-e5bd-4c73-9f8d-693349955d6c)

![Solving a Problem](https://github.com/user-attachments/assets/2487b676-441f-4339-a083-2b8b71946c69)

</details>