### PR TITLE
feat(Peacock): change activity type to watching

### DIFF
--- a/websites/P/Peacock/metadata.json
+++ b/websites/P/Peacock/metadata.json
@@ -14,7 +14,7 @@
     "www.peacocktv.com",
     "peacocktv.com"
   ],
-  "version": "1.0.23",
+  "version": "1.0.24",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/thumbnail.png",
   "color": "#FCCC12",

--- a/websites/P/Peacock/presence.ts
+++ b/websites/P/Peacock/presence.ts
@@ -1,4 +1,4 @@
-import { Assets } from 'premid'
+import { ActivityType, Assets } from 'premid'
 
 const presence = new Presence({
   clientId: '767402228825980929',
@@ -19,6 +19,7 @@ presence.on('UpdateData', async () => {
   const presenceData: PresenceData = {
     largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png',
     startTimestamp: elapsed,
+    type: ActivityType.Watching,
   }
 
   strings ??= await newStrings


### PR DESCRIPTION
## Description
Peacock showed Playing as its activity type before, I imported the activity th

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
