### PR TITLE
feat(RTLplay): modernize, webradios & fixes

### DIFF
--- a/websites/R/RTLplay/RTLplay.json
+++ b/websites/R/RTLplay/RTLplay.json
@@ -1,0 +1,18 @@
+{
+  "RTLplay.watchingLiveMusic": {
+    "description": "Used when the user is watching a music channel that broadcasts music videos, often a radio station that livestreams at the same time.",
+    "message": "Watching a live music video"
+  },
+  "RTLplay.watchingAProgramOrSeries": {
+    "description": "Used when a user is watching media, which may be a TV series or a program.",
+    "message": "Watch a program or series"
+  },
+  "RTLplay.movie": {
+    "description": "Category of media",
+    "message": "Movie"
+  },
+  "RTLplay.tvshow": {
+    "description": "Category of media",
+    "message": "TV Serie"
+  }
+}

--- a/websites/R/RTLplay/metadata.json
+++ b/websites/R/RTLplay/metadata.json
@@ -26,7 +26,7 @@
     "www.radiocontact.be",
     "www.belrtl.be"
   ],
-  "version": "2.1.4",
+  "version": "2.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/R/RTLplay/assets/thumbnail.jpeg",
   "color": "#121726",


### PR DESCRIPTION
## Description
The majority of the core features are not impacted.

Soft modernize :
- the activity now uses the new timestamp functions
- now uses a translation file instead of the function getAdditionnalStrings
- some strings use translations from another presence I created to avoid duplication (RTBF Auvio)
- updated some media detection (radios)
- changed a bit of the structure to match more of what I've made on a more recent Activity I created (RTBF Auvio)

Fixes :
- the parsing of mediaName, episodeNumber, seasonNumber, and episodeName was no longer done correctly on the player page. I fixed it and added a fallback method (new special characters messed up the regex match)
- the RTLdistrict channel was no longer detected correctly on the live page (URL changed)

Small features added :
- added support for Radio Contact and Bel RTL themed web radio stations and also the Mint radio
- localized assets are now active (the extension sends English even if the extension language is set to French and the presence language is set to auto (french); if the presence language is forcibly set to French, it works).
- The Show Title as Presence setting during radio playback now displays the artist being listened to in a format similar to Spotify.

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->








|   |   |
|---|---|
| Localized Assets (Ad)  | <img width="275" height="104" alt="image" src="https://github.com/user-attachments/assets/8e04d277-0131-441b-ac2d-f0d7f67caa25" />  |
| Broken parsing  | <img width="274" height="105" alt="image" src="https://github.com/user-attachments/assets/36b0791e-f3bc-4531-b8ef-9564b02e0c57" />  |
| Fixed parsing  | <img width="277" height="110" alt="image" src="https://github.com/user-attachments/assets/81e0feea-f30b-4cdb-91ee-22d9dc0df96f" />  |
| New webradios + spotify format  | <img width="282" height="114" alt="image" src="https://github.com/user-attachments/assets/f36a35ef-5bd7-480c-b8b3-e1624968a062" />  |


</details>
