### PR TITLE
fix(mapple.tv): update support for additional domains

### DIFF
--- a/websites/M/Mapple.tv/metadata.json
+++ b/websites/M/Mapple.tv/metadata.json
@@ -9,7 +9,11 @@
   "description": {
     "en": "Shows what you're watching on mapple.tv"
   },
-  "url": "mapple.tv",
+  "url": [
+    "mapple.tv",
+    "mapple.mov",
+    "mapple.uk"
+  ],
   "version": "1.0.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/thumbnail.jpg",

--- a/websites/M/Mapple.tv/metadata.json
+++ b/websites/M/Mapple.tv/metadata.json
@@ -14,7 +14,7 @@
     "mapple.mov",
     "mapple.uk"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/M/Mapple.tv/assets/thumbnail.jpg",
   "color": "#000000",


### PR DESCRIPTION
- Updated `url` field to accept multiple domains (`mapple.tv`, `mapple.mov`, `mapple.uk`)
- Bumped version to 1.0.2

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)
