### PR TITLE
feat(Anime Online Ninja): add activity

### DIFF
--- a/websites/A/Anime Online Ninja/iframe.ts
+++ b/websites/A/Anime Online Ninja/iframe.ts
@@ -1,0 +1,14 @@
+const iframe = new iFrame()
+
+iframe.on('UpdateData', () => {
+  const video = document.querySelector<HTMLVideoElement>('video')
+  if (!video || Number.isNaN(video.duration))
+    return
+  iframe.send({
+    iFrameVideoData: {
+      currTime: video.currentTime,
+      dur: video.duration,
+      paused: video.paused || video.ended,
+    },
+  })
+})

--- a/websites/A/Anime Online Ninja/metadata.json
+++ b/websites/A/Anime Online Ninja/metadata.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.13",
+  "apiVersion": 1,
+  "author": {
+    "id": "432215088686956565",
+    "name": "_doritos."
+  },
+  "service": "Anime Online Ninja",
+  "description": {
+    "en": "The place to watch subtitled anime and movies in good quality across multiple servers.",
+    "es": "El lugar donde podrás ver anime y películas subtitulados en buena calidad y múltiples servidores."
+  },
+  "url": [
+    "animeonline.ninja",
+    "ww3.animeonline.ninja"
+  ],
+  "version": "1.0.0",
+  "logo": "https://imgur.com/cRlK7Td.png",
+  "thumbnail": "https://imgur.com/KW5WkTf.png",
+  "color": "#000000",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "stream",
+    "video"
+  ],
+  "iframe": true,
+  "iFrameRegExp": "(streamtape\\.com|mixdropjmk\\.pw|netuplayer\\.top|dood\\.ws|d-s\\.io|[a-z0-9]+\\.(com|net|org|ws|pw|top|io||to))"
+}

