### PR TITLE
feat(Songsterr): add slideshow and button

### DIFF
--- a/websites/S/Songsterr/metadata.json
+++ b/websites/S/Songsterr/metadata.json
@@ -15,7 +15,7 @@
     "www.songsterr.com",
     "songsterr.com"
   ],
-  "version": "1.0.11",
+  "version": "1.0.12",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/S/Songsterr/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/S/Songsterr/assets/thumbnail.png",
   "color": "#138CF6",

--- a/websites/S/Songsterr/presence.ts
+++ b/websites/S/Songsterr/presence.ts
@@ -1,16 +1,28 @@
 const presence = new Presence({
   clientId: '1112463096368353300',
 })
+
+enum ActivityAssets {
+  Logo = 'https://cdn.rcd.gg/PreMiD/websites/S/Songsterr/assets/logo.png',
+}
+
 const browsingTimestamp = Math.floor(Date.now() / 1000)
+const slideshow = presence.createSlideshow()
 
 presence.on('UpdateData', async () => {
+  let useSlideshow: boolean = false
+
   const presenceData: PresenceData = {
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/S/Songsterr/assets/logo.png',
+    largeImageKey: ActivityAssets.Logo,
     startTimestamp: browsingTimestamp,
   }
+
+  // Information needed to determine what user is doing
   const { pathname } = document.location
   const { role } = document.querySelector('#apptab') ?? {}
-  const obj: { [key: string]: string } = {
+
+  // Details string to be used based on the current path name
+  const path_event: { [key: string]: string } = {
     plus: 'Viewing Plans',
     mytabs: 'Checking Submitted Tabs',
     submit: 'Submitting Tabs',
@@ -21,28 +33,52 @@ presence.on('UpdateData', async () => {
     payment: 'Buying Songsterr Plus',
   }
 
+  // Role happens to be complementery when Search, My Tabs, New Tab etc. windows are open. Else a tab is on the screen.
   if (role === 'complementary') {
-    if (pathname.split('/').at(-1)! in obj) {
-      presenceData.details = obj[pathname.split('/').at(-1)!]
+    if (pathname.split('/').at(-1)! in path_event) {
+      presenceData.details = path_event[pathname.split('/').at(-1)!]
+    }
+    else if (pathname === '/') {
+      const searchQuery = document.querySelector<HTMLInputElement>('#search-wrap > div > div > div > input')?.value
+      if (searchQuery?.length)
+        presenceData.details = `Searching tabs for ${searchQuery}`
+      else
+        presenceData.details = 'Searching tabs!'
     }
     else {
-      presenceData.details = `Searching tabs for ${
-        document.querySelector<HTMLInputElement>(
-          '#search-wrap > div > div > div > input',
-        )?.value
-      }`
+      presenceData.details = null
+      presenceData.state = null
     }
   }
   else {
-    presenceData.state = `Author: ${
-      document.querySelector('[aria-label="artist"]')?.textContent
-    }`
-    presenceData.details = `Title: ${
-      document.querySelector('[aria-label="title"]')?.textContent
-    }`
+    useSlideshow = true
+
+    const instrument = document.querySelector('button#control-mixer > div > div')?.innerHTML
+    // Appends tuning notes to each other (Couldn't find a way to directly get tuning names like E Standart, Drop D etc.)
+    let tuning = ''
+    document.querySelectorAll('#tablature > div > svg > text').forEach((obj) => {
+      tuning = tuning.concat(obj.innerHTML)
+    })
+
+    slideshow.addSlide('songInfo', {
+      largeImageKey: ActivityAssets.Logo,
+      startTimestamp: browsingTimestamp,
+      details: `Title: ${document.querySelector('[aria-label="title"]')?.textContent}`,
+      state: `Author: ${document.querySelector('[aria-label="artist"]')?.textContent}`,
+      buttons: [{ label: 'Play Yourself', url: document.location.href }],
+    }, 5000)
+
+    slideshow.addSlide('instrumentInfo', {
+      largeImageKey: ActivityAssets.Logo,
+      startTimestamp: browsingTimestamp,
+      details: `Instrument: ${instrument}`,
+      state: !instrument?.includes('Drums') ? `Tuning: ${tuning}` : null, // No tuning if instrument is Drums
+      buttons: [{ label: 'Play Yourself', url: document.location.href }],
+    }, 5000)
   }
 
-  if (presenceData.details)
+  if (useSlideshow)
+    presence.setActivity(slideshow)
+  else
     presence.setActivity(presenceData)
-  else presence.setActivity()
 })


### PR DESCRIPTION
## Description
Added tuning and instrument information to the presence. For this, started using slideshows. Added a button directing to the tab actively being played.

Also overall improvements like adding comments, improving variable names, displaying a better searching message if search query is empty.

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="355" height="595" alt="image" src="https://github.com/user-attachments/assets/d7a9b6f1-163e-4b27-9a7b-1ae66285967a" />

<img width="361" height="597" alt="image" src="https://github.com/user-attachments/assets/04fcfcd6-f2f8-4779-98d1-99f1b7761c32" />

</details>
