### PR TITLE
docs(readme): update documentation link to avoid 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Want to create your own Activity or modify an existing one? Great! Follow these 
 
 2. **Learn the basics**
 
-   - Read our [documentation](https://docs.premid.app/dev/presence) to understand how Activities work
+   - Read our [documentation](https://docs.premid.app/) to understand how Activities work
    - Browse through existing Activities to see examples and best practices
 
 3. **Start creating/editing**


### PR DESCRIPTION
The previous link pointed to /dev/presence which returned 404. Now it points to the main documentation page.

## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