--- a/websites/A/Anime Online Ninja/presence.ts
+++ b/websites/A/Anime Online Ninja/presence.ts
@@ -1,0 +1,184 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  clientId: '1404246681536434266',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://imgur.com/cRlK7Td.png',
+  Gif = 'https://imgur.com/1VChgPE.gif',
+}
+
+let cacheEpisode: {
+  text: string
+  numberEpisode: string
+  seasonAnime: string
+  nameAnime: string
+  bannerImg: string
+  nameAnimeUrl: string | null | undefined
+  epDesc: string | undefined | null
+} = {
+  text: '',
+  numberEpisode: '1',
+  seasonAnime: '',
+  nameAnime: '',
+  bannerImg: ActivityAssets.Logo,
+  nameAnimeUrl: '',
+  epDesc: '',
+}
+
+async function getEpisode(text: string) {
+  if (text === cacheEpisode.text) {
+    return {
+      nameAnime: cacheEpisode.nameAnime,
+      numberEpisode: cacheEpisode.numberEpisode,
+      seasonAnime: cacheEpisode.seasonAnime,
+      bannerImg: cacheEpisode.bannerImg,
+      nameAnimeUrl: cacheEpisode.nameAnimeUrl,
+      epDesc: cacheEpisode.epDesc,
+    }
+  }
+
+  const normalize = (s: string) =>
+    s
+      .replace(/[\u00A0\u202F\u205F\u3000]|\u2000-\u200B/g, ' ')
+      .replace(/：/g, ':')
+      .replace(/[–—]/g, '-')
+      .replace(/[×✕✖]/g, 'x')
+      .replace(/\s+/g, ' ')
+      .trim()
+
+  const rawTitle = document.querySelector('#info > h1')?.textContent || document.querySelector('#single h1')?.textContent || 'Undefined'
+  const title = normalize(rawTitle)
+  const nameAnime
+    = title.split(/[:\-](?=\s*\d+\s*x\s*\d)/i)[0]?.trim() || ''
+
+  const sm = title.match(/[:\-]?\s*(\d+)\s*x\s*(\d+)/iu)
+  const seasonNumber = sm?.[1] ?? '1'
+  const episodeNumber = sm?.[2] ?? '1'
+  const seasonAnime = `Season ${seasonNumber}`
+  const numberEpisode = `Episode ${episodeNumber}`
+  const epDesc = ((p3 => (p3 && /temporada/i.test(p3.textContent || '')) ? p3.nextElementSibling?.textContent : p3?.textContent)(document.querySelector('#info > div > p:nth-child(3)')) || 'Viendo en Anime Online Ninja').trim().slice(0, 123)
+  const nameAnimeUrl = document
+    .querySelector('#single > div.content.right > div.pag_episodes > div:nth-child(2) > a')
+    ?.getAttribute('href') ?? undefined
+
+  const img = document.querySelector<HTMLImageElement>('#dt_galery img.lazy')
+  const raw = img?.dataset?.src ?? img?.getAttribute('src') ?? img?.src ?? ActivityAssets.Logo
+  const bannerImg = typeof raw === 'string' ? raw.trim().replace(/\r?\n/g, '') : ActivityAssets.Logo
+
+  cacheEpisode = {
+    text,
+    nameAnime,
+    seasonAnime,
+    numberEpisode,
+    bannerImg,
+    nameAnimeUrl,
+    epDesc,
+  }
+
+  return {
+    nameAnime,
+    seasonAnime,
+    numberEpisode,
+    bannerImg,
+    nameAnimeUrl,
+  }
+}
+
+let iframePlayback = false
+let currTime = 0
+let durTime = 0
+let isPaused = true
+
+presence.on('iFrameData', (data: any) => {
+  if (data.iFrameVideoData) {
+    iframePlayback = true
+    currTime = data.iFrameVideoData.currTime
+    durTime = data.iFrameVideoData.dur
+    isPaused = data.iFrameVideoData.paused
+  }
+})
+
+presence.on('UpdateData', async () => {
+  const { pathname } = document.location
+  const presenceData: PresenceData = {
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: browsingTimestamp,
+    smallImageKey: Assets.Play,
+    type: ActivityType.Watching,
+  }
+
+  if (/^\/pelicula\/[^/]+\/?$/.test(pathname) || pathname.includes('/episodio/')) {
+    const player = document.querySelector('#dooplay_player_response')
+    if (player) {
+      const dataAnime = document.querySelector('#info > h1')?.textContent || document.querySelector('#single h1')?.textContent
+      if (dataAnime) {
+        const animeData = await getEpisode(dataAnime)
+        if (animeData) {
+          presenceData.name = animeData.nameAnime
+          presenceData.details = animeData.nameAnime
+          presenceData.state = animeData.epDesc
+          presenceData.largeImageKey = animeData.bannerImg
+          presenceData.largeImageText = `${animeData.seasonAnime.toString()}, ${animeData.numberEpisode.toString()}`
+
+          if (iframePlayback) {
+            presenceData.smallImageKey = isPaused ? Assets.Pause : Assets.Play
+            presenceData.smallImageText = isPaused ? 'Pausado' : 'Reproduciendo'
+          }
+
+          if (!isPaused) {
+            const [startTs, endTs] = getTimestamps(
+              Math.floor(currTime),
+              Math.floor(durTime),
+            )
+            presenceData.startTimestamp = startTs
+            presenceData.endTimestamp = endTs
+          }
+          else {
+            delete presenceData.startTimestamp
+            delete presenceData.endTimestamp
+          }
+        }
+      }
+    }
+  }
+  else if (pathname.includes('/genero/')) {
+    presenceData.details = 'Navegando'
+    presenceData.state = 'Viendo: Categorias'
+    presenceData.largeImageKey = ActivityAssets.Gif
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (/^\/pelicula\/?$/.test(pathname)) {
+    presenceData.details = 'Navegando'
+    presenceData.state = 'Viendo: Peliculas'
+    presenceData.largeImageKey = ActivityAssets.Gif
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (pathname.includes('/ratings/')) {
+    presenceData.details = 'Navegando'
+    presenceData.state = 'Viendo: Los Mas Valorados'
+    presenceData.largeImageKey = ActivityAssets.Gif
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (pathname.includes('/tendencias/')) {
+    presenceData.details = 'Navegando'
+    presenceData.state = 'Viendo: Ultimas Tendencias'
+    presenceData.largeImageKey = ActivityAssets.Gif
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (pathname.includes('/online/')) {
+    presenceData.details = 'Navegando'
+    presenceData.state = `Viendo: ${document.querySelector('#single h1')?.textContent}` || 'Un Anime'
+    presenceData.largeImageKey = ActivityAssets.Gif
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (pathname.includes('/')) {
+    presenceData.details = 'Navegando'
+    presenceData.state = 'Viendo la Pagina Principal'
+    presenceData.largeImageKey = ActivityAssets.Gif
+    presenceData.smallImageKey = Assets.Reading
+  }
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Add support for Anime Online Ninja site

This update adds support for the Anime Online Ninja site. It includes caching to prevent duplicate entries, timestamps to indicate video time, and support for the different sections of the site.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
