### PR TITLE
feat: Watch Party sync script system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 !*.config.*js
 websites/**/dist
 websites/**/tsconfig.json
+syncScripts/**/dist
+syncScripts/**/tsconfig.json
 node_modules
 
 # MacOS-generated files

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -799,4 +799,144 @@ declare global {
     UpdateData: []
   }
 
+  // Sync Script types
+
+  interface SyncScriptPlaybackReport {
+    playing: boolean
+    currentTime: number
+    duration: number
+    playbackRate?: number
+  }
+
+  interface SyncScriptSyncCommand {
+    action: 'play' | 'pause' | 'seek' | 'rate'
+    currentTime?: number
+    playbackRate?: number
+    capturedAt?: number
+  }
+
+  interface SyncScriptPageInfo {
+    title?: string
+    subtitle?: string
+    thumbnail?: string
+  }
+
+  interface SyncScriptTakeControlOptions {
+    onPlay: (timeSeconds: number) => void
+    onPause: (timeSeconds: number) => void
+    onSeek: (timeSeconds: number) => void
+    onRate?: (playbackRate: number) => void
+    driftThreshold?: number
+    pauseAfterSeek?: boolean | number
+  }
+
+  interface AutoVideoHandle {
+    detach(): void
+    onSyncCommand(handler: (cmd: SyncScriptSyncCommand) => void): () => void
+    reportAd(isInAd: boolean): void
+    reportBuffering(isBuffering: boolean): void
+  }
+
+  interface ManualVideoHandle {
+    reportPlayback(status: SyncScriptPlaybackReport): void
+    onSyncCommand(handler: (cmd: SyncScriptSyncCommand) => void): () => void
+    reportAd(isInAd: boolean): void
+    reportBuffering(isBuffering: boolean): void
+    release(): void
+  }
+
+  interface SyncScriptVideoAPI {
+    attach(element: HTMLMediaElement | string): AutoVideoHandle
+    takeControl(options: SyncScriptTakeControlOptions): ManualVideoHandle
+    reportAd(isInAd: boolean): void
+    reportBuffering(isBuffering: boolean): void
+  }
+
+  interface MessagingNamespace {
+    send(key: string, data: unknown): void
+    request(key: string, data: unknown): Promise<unknown>
+    onMessage(key: string, handler: (data: unknown) => void): () => void
+    onRequest(key: string, handler: (data: unknown) => unknown | Promise<unknown>): () => void
+  }
+
+  interface IframeMessaging {
+    send(frameId: number, key: string, data: unknown): void
+    request(frameId: number, key: string, data: unknown): Promise<unknown>
+    onMessage(key: string, handler: (data: unknown, frameId: number) => void): () => void
+    onRequest(key: string, handler: (data: unknown, frameId: number) => unknown | Promise<unknown>): () => void
+  }
+
+  interface PartyState {
+    readonly role: 'controller' | 'follower'
+    readonly paused: boolean
+    readonly active: boolean
+    readonly isHost: boolean
+    onRoleChange(handler: (role: 'controller' | 'follower') => void): () => void
+    onPauseChange(handler: (paused: boolean) => void): () => void
+    onActiveChange(handler: (active: boolean) => void): () => void
+  }
+
+  interface SyncScriptContext {
+    features(features: { video?: boolean, cursor?: boolean, scroll?: boolean }): void
+
+    video: SyncScriptVideoAPI
+
+    setPageInfo(info: SyncScriptPageInfo): void
+
+    sendCustomData(key: string, data: unknown): void
+    onCustomData(key: string, handler: (data: unknown) => void): () => void
+
+    iframe: IframeMessaging
+    mainworld: MessagingNamespace
+
+    party: PartyState
+  }
+
+  interface SyncScriptDefinition {
+    setup(ctx: SyncScriptContext): (() => void) | void
+    onNavigate?(ctx: SyncScriptContext, url: string): void
+  }
+
+  interface SyncScriptHandle {
+    destroy(): void
+  }
+
+  interface SyncIframeVideoAPI {
+    attach(element: HTMLMediaElement | string): AutoVideoHandle
+    onSyncCommand(handler: (cmd: SyncScriptSyncCommand) => void): () => void
+  }
+
+  interface SyncIframeContext {
+    video: SyncIframeVideoAPI
+
+    sendCustomData(key: string, data: unknown): void
+    onCustomData(key: string, handler: (data: unknown) => void): () => void
+
+    content: MessagingNamespace
+  }
+
+  interface SyncIframeScriptDefinition {
+    setup(ctx: SyncIframeContext): (() => void) | void
+  }
+
+  interface SyncMainworldContext {
+    content: MessagingNamespace
+  }
+
+  interface SyncMainworldScriptDefinition {
+    setup(ctx: SyncMainworldContext): (() => void) | void
+  }
+
+  const SyncScript: {
+    register(definition: SyncScriptDefinition): SyncScriptHandle
+  }
+
+  const SyncIframeScript: {
+    register(definition: SyncIframeScriptDefinition): SyncScriptHandle
+  }
+
+  const SyncMainworldScript: {
+    register(definition: SyncMainworldScriptDefinition): SyncScriptHandle
+  }
+
 }

--- a/@types/premid/index.d.ts
+++ b/@types/premid/index.d.ts
@@ -831,39 +831,39 @@ declare global {
   }
 
   interface AutoVideoHandle {
-    detach(): void
-    onSyncCommand(handler: (cmd: SyncScriptSyncCommand) => void): () => void
-    reportAd(isInAd: boolean): void
-    reportBuffering(isBuffering: boolean): void
+    detach: () => void
+    onSyncCommand: (handler: (cmd: SyncScriptSyncCommand) => void) => () => void
+    reportAd: (isInAd: boolean) => void
+    reportBuffering: (isBuffering: boolean) => void
   }
 
   interface ManualVideoHandle {
-    reportPlayback(status: SyncScriptPlaybackReport): void
-    onSyncCommand(handler: (cmd: SyncScriptSyncCommand) => void): () => void
-    reportAd(isInAd: boolean): void
-    reportBuffering(isBuffering: boolean): void
-    release(): void
+    reportPlayback: (status: SyncScriptPlaybackReport) => void
+    onSyncCommand: (handler: (cmd: SyncScriptSyncCommand) => void) => () => void
+    reportAd: (isInAd: boolean) => void
+    reportBuffering: (isBuffering: boolean) => void
+    release: () => void
   }
 
   interface SyncScriptVideoAPI {
-    attach(element: HTMLMediaElement | string): AutoVideoHandle
-    takeControl(options: SyncScriptTakeControlOptions): ManualVideoHandle
-    reportAd(isInAd: boolean): void
-    reportBuffering(isBuffering: boolean): void
+    attach: (element: HTMLMediaElement | string) => AutoVideoHandle
+    takeControl: (options: SyncScriptTakeControlOptions) => ManualVideoHandle
+    reportAd: (isInAd: boolean) => void
+    reportBuffering: (isBuffering: boolean) => void
   }
 
   interface MessagingNamespace {
-    send(key: string, data: unknown): void
-    request(key: string, data: unknown): Promise<unknown>
-    onMessage(key: string, handler: (data: unknown) => void): () => void
-    onRequest(key: string, handler: (data: unknown) => unknown | Promise<unknown>): () => void
+    send: (key: string, data: unknown) => void
+    request: (key: string, data: unknown) => Promise<unknown>
+    onMessage: (key: string, handler: (data: unknown) => void) => () => void
+    onRequest: (key: string, handler: (data: unknown) => unknown | Promise<unknown>) => () => void
   }
 
   interface IframeMessaging {
-    send(frameId: number, key: string, data: unknown): void
-    request(frameId: number, key: string, data: unknown): Promise<unknown>
-    onMessage(key: string, handler: (data: unknown, frameId: number) => void): () => void
-    onRequest(key: string, handler: (data: unknown, frameId: number) => unknown | Promise<unknown>): () => void
+    send: (frameId: number, key: string, data: unknown) => void
+    request: (frameId: number, key: string, data: unknown) => Promise<unknown>
+    onMessage: (key: string, handler: (data: unknown, frameId: number) => void) => () => void
+    onRequest: (key: string, handler: (data: unknown, frameId: number) => unknown | Promise<unknown>) => () => void
   }
 
   interface PartyState {
@@ -871,20 +871,20 @@ declare global {
     readonly paused: boolean
     readonly active: boolean
     readonly isHost: boolean
-    onRoleChange(handler: (role: 'controller' | 'follower') => void): () => void
-    onPauseChange(handler: (paused: boolean) => void): () => void
-    onActiveChange(handler: (active: boolean) => void): () => void
+    onRoleChange: (handler: (role: 'controller' | 'follower') => void) => () => void
+    onPauseChange: (handler: (paused: boolean) => void) => () => void
+    onActiveChange: (handler: (active: boolean) => void) => () => void
   }
 
   interface SyncScriptContext {
-    features(features: { video?: boolean, cursor?: boolean, scroll?: boolean }): void
+    features: (features: { video?: boolean, cursor?: boolean, scroll?: boolean }) => void
 
     video: SyncScriptVideoAPI
 
-    setPageInfo(info: SyncScriptPageInfo): void
+    setPageInfo: (info: SyncScriptPageInfo) => void
 
-    sendCustomData(key: string, data: unknown): void
-    onCustomData(key: string, handler: (data: unknown) => void): () => void
+    sendCustomData: (key: string, data: unknown) => void
+    onCustomData: (key: string, handler: (data: unknown) => void) => () => void
 
     iframe: IframeMessaging
     mainworld: MessagingNamespace
@@ -893,30 +893,30 @@ declare global {
   }
 
   interface SyncScriptDefinition {
-    setup(ctx: SyncScriptContext): (() => void) | void
-    onNavigate?(ctx: SyncScriptContext, url: string): void
+    setup: (ctx: SyncScriptContext) => (() => void) | void
+    onNavigate?: (ctx: SyncScriptContext, url: string) => void
   }
 
   interface SyncScriptHandle {
-    destroy(): void
+    destroy: () => void
   }
 
   interface SyncIframeVideoAPI {
-    attach(element: HTMLMediaElement | string): AutoVideoHandle
-    onSyncCommand(handler: (cmd: SyncScriptSyncCommand) => void): () => void
+    attach: (element: HTMLMediaElement | string) => AutoVideoHandle
+    onSyncCommand: (handler: (cmd: SyncScriptSyncCommand) => void) => () => void
   }
 
   interface SyncIframeContext {
     video: SyncIframeVideoAPI
 
-    sendCustomData(key: string, data: unknown): void
-    onCustomData(key: string, handler: (data: unknown) => void): () => void
+    sendCustomData: (key: string, data: unknown) => void
+    onCustomData: (key: string, handler: (data: unknown) => void) => () => void
 
     content: MessagingNamespace
   }
 
   interface SyncIframeScriptDefinition {
-    setup(ctx: SyncIframeContext): (() => void) | void
+    setup: (ctx: SyncIframeContext) => (() => void) | void
   }
 
   interface SyncMainworldContext {
@@ -924,19 +924,19 @@ declare global {
   }
 
   interface SyncMainworldScriptDefinition {
-    setup(ctx: SyncMainworldContext): (() => void) | void
+    setup: (ctx: SyncMainworldContext) => (() => void) | void
   }
 
   const SyncScript: {
-    register(definition: SyncScriptDefinition): SyncScriptHandle
+    register: (definition: SyncScriptDefinition) => SyncScriptHandle
   }
 
   const SyncIframeScript: {
-    register(definition: SyncIframeScriptDefinition): SyncScriptHandle
+    register: (definition: SyncIframeScriptDefinition) => SyncScriptHandle
   }
 
   const SyncMainworldScript: {
-    register(definition: SyncMainworldScriptDefinition): SyncScriptHandle
+    register: (definition: SyncMainworldScriptDefinition) => SyncScriptHandle
   }
 
 }

--- a/cli/src/classes/ActivityCompiler.ts
+++ b/cli/src/classes/ActivityCompiler.ts
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs'
-import { cp, readdir, readFile, rm } from 'node:fs/promises'
-import { basename, dirname, join, resolve } from 'node:path'
-import AdmZip from 'adm-zip'
+import { cp, readFile, rm } from 'node:fs/promises'
+import { basename, dirname, resolve } from 'node:path'
 import chalk from 'chalk'
 import { watch } from 'chokidar'
 import { build } from 'esbuild'
@@ -18,6 +17,7 @@ import { getJsonPosition } from '../util/getJsonPosition.js'
 import { error, exit, prefix } from '../util/log.js'
 import { sanitazeFolderName } from '../util/sanitazeFolderName.js'
 import { addSarifLog, SarifRuleId, writeSarifLog } from '../util/sarif.js'
+import { zipDir } from '../util/zipDir.js'
 import { AssetsManager } from './AssetsManager.js'
 import { DependenciesManager } from './DependenciesManager.js'
 import { TypescriptCompiler } from './TypescriptCompiler.js'
@@ -449,19 +449,4 @@ export class ActivityCompiler {
 
     return valid
   }
-}
-
-async function zipDir(dir: string, filename: string) {
-  const zip = new AdmZip()
-  const zipPathInDir = resolve(dir, filename)
-
-  //* Read all files in the directory and add them to the zip
-  const files = await readdir(dir, { recursive: true })
-
-  for (const file of files) {
-    const filePath = join(dir, file)
-    zip.addLocalFile(filePath)
-  }
-
-  zip.writeZip(zipPathInDir)
 }

--- a/cli/src/classes/SyncScriptCompiler.ts
+++ b/cli/src/classes/SyncScriptCompiler.ts
@@ -1,0 +1,214 @@
+import { existsSync } from 'node:fs'
+import { cp, rm } from 'node:fs/promises'
+import { basename, dirname, resolve } from 'node:path'
+import chalk from 'chalk'
+import { watch } from 'chokidar'
+import { build } from 'esbuild'
+import ora from 'ora'
+import ts from 'typescript'
+import { error, exit, info, prefix } from '../util/log.js'
+import { WebSocketServer } from './WebSocketServer.js'
+
+export interface SyncScriptMetadata {
+  service: string
+  regExp: string
+  iframeRegExp?: string
+}
+
+export class SyncScriptCompiler {
+  ws: WebSocketServer | undefined
+
+  constructor(
+    public readonly cwd: string,
+    public readonly metadata: SyncScriptMetadata,
+  ) {}
+
+  async compile({ kill }: { kill: boolean }): Promise<boolean> {
+    const success = await this.typecheck(kill)
+    if (!success)
+      return false
+
+    const spinner = ora(prefix + chalk.greenBright(` Compiling ${this.metadata.service}...`))
+    spinner.start()
+
+    const hasIframe = existsSync(resolve(this.cwd, 'iframe.ts'))
+    const hasMainworld = existsSync(resolve(this.cwd, 'mainworld.ts'))
+
+    if (existsSync(resolve(this.cwd, 'dist')))
+      await rm(resolve(this.cwd, 'dist'), { recursive: true })
+
+    await build({
+      entryPoints: [
+        resolve(this.cwd, 'content.ts'),
+        ...(hasIframe ? [resolve(this.cwd, 'iframe.ts')] : []),
+        ...(hasMainworld ? [resolve(this.cwd, 'mainworld.ts')] : []),
+      ],
+      outdir: resolve(this.cwd, 'dist'),
+      bundle: true,
+      minify: true,
+      sourcemap: 'inline',
+      tsconfig: resolve(this.cwd, 'tsconfig.json'),
+    })
+
+    await cp(resolve(this.cwd, 'metadata.json'), resolve(this.cwd, 'dist', 'metadata.json'))
+
+    spinner.succeed(prefix + chalk.greenBright(` Compiled ${this.metadata.service}!`))
+    return true
+  }
+
+  async watch() {
+    this.ws = new WebSocketServer(this.cwd, 'localSyncScript')
+
+    watch(this.cwd, {
+      depth: 0,
+      ignoreInitial: true,
+      ignored: ['**/dist/**'],
+      persistent: true,
+    }).on('all', async (event, path) => {
+      if (['add', 'unlink'].includes(event) && (basename(path) === 'iframe.ts' || basename(path) === 'mainworld.ts')) {
+        return this.restartTsWatch()
+      }
+
+      if (event === 'change' && basename(path) === 'metadata.json') {
+        return this.compileAndSend()
+      }
+    })
+
+    this.startTsWatch()
+  }
+
+  private program: ts.WatchOfFilesAndCompilerOptions<ts.SemanticDiagnosticsBuilderProgram> | undefined
+
+  private startTsWatch() {
+    const hasIframe = existsSync(resolve(this.cwd, 'iframe.ts'))
+    const hasMainworld = existsSync(resolve(this.cwd, 'mainworld.ts'))
+    const tsconfigPath = resolve(this.cwd, 'tsconfig.json')
+
+    const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
+    if (configFile.error) {
+      error('Failed to read tsconfig.json:')
+      exit(ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'))
+    }
+
+    const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, this.cwd)
+    if (parsedConfig.errors.length) {
+      error('Failed to parse tsconfig.json:')
+      parsedConfig.errors.forEach((diagnostic) => {
+        error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+      })
+      process.exit(1)
+    }
+
+    const host = ts.createWatchCompilerHost(
+      [resolve(this.cwd, 'content.ts'), ...(hasIframe ? [resolve(this.cwd, 'iframe.ts')] : []), ...(hasMainworld ? [resolve(this.cwd, 'mainworld.ts')] : [])],
+      {
+        ...parsedConfig.options,
+        noEmit: true,
+      },
+      ts.sys,
+      ts.createSemanticDiagnosticsBuilderProgram,
+      (diagnostic) => {
+        if (!diagnostic.file) {
+          return error(ts.formatDiagnostic(diagnostic, {
+            getCanonicalFileName: fileName => fileName,
+            getCurrentDirectory: () => this.cwd,
+            getNewLine: () => '\n',
+          }))
+        }
+        error(chalk.white(`${chalk.cyan(
+          `${basename(dirname(diagnostic.file.fileName))}/${basename(diagnostic.file.fileName)}`,
+        )}`
+        + `:${
+          chalk.yellowBright(diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!).line + 1)
+        }:${
+          chalk.yellowBright(diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!).character + 1)
+        } - ${
+          chalk.redBright('Error ')
+        }${chalk.gray(`TS${diagnostic.code}:`)
+        } ${
+          ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')}`))
+      },
+      (diagnostic) => {
+        info(diagnostic.messageText as string)
+
+        if (diagnostic.code === 6194 && (diagnostic.messageText as string).startsWith('Found 0 errors.')) {
+          this.compileAndSend()
+        }
+      },
+    )
+
+    this.program = ts.createWatchProgram(host)
+  }
+
+  private stopTsWatch() {
+    this.program?.updateRootFileNames([])
+    this.program?.close()
+    this.program = undefined
+  }
+
+  private restartTsWatch() {
+    this.stopTsWatch()
+    this.startTsWatch()
+  }
+
+  private async compileAndSend() {
+    await this.compile({ kill: false })
+    await this.ws?.send()
+  }
+
+  private async typecheck(killOnError: boolean): Promise<boolean> {
+    const spinner = ora(
+      prefix + chalk.yellow(` Type checking ${this.metadata.service}...`),
+    ).start()
+
+    const hasIframe = existsSync(resolve(this.cwd, 'iframe.ts'))
+    const hasMainworld = existsSync(resolve(this.cwd, 'mainworld.ts'))
+    const tsconfigPath = resolve(this.cwd, 'tsconfig.json')
+
+    const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
+    if (configFile.error) {
+      spinner.fail(prefix + chalk.red(' Failed to read tsconfig.json:'))
+      exit(ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'))
+    }
+
+    const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, this.cwd)
+    if (parsedConfig.errors.length) {
+      spinner.fail(prefix + chalk.red(' Failed to parse tsconfig.json:'))
+      parsedConfig.errors.forEach((diagnostic) => {
+        error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+      })
+      if (killOnError)
+        process.exit(1)
+      return false
+    }
+
+    const program = ts.createProgram({
+      rootNames: [resolve(this.cwd, 'content.ts'), ...(hasIframe ? [resolve(this.cwd, 'iframe.ts')] : []), ...(hasMainworld ? [resolve(this.cwd, 'mainworld.ts')] : [])],
+      options: { ...parsedConfig.options, noEmit: true },
+    })
+
+    const allDiagnostics = ts
+      .getPreEmitDiagnostics(program)
+      .concat(program.emit().diagnostics)
+
+    if (allDiagnostics.length > 0) {
+      spinner.fail(prefix + chalk.red(' Type checking failed:'))
+      allDiagnostics.forEach((diagnostic) => {
+        if (diagnostic.file) {
+          const { line, character } = ts.getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start!)
+          const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+          error(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`)
+        }
+        else {
+          error(ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+        }
+      })
+      if (killOnError)
+        process.exit(1)
+      return false
+    }
+
+    spinner.succeed(prefix + chalk.greenBright(` Type checking ${this.metadata.service} passed!`))
+    return true
+  }
+}

--- a/cli/src/classes/SyncScriptCompiler.ts
+++ b/cli/src/classes/SyncScriptCompiler.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { cp, rm } from 'node:fs/promises'
 import { basename, dirname, resolve } from 'node:path'
+import process from 'node:process'
 import chalk from 'chalk'
 import { watch } from 'chokidar'
 import { build } from 'esbuild'

--- a/cli/src/classes/SyncScriptCompiler.ts
+++ b/cli/src/classes/SyncScriptCompiler.ts
@@ -8,6 +8,7 @@ import { build } from 'esbuild'
 import ora from 'ora'
 import ts from 'typescript'
 import { error, exit, info, prefix } from '../util/log.js'
+import { zipDir } from '../util/zipDir.js'
 import { WebSocketServer } from './WebSocketServer.js'
 
 export interface SyncScriptMetadata {
@@ -24,7 +25,7 @@ export class SyncScriptCompiler {
     public readonly metadata: SyncScriptMetadata,
   ) {}
 
-  async compile({ kill }: { kill: boolean }): Promise<boolean> {
+  async compile({ kill, zip = false }: { kill: boolean, zip?: boolean }): Promise<boolean> {
     const success = await this.typecheck(kill)
     if (!success)
       return false
@@ -54,6 +55,11 @@ export class SyncScriptCompiler {
     await cp(resolve(this.cwd, 'metadata.json'), resolve(this.cwd, 'dist', 'metadata.json'))
 
     spinner.succeed(prefix + chalk.greenBright(` Compiled ${this.metadata.service}!`))
+
+    if (zip) {
+      await zipDir(resolve(this.cwd, 'dist'), `${this.metadata.service}.zip`)
+    }
+
     return true
   }
 

--- a/cli/src/classes/WebSocketServer.ts
+++ b/cli/src/classes/WebSocketServer.ts
@@ -9,8 +9,13 @@ import { info, prefix } from '../util/log.js'
 
 export class WebSocketServer {
   private server: WSServer
+  private label: string
 
-  constructor(public readonly cwd: string) {
+  constructor(
+    public readonly cwd: string,
+    private readonly messageType: string = 'localPresence',
+  ) {
+    this.label = messageType === 'localSyncScript' ? 'sync script' : 'activity'
     this.server = new WSServer({ port: 3021 })
 
     this.server.on('connection', (socket) => {
@@ -46,7 +51,7 @@ export class WebSocketServer {
     const files = await readdir(distPath)
 
     const spinner = ora(
-      prefix + chalk.yellow(' Sending activity to the extension...'),
+      prefix + chalk.yellow(` Sending ${this.label} to the extension...`),
     ).start()
 
     let expectedCount = 0
@@ -83,7 +88,7 @@ export class WebSocketServer {
       client.on('close', removeExpectedCount)
 
       client.send(JSON.stringify({
-        type: 'localPresence',
+        type: this.messageType,
         files: await Promise.all(files
           .filter(file => ['.json', '.js'].includes(extname(file)))
           .map(async (file) => {
@@ -108,7 +113,7 @@ export class WebSocketServer {
       await new Promise(resolve => setTimeout(resolve, 100))
     }
 
-    spinner.succeed(prefix + chalk.greenBright(' Activity sent to the extension!'))
+    spinner.succeed(prefix + chalk.greenBright(` ${this.label[0].toUpperCase() + this.label.slice(1)} sent to the extension!`))
 
     this.isSending = false
   }

--- a/cli/src/commands/checkDns.ts
+++ b/cli/src/commands/checkDns.ts
@@ -52,7 +52,6 @@ export async function checkDns(
     fix?: boolean
   } = {},
 ) {
-
   let activities: ActivityMetadataAndFolder[] = []
 
   if (all) {

--- a/cli/src/commands/release.ts
+++ b/cli/src/commands/release.ts
@@ -1,14 +1,16 @@
 import type { ActivityMetadata } from '../classes/ActivityCompiler.js'
 import { existsSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { cp, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import isCI from 'is-ci'
+import { SyncScriptCompiler } from '../classes/SyncScriptCompiler.js'
 import { getDmcaServices, isDmcaBlocked } from '../util/dmca.js'
 import { getChangedActivities } from '../util/getActivities.js'
 import { getFolderLetter } from '../util/getFolderLetter.js'
+import { getChangedSyncScripts } from '../util/getSyncScripts.js'
 import { exit, MESSAGES, success } from '../util/log.js'
 import { sanitazeFolderName } from '../util/sanitazeFolderName.js'
 import { buildActivity } from './build/buildActivity.js'
@@ -145,4 +147,78 @@ export async function release() {
   }
 
   core.info(`Successfully updated ${successCount} activities`)
+
+  // Release sync scripts
+  const { changed: changedScripts, deleted: deletedScripts } = await getChangedSyncScripts()
+  core.info(`Found ${changedScripts.length} changed sync scripts, ${deletedScripts.length} deleted sync scripts`)
+
+  for (const script of deletedScripts) {
+    try {
+      const response = await fetch(`${apiUrl}/sync-scripts/v1/${encodeURIComponent(script.metadata.service)}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      if (!response.ok)
+        core.setFailed(`Failed to delete sync script ${script.metadata.service}: ${response.statusText}, ${await response.text()}`)
+    }
+    catch (error) {
+      core.setFailed(`Error deleting sync script ${script.metadata.service}: ${error}`)
+    }
+  }
+
+  let syncSuccessCount = 0
+
+  for (const script of changedScripts) {
+    await cp(
+      resolve(process.cwd(), 'cli/templates/sync-tsconfig.json'),
+      resolve(script.folder, 'tsconfig.json'),
+    )
+
+    const compiler = new SyncScriptCompiler(script.folder, script.metadata)
+    const built = await compiler.compile({ kill: false, zip: false })
+    if (!built) {
+      core.setFailed(`Failed to build sync script ${script.metadata.service}`)
+      continue
+    }
+
+    const contentJs = await readFile(resolve(script.folder, 'dist', 'content.js'), 'utf8')
+    const iframeJs = existsSync(resolve(script.folder, 'dist', 'iframe.js'))
+      ? await readFile(resolve(script.folder, 'dist', 'iframe.js'), 'utf8')
+      : undefined
+    const mainworldJs = existsSync(resolve(script.folder, 'dist', 'mainworld.js'))
+      ? await readFile(resolve(script.folder, 'dist', 'mainworld.js'), 'utf8')
+      : undefined
+
+    try {
+      const response = await fetch(`${apiUrl}/sync-scripts/v1`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          service: script.metadata.service,
+          contentJs,
+          iframeJs,
+          mainworldJs,
+          regExp: script.metadata.regExp,
+          iframeRegExp: script.metadata.iframeRegExp,
+        }),
+      })
+
+      if (response.ok)
+        syncSuccessCount++
+      else
+        core.setFailed(`Failed to update sync script ${script.metadata.service}: ${response.statusText}, ${await response.text()}`)
+    }
+    catch (error) {
+      core.setFailed(`Error updating sync script ${script.metadata.service}: ${error}`)
+    }
+  }
+
+  core.info(`Successfully updated ${syncSuccessCount} sync scripts`)
 }

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -1,0 +1,116 @@
+import { existsSync } from 'node:fs'
+import { cp, mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { confirm, input } from '@inquirer/prompts'
+import chalk from 'chalk'
+import { SyncScriptCompiler } from '../classes/SyncScriptCompiler.js'
+import { getSingleSyncScript, getSyncScripts } from '../util/getSyncScripts.js'
+import { exit, info, prefix, success } from '../util/log.js'
+import { sanitazeFolderName } from '../util/sanitazeFolderName.js'
+
+export async function syncDev(service?: string) {
+  const { metadata, folder } = await getSingleSyncScript('Select a sync script to develop', service)
+
+  await cp(
+    resolve(process.cwd(), 'cli/templates/sync-tsconfig.json'),
+    resolve(folder, 'tsconfig.json'),
+  )
+
+  const compiler = new SyncScriptCompiler(folder, metadata)
+  await compiler.watch()
+}
+
+export async function syncBuild(service?: string, { all = false, kill = true }: { all?: boolean, kill?: boolean } = {}) {
+  if (all) {
+    const scripts = await getSyncScripts()
+
+    if (scripts.length === 0)
+      exit('No sync scripts found')
+
+    info(`Building ${scripts.length} sync scripts...`)
+
+    let allSuccess = true
+    for (const script of scripts) {
+      await cp(
+        resolve(process.cwd(), 'cli/templates/sync-tsconfig.json'),
+        resolve(script.folder, 'tsconfig.json'),
+      )
+
+      const compiler = new SyncScriptCompiler(script.folder, script.metadata)
+      const isSuccess = await compiler.compile({ kill })
+      allSuccess = allSuccess && isSuccess
+    }
+
+    info(`${scripts.length} sync scripts built ${allSuccess ? 'successfully' : 'with errors'}`)
+    process.exit(allSuccess ? 0 : 1)
+  }
+
+  const { metadata, folder } = await getSingleSyncScript('Select a sync script to build', service)
+
+  await cp(
+    resolve(process.cwd(), 'cli/templates/sync-tsconfig.json'),
+    resolve(folder, 'tsconfig.json'),
+  )
+
+  const compiler = new SyncScriptCompiler(folder, metadata)
+  const isSuccess = await compiler.compile({ kill })
+  process.exit(isSuccess ? 0 : 1)
+}
+
+export async function syncNew(service?: string) {
+  if (!service)
+    service = await input({ message: 'What is the name of the service?' }).catch(() => undefined)
+
+  if (!service)
+    exit('Service name is required')
+
+  const sanitized = sanitazeFolderName(service)
+  const path = resolve(process.cwd(), 'syncScripts', sanitized)
+
+  if (existsSync(path)) {
+    const develop = await confirm({
+      message: 'The sync script already exists. Would you like to develop it?',
+    })
+
+    if (develop)
+      return syncDev(service)
+
+    exit('Sync script already exists')
+  }
+
+  const regExp = await input({
+    message: 'RegExp pattern for URL matching',
+    default: `^https?[:][/][/]([a-z0-9-]+[.])*${service!.toLowerCase().replaceAll(/\W/g, '')}[.]com[/]`,
+  }).catch(() => exit('Something went wrong.'))
+
+  const useIframe = await confirm({
+    message: 'Does this sync script need iframe support?',
+    default: false,
+  }).catch(() => exit('Something went wrong.'))
+
+  const metadata: Record<string, string> = {
+    service,
+    regExp,
+  }
+
+  if (useIframe) {
+    metadata.iframeRegExp = await input({
+      message: 'RegExp pattern for iframe URL matching',
+    }).catch(() => exit('Something went wrong.'))
+  }
+
+  const templatesDir = resolve(fileURLToPath(import.meta.url), '../../../templates')
+
+  await mkdir(path, { recursive: true })
+  await writeFile(resolve(path, 'metadata.json'), `${JSON.stringify(metadata, null, 2)}\n`)
+  await cp(resolve(templatesDir, 'sync-content.ts'), resolve(path, 'content.ts'))
+
+  if (useIframe)
+    await cp(resolve(templatesDir, 'sync-iframe.ts'), resolve(path, 'iframe.ts'))
+
+  success(
+    `Sync script created successfully! ${chalk.grey(chalk.underline(resolve(path, 'metadata.json')))}\n${prefix} ${chalk.white('Please edit the metadata.json file and add the correct information.')}\n${prefix} ${chalk.white(`After that, run ${chalk.cyan(`pmd sync-dev "${service}"`)} to start developing.`)}`,
+  )
+}

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { cp, mkdir, writeFile } from 'node:fs/promises'
+import { cp, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -22,7 +22,7 @@ export async function syncDev(service?: string) {
   await compiler.watch()
 }
 
-export async function syncBuild(service?: string, { all = false, kill = true }: { all?: boolean, kill?: boolean } = {}) {
+export async function syncBuild(service?: string, { all = false, kill = true, zip = false }: { all?: boolean, kill?: boolean, zip?: boolean } = {}) {
   if (all) {
     const scripts = await getSyncScripts()
 
@@ -39,7 +39,7 @@ export async function syncBuild(service?: string, { all = false, kill = true }: 
       )
 
       const compiler = new SyncScriptCompiler(script.folder, script.metadata)
-      const isSuccess = await compiler.compile({ kill })
+      const isSuccess = await compiler.compile({ kill, zip })
       allSuccess = allSuccess && isSuccess
     }
 
@@ -55,8 +55,59 @@ export async function syncBuild(service?: string, { all = false, kill = true }: 
   )
 
   const compiler = new SyncScriptCompiler(folder, metadata)
-  const isSuccess = await compiler.compile({ kill })
+  const isSuccess = await compiler.compile({ kill, zip })
   process.exit(isSuccess ? 0 : 1)
+}
+
+export async function syncRelease(service?: string) {
+  const apiKey = process.env.ADMIN_API_KEY
+  if (!apiKey)
+    exit('ADMIN_API_KEY environment variable is required')
+
+  const apiUrl = process.env.API_URL || 'https://api.premid.app/v6'
+
+  const { metadata, folder } = await getSingleSyncScript('Select a sync script to release', service)
+
+  await cp(
+    resolve(process.cwd(), 'cli/templates/sync-tsconfig.json'),
+    resolve(folder, 'tsconfig.json'),
+  )
+
+  const compiler = new SyncScriptCompiler(folder, metadata)
+  const built = await compiler.compile({ kill: false, zip: false })
+  if (!built)
+    exit(`Failed to build ${metadata.service}`)
+
+  const contentJs = await readFile(resolve(folder, 'dist', 'content.js'), 'utf8')
+  const iframeJs = existsSync(resolve(folder, 'dist', 'iframe.js'))
+    ? await readFile(resolve(folder, 'dist', 'iframe.js'), 'utf8')
+    : undefined
+  const mainworldJs = existsSync(resolve(folder, 'dist', 'mainworld.js'))
+    ? await readFile(resolve(folder, 'dist', 'mainworld.js'), 'utf8')
+    : undefined
+
+  info(`Releasing ${metadata.service}...`)
+
+  const response = await fetch(`${apiUrl}/sync-scripts/v1`, {
+    method: 'POST',
+    headers: {
+      'Authorization': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      service: metadata.service,
+      contentJs,
+      iframeJs,
+      mainworldJs,
+      regExp: metadata.regExp,
+      iframeRegExp: metadata.iframeRegExp,
+    }),
+  })
+
+  if (response.ok)
+    success(`Released sync script: ${metadata.service}`)
+  else
+    exit(`Failed to release ${metadata.service}: ${response.statusText} — ${await response.text()}`)
 }
 
 export async function syncNew(service?: string) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,7 +7,7 @@ import { bump } from './commands/bump.js'
 import { checkDns } from './commands/checkDns.js'
 import { newActivity } from './commands/new.js'
 import { release } from './commands/release.js'
-import { syncBuild, syncDev, syncNew } from './commands/sync.js'
+import { syncBuild, syncDev, syncNew, syncRelease } from './commands/sync.js'
 import { updateAssets } from './commands/updateAssets.js'
 import { getCliPackageJson, getPackageJson } from './util/getPackageJson.js'
 import { exit } from './util/log.js'
@@ -68,7 +68,12 @@ cli
   .command('sync-build [script]', 'Build a sync script')
   .option('--all', 'Build all sync scripts')
   .option('--kill', 'Kill on error', { default: true })
+  .option('--zip', 'Zip the sync script')
   .action(syncBuild)
+
+cli
+  .command('sync-release [script]', 'Build and release a sync script to the API')
+  .action(syncRelease)
 
 cli
   .command('update-assets', 'Update assets for all activities in CI')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,7 @@ import { bump } from './commands/bump.js'
 import { checkDns } from './commands/checkDns.js'
 import { newActivity } from './commands/new.js'
 import { release } from './commands/release.js'
+import { syncBuild, syncDev, syncNew } from './commands/sync.js'
 import { updateAssets } from './commands/updateAssets.js'
 import { getCliPackageJson, getPackageJson } from './util/getPackageJson.js'
 import { exit } from './util/log.js'
@@ -54,6 +55,20 @@ cli
   .option('--changed', 'Check only changed activities')
   .option('--fix', 'Remove invalid URLs and activities')
   .action(checkDns)
+
+cli
+  .command('sync-new [script]', 'Create a new sync script')
+  .action(syncNew)
+
+cli
+  .command('sync-dev [script]', 'Develop a sync script with hot-reload')
+  .action(syncDev)
+
+cli
+  .command('sync-build [script]', 'Build a sync script')
+  .option('--all', 'Build all sync scripts')
+  .option('--kill', 'Kill on error', { default: true })
+  .action(syncBuild)
 
 cli
   .command('update-assets', 'Update assets for all activities in CI')

--- a/cli/src/util/getActivities.ts
+++ b/cli/src/util/getActivities.ts
@@ -59,6 +59,7 @@ export async function getChangedActivities(): Promise<{
     '/',
     process.cwd(),
     resolve(process.cwd(), 'websites'),
+    resolve(process.cwd(), 'syncScripts'),
   ]
 
   const modifiedAddedFiles = changedFiles.filter(file => !file.deleted)

--- a/cli/src/util/getActivities.ts
+++ b/cli/src/util/getActivities.ts
@@ -62,8 +62,12 @@ export async function getChangedActivities(): Promise<{
     resolve(process.cwd(), 'syncScripts'),
   ]
 
+  const syncScriptsDir = resolve(process.cwd(), 'syncScripts')
   const modifiedAddedFiles = changedFiles.filter(file => !file.deleted)
   for (const file of modifiedAddedFiles) {
+    if (file.path.startsWith(syncScriptsDir))
+      continue
+
     let path = file.path
     while (!existsSync(resolve(path, 'metadata.json'))) {
       path = dirname(path)

--- a/cli/src/util/getActivities.ts
+++ b/cli/src/util/getActivities.ts
@@ -1,15 +1,12 @@
 import type { ActivityMetadata } from '../classes/ActivityCompiler.js'
-import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
-import { context } from '@actions/github'
-import gitDiffParser from 'gitdiff-parser'
 import { globby } from 'globby'
 import isCI from 'is-ci'
 import multimatch from 'multimatch'
-import { exit, info } from './log.js'
+import { decodeUtf8Escapes, getChangedFilesCi, getChangedFilesLocal } from './getChangedFiles.js'
 
 export interface ActivityMetadataAndFolder {
   metadata: ActivityMetadata
@@ -127,71 +124,4 @@ export async function getChangedActivities(): Promise<{
       } satisfies ActivityMetadataAndFolder
     }),
   }
-}
-
-async function getChangedFilesCi() {
-  if (!process.env.GITHUB_TOKEN) {
-    exit('GITHUB_TOKEN is not set')
-  }
-
-  let base: string | undefined
-  let head: string | undefined
-
-  switch (context.eventName) {
-    case 'pull_request':
-    case 'pull_request_review':
-      base = context.payload.pull_request?.base?.sha
-      head = context.payload.pull_request?.head?.sha
-      break
-    case 'push':
-      base = context.payload.before
-      head = context.payload.after
-      break
-  }
-
-  if (!base || !head) {
-    exit('No base or head found')
-  }
-
-  info(`Getting changed files from ${base} to ${head}`)
-
-  const response = await fetch(`https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${base}...${head}.diff`, {
-    headers: {
-      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-    },
-  })
-
-  const files = gitDiffParser.parse(await response.text())
-  return files.map(file => ({
-    path: file.type === 'delete' ? file.oldPath : file.newPath,
-    deleted: file.type === 'delete',
-  }))
-}
-
-async function getChangedFilesLocal() {
-  const base = execSync('git merge-base main HEAD').toString().trim()
-  const head = execSync('git rev-parse HEAD').toString().trim()
-  const diffOutput = execSync(`git diff --name-status ${base} ${head}`).toString().trim()
-
-  return diffOutput.split('\n').filter(line => line.length > 0).map((line) => {
-    const [status, path] = line.split('\t')
-    return {
-      path,
-      deleted: status === 'D',
-    }
-  })
-}
-
-function decodeUtf8Escapes(filePath: string) {
-  filePath = filePath
-    .replace(/"$/, '')
-    .replace(/^"/, '')
-    .replace(/^\//, '')
-
-  const decodedPath = filePath.replace(/\\(\d{3})/g, (_, octalCode) =>
-    String.fromCharCode(Number.parseInt(octalCode, 8)))
-
-  const bytes = new Uint8Array([...decodedPath].map(char => char.charCodeAt(0)))
-  const decoder = new TextDecoder('utf-8')
-  return decoder.decode(bytes)
 }

--- a/cli/src/util/getChangedFiles.ts
+++ b/cli/src/util/getChangedFiles.ts
@@ -1,0 +1,74 @@
+import { execSync } from 'node:child_process'
+import process from 'node:process'
+import { context } from '@actions/github'
+import gitDiffParser from 'gitdiff-parser'
+import { exit, info } from './log.js'
+
+export interface ChangedFile {
+  path: string
+  deleted: boolean
+}
+
+export async function getChangedFilesCi(): Promise<ChangedFile[]> {
+  if (!process.env.GITHUB_TOKEN)
+    exit('GITHUB_TOKEN is not set')
+
+  let base: string | undefined
+  let head: string | undefined
+
+  switch (context.eventName) {
+    case 'pull_request':
+    case 'pull_request_review':
+      base = context.payload.pull_request?.base?.sha
+      head = context.payload.pull_request?.head?.sha
+      break
+    case 'push':
+      base = context.payload.before
+      head = context.payload.after
+      break
+  }
+
+  if (!base || !head)
+    exit('No base or head found')
+
+  info(`Getting changed files from ${base} to ${head}`)
+
+  const response = await fetch(`https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${base}...${head}.diff`, {
+    headers: {
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+    },
+  })
+
+  const files = gitDiffParser.parse(await response.text())
+  return files.map(file => ({
+    path: file.type === 'delete' ? file.oldPath : file.newPath,
+    deleted: file.type === 'delete',
+  }))
+}
+
+export function getChangedFilesLocal(): ChangedFile[] {
+  const base = execSync('git merge-base main HEAD').toString().trim()
+  const head = execSync('git rev-parse HEAD').toString().trim()
+  const diffOutput = execSync(`git diff --name-status ${base} ${head}`).toString().trim()
+
+  return diffOutput.split('\n').filter(line => line.length > 0).map((line) => {
+    const [status, path] = line.split('\t')
+    return {
+      path,
+      deleted: status === 'D',
+    }
+  })
+}
+
+export function decodeUtf8Escapes(filePath: string): string {
+  filePath = filePath
+    .replace(/"$/, '')
+    .replace(/^"/, '')
+    .replace(/^\//, '')
+
+  const decodedPath = filePath.replace(/\\(\d{3})/g, (_, octalCode) =>
+    String.fromCharCode(Number.parseInt(octalCode, 8)))
+
+  const bytes = new Uint8Array([...decodedPath].map(char => char.charCodeAt(0)))
+  return new TextDecoder('utf-8').decode(bytes)
+}

--- a/cli/src/util/getSyncScripts.ts
+++ b/cli/src/util/getSyncScripts.ts
@@ -1,0 +1,47 @@
+import type { SyncScriptMetadata } from '../classes/SyncScriptCompiler.js'
+import { readFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { search } from '@inquirer/prompts'
+import { globby } from 'globby'
+import { exit } from './log.js'
+import { searchChoices } from './searchChoices.js'
+
+export interface SyncScriptMetadataAndFolder {
+  metadata: SyncScriptMetadata
+  folder: string
+}
+
+export async function getSyncScripts(): Promise<SyncScriptMetadataAndFolder[]> {
+  return (await Promise.all(
+    (
+      await globby([`syncScripts/*/metadata.json`], {
+        absolute: true,
+      })
+    ).map(async (file): Promise<SyncScriptMetadataAndFolder> => ({
+      metadata: JSON.parse(await readFile(file, 'utf-8')),
+      folder: dirname(file),
+    })),
+  )).sort(({ metadata: a }, { metadata: b }) => a.service.localeCompare(b.service))
+}
+
+export async function getSingleSyncScript(message: string, service?: string): Promise<SyncScriptMetadataAndFolder> {
+  const scripts = await getSyncScripts()
+
+  if (scripts.length === 0)
+    exit('No sync scripts found')
+
+  if (service) {
+    const match = scripts.find(s => s.metadata.service.toLowerCase() === service.toLowerCase())
+    if (!match)
+      exit(`No sync script found for service "${service}"`)
+    return match
+  }
+
+  return search({
+    message,
+    source: input => searchChoices(
+      scripts.map(s => ({ name: s.metadata.service, value: s })),
+      input,
+    ),
+  })
+}

--- a/cli/src/util/getSyncScripts.ts
+++ b/cli/src/util/getSyncScripts.ts
@@ -1,8 +1,13 @@
 import type { SyncScriptMetadata } from '../classes/SyncScriptCompiler.js'
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
 import { search } from '@inquirer/prompts'
 import { globby } from 'globby'
+import isCI from 'is-ci'
+import multimatch from 'multimatch'
+import { decodeUtf8Escapes, getChangedFilesCi, getChangedFilesLocal } from './getChangedFiles.js'
 import { exit } from './log.js'
 import { searchChoices } from './searchChoices.js'
 
@@ -22,6 +27,55 @@ export async function getSyncScripts(): Promise<SyncScriptMetadataAndFolder[]> {
       folder: dirname(file),
     })),
   )).sort(({ metadata: a }, { metadata: b }) => a.service.localeCompare(b.service))
+}
+
+export async function getChangedSyncScripts(): Promise<{
+  changed: SyncScriptMetadataAndFolder[]
+  deleted: { metadata: Pick<SyncScriptMetadata, 'service'>, folder: string }[]
+}> {
+  const changedFiles = (isCI ? await getChangedFilesCi() : getChangedFilesLocal())
+    .map(file => ({
+      ...file,
+      path: resolve(process.cwd(), decodeUtf8Escapes(file.path)),
+    }))
+
+  const syncScriptsDir = resolve(process.cwd(), 'syncScripts')
+  const scriptPaths = new Set<string>()
+
+  for (const file of changedFiles.filter(f => !f.deleted)) {
+    if (!file.path.startsWith(syncScriptsDir))
+      continue
+
+    let path = file.path
+    while (!existsSync(resolve(path, 'metadata.json'))) {
+      const parent = dirname(path)
+      if (parent === path || parent === syncScriptsDir || parent === process.cwd())
+        break
+      path = parent
+    }
+
+    if (existsSync(resolve(path, 'metadata.json')))
+      scriptPaths.add(path)
+  }
+
+  const deletedFolders = changedFiles
+    .filter(f => f.deleted && f.path.startsWith(syncScriptsDir))
+    .map(f => dirname(f.path))
+    .filter(folder => multimatch(folder, ['**/syncScripts/*']).length > 0)
+    .filter(folder => !Array.from(scriptPaths).some(p => p.startsWith(folder)))
+
+  return {
+    changed: await Promise.all(
+      Array.from(scriptPaths).map(async (folder): Promise<SyncScriptMetadataAndFolder> => ({
+        metadata: JSON.parse(await readFile(resolve(folder, 'metadata.json'), 'utf-8')),
+        folder,
+      })),
+    ),
+    deleted: deletedFolders.map((folder) => {
+      const service = folder.split('/').at(-1) ?? ''
+      return { metadata: { service }, folder }
+    }),
+  }
 }
 
 export async function getSingleSyncScript(message: string, service?: string): Promise<SyncScriptMetadataAndFolder> {

--- a/cli/src/util/zipDir.ts
+++ b/cli/src/util/zipDir.ts
@@ -1,0 +1,18 @@
+import { readdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import AdmZip from 'adm-zip'
+
+export async function zipDir(dir: string, filename: string) {
+  const zip = new AdmZip()
+  const zipPathInDir = resolve(dir, filename)
+
+  //* Read all files in the directory and add them to the zip
+  const files = await readdir(dir, { recursive: true })
+
+  for (const file of files) {
+    const filePath = join(dir, file)
+    zip.addLocalFile(filePath)
+  }
+
+  zip.writeZip(zipPathInDir)
+}

--- a/cli/templates/sync-content.ts
+++ b/cli/templates/sync-content.ts
@@ -1,0 +1,11 @@
+SyncScript.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    const video = document.querySelector('video')
+    if (video)
+      ctx.video.attach(video)
+
+    ctx.setPageInfo({ title: document.title })
+  },
+})

--- a/cli/templates/sync-iframe.ts
+++ b/cli/templates/sync-iframe.ts
@@ -1,0 +1,7 @@
+SyncIframeScript.register({
+  setup(ctx) {
+    const video = document.querySelector('video')
+    if (video)
+      ctx.video.setElement(video)
+  },
+})

--- a/cli/templates/sync-tsconfig.json
+++ b/cli/templates/sync-tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -76,18 +76,39 @@ export default defineConfig({
             { text: 'Activity Forwarding', link: '/v1/guide/activity-forwarding' },
           ],
         },
+        {
+          text: 'Watch Party',
+          items: [
+            { text: 'Sync Script Guide', link: '/v1/guide/watch-party-sync-scripts' },
+            { text: 'Video Sync', link: '/v1/guide/watch-party-video' },
+            { text: 'Advanced Features', link: '/v1/guide/watch-party-advanced' },
+            { text: 'Sync Behavior', link: '/v1/guide/watch-party-behavior' },
+          ],
+        },
       ],
       '/v1/api/': [
         {
-          text: 'API Reference',
+          text: 'Overview',
           items: [
-            { text: 'Overview', link: '/v1/api/' },
+            { text: 'API Reference', link: '/v1/api/' },
+          ],
+        },
+        {
+          text: 'Activities',
+          items: [
             { text: 'Presence Class', link: '/v1/api/presence-class' },
             { text: 'PresenceData Interface', link: '/v1/api/presence-data' },
             { text: 'metadata.json Structure', link: '/v1/api/metadata-json' },
             { text: 'Slideshow Class', link: '/v1/api/slideshow' },
             { text: 'iFrame Class', link: '/v1/api/iframe' },
             { text: 'Utility Functions', link: '/v1/api/utility-functions' },
+          ],
+        },
+        {
+          text: 'Watch Party',
+          items: [
+            { text: 'SyncScriptContext', link: '/v1/api/sync-script-context' },
+            { text: 'Sync Script Types', link: '/v1/api/sync-script-types' },
           ],
         },
       ],
@@ -100,6 +121,7 @@ export default defineConfig({
             { text: 'Activity with Settings', link: '/v1/examples/settings' },
             { text: 'Activity with iFrames', link: '/v1/examples/iframes' },
             { text: 'Activity with Slideshow', link: '/v1/examples/slideshow' },
+            { text: 'Watch Party Sync Script', link: '/v1/examples/watch-party' },
           ],
         },
       ],

--- a/docs/v1/api/index.md
+++ b/docs/v1/api/index.md
@@ -12,6 +12,8 @@ The PreMiD API consists of several key components:
 - [Slideshow Class](/v1/api/slideshow): A class for creating slideshows that alternate between different presence data
 - [iFrame Class](/v1/api/iframe): A class for interacting with iframes
 - [Utility Functions](/v1/api/utility-functions): Helper functions for common tasks
+- [SyncScriptContext](/v1/api/sync-script-context): The API for Watch Party sync scripts
+- [Sync Script Types](/v1/api/sync-script-types): TypeScript interfaces for sync scripts
 
 ## Getting Started
 

--- a/docs/v1/api/sync-script-context.md
+++ b/docs/v1/api/sync-script-context.md
@@ -1,0 +1,755 @@
+# SyncScriptContext
+
+The `SyncScriptContext` is the main object sync script developers interact with when building Watch Party sync scripts. It provides methods for video synchronization, page metadata, cross-frame messaging, and party state observation.
+
+See the [Sync Script Types](/v1/api/sync-script-types) reference for full interface definitions, and the [Watch Party Sync Scripts](/v1/guide/watch-party-sync-scripts) guide for usage patterns.
+
+## Registration
+
+### SyncScriptV1.register
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register(options: {
+  setup: (ctx: SyncScriptContext) => (() => void) | void
+  onNavigate?: (ctx: SyncScriptContext, url: string) => void
+}): SyncScriptHandle
+```
+
+Registers a sync script with the PreMiD extension. The `setup` function is called once when the sync script is initialized. Return a cleanup function from `setup` to dispose of resources when the script is torn down.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `options.setup` | `(ctx: SyncScriptContext) => (() => void) \| void` | Called once on initialization. Receives the context object. May return a cleanup function. |
+| `options.onNavigate` | `(ctx: SyncScriptContext, url: string) => void` | Called when the user navigates to a new page within the same site. |
+
+#### Returns
+
+A `SyncScriptHandle` for managing the registered script.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    const handle = ctx.video.attach('video')
+
+    ctx.setPageInfo({
+      title: document.querySelector('.title')?.textContent ?? 'Unknown',
+    })
+
+    return () => {
+      handle.detach()
+    }
+  },
+  onNavigate(ctx, url) {
+    ctx.setPageInfo({
+      title: document.querySelector('.title')?.textContent ?? 'Unknown',
+    })
+  },
+})
+```
+
+## Features
+
+### features
+
+<!-- eslint-skip -->
+
+```typescript
+features(features: { video?: boolean, cursor?: boolean, scroll?: boolean }): void
+```
+
+Declares which sync features this script supports. Must be called before using any feature-specific APIs such as `video`.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `features.video` | `boolean` | Enable video synchronization. |
+| `features.cursor` | `boolean` | Enable cursor synchronization. |
+| `features.scroll` | `boolean` | Enable scroll synchronization. |
+
+::: warning
+You must call `features()` before accessing `video.attach()` or `video.takeControl()`. Calling video methods without declaring video support will throw an error.
+:::
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+ctx.features({ video: true, cursor: true })
+```
+
+## Video
+
+### video.attach
+
+<!-- eslint-skip -->
+
+```typescript
+video.attach(element: HTMLMediaElement | string): AutoVideoHandle
+```
+
+Attaches to a standard HTML media element for automatic video synchronization. PreMiD will automatically manage play, pause, seek, and playback rate events on the element.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `element` | `HTMLMediaElement \| string` | A direct reference to the media element, or a CSS selector string that resolves to one. |
+
+#### Returns
+
+An `AutoVideoHandle` with the following methods:
+
+- `detach()` -- Stops synchronization and removes all event listeners.
+- `onSyncCommand(handler)` -- Registers a handler called when the party sends a sync command. Returns an unsubscribe function.
+- `reportAd(isInAd)` -- Reports whether an ad is currently playing.
+- `reportBuffering(isBuffering)` -- Reports whether the video is buffering.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const handle = ctx.video.attach('video.main-player')
+
+handle.onSyncCommand((command) => {
+  console.log('Received sync command:', command)
+})
+
+// Later, when cleaning up
+handle.detach()
+```
+
+### video.takeControl
+
+<!-- eslint-skip -->
+
+```typescript
+video.takeControl(options: TakeControlOptions): ManualVideoHandle
+```
+
+Takes manual control of video synchronization for custom players that do not use a standard `HTMLMediaElement`. You provide callbacks that are invoked when the party sends sync commands.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `options.onPlay` | `() => void` | Called when the party requests playback to start. |
+| `options.onPause` | `() => void` | Called when the party requests playback to pause. |
+| `options.onSeek` | `(time: number) => void` | Called when the party requests a seek to a specific time in seconds. |
+| `options.onRate` | `(rate: number) => void` | Called when the party requests a playback rate change. |
+| `options.pauseAfterSeek` | `boolean \| number` | If `true`, pauses after seeking. If a number, pauses after a delay of that many milliseconds. |
+
+#### Returns
+
+A `ManualVideoHandle` with the following methods:
+
+- `reportPlayback(state)` -- Reports current playback state (time, duration, paused, rate) to the party.
+- `onSyncCommand(handler)` -- Registers a handler called on sync commands. Returns an unsubscribe function.
+- `reportAd(isInAd)` -- Reports whether an ad is currently playing.
+- `reportBuffering(isBuffering)` -- Reports whether the video is buffering.
+- `release()` -- Releases manual control and stops synchronization.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const player = getCustomPlayer()
+
+const handle = ctx.video.takeControl({
+  onPlay: () => player.play(),
+  onPause: () => player.pause(),
+  onSeek: (time) => player.seekTo(time),
+  onRate: (rate) => player.setPlaybackRate(rate),
+  pauseAfterSeek: 200,
+})
+
+// Report playback state periodically
+setInterval(() => {
+  handle.reportPlayback({
+    time: player.getCurrentTime(),
+    duration: player.getDuration(),
+    paused: player.isPaused(),
+    rate: player.getPlaybackRate(),
+  })
+}, 1000)
+
+// Later, when cleaning up
+handle.release()
+```
+
+### video.reportAd
+
+<!-- eslint-skip -->
+
+```typescript
+video.reportAd(isInAd: boolean): void
+```
+
+Convenience shortcut for reporting ad state directly from the context. Notifies the party that the user is viewing an ad so synchronization can be paused.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `isInAd` | `boolean` | Whether an ad is currently playing. |
+
+::: tip
+Ad-exit transitions (`false`) have a 500ms debounce to prevent flickering when ads change rapidly between segments.
+:::
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+adObserver.on('adStart', () => ctx.video.reportAd(true))
+adObserver.on('adEnd', () => ctx.video.reportAd(false))
+```
+
+### video.reportBuffering
+
+<!-- eslint-skip -->
+
+```typescript
+video.reportBuffering(isBuffering: boolean): void
+```
+
+Convenience shortcut for reporting buffering state directly from the context. Notifies the party that the video is buffering so synchronization can account for it.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `isBuffering` | `boolean` | Whether the video is currently buffering. |
+
+::: tip
+Buffering-exit transitions (`false`) have a 500ms debounce to prevent flickering during brief rebuffers.
+:::
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+video.addEventListener('waiting', () => ctx.video.reportBuffering(true))
+video.addEventListener('playing', () => ctx.video.reportBuffering(false))
+```
+
+## Page Info
+
+### setPageInfo
+
+<!-- eslint-skip -->
+
+```typescript
+setPageInfo(info: PageInfo): void
+```
+
+Sets metadata about the current page that is displayed to other party members.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `info.title` | `string` | The title of the content being viewed. |
+| `info.subtitle` | `string` | A subtitle or secondary description. |
+| `info.thumbnail` | `string` | A URL to a thumbnail image. |
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+ctx.setPageInfo({
+  title: 'Episode 5 - The Final Chapter',
+  subtitle: 'Season 2',
+  thumbnail: 'https://example.com/thumb.jpg',
+})
+```
+
+## Blocking
+
+### reportBlocked
+
+<!-- eslint-skip -->
+
+```typescript
+reportBlocked(reason: string): void
+```
+
+Reports that the user is blocked from viewing the content. Use this for login walls, geo-restrictions, or paywalls so other party members understand why synchronization has stopped.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `reason` | `string` | A human-readable description of why access is blocked. |
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+if (!isLoggedIn) {
+  ctx.reportBlocked('Login required to watch this content')
+}
+```
+
+### reportUnblocked
+
+<!-- eslint-skip -->
+
+```typescript
+reportUnblocked(): void
+```
+
+Reports that the user is no longer blocked. Call this after a previously reported block has been resolved.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+onLogin(() => {
+  ctx.reportUnblocked()
+})
+```
+
+## Custom Data
+
+### sendCustomData
+
+<!-- eslint-skip -->
+
+```typescript
+sendCustomData(key: string, data: unknown): void
+```
+
+Sends arbitrary data to other party members. Useful for syncing application-specific state that is not covered by the built-in APIs.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | A unique key identifying the data type. Must be 1-32 characters, alphanumeric with hyphens and underscores only. |
+| `data` | `unknown` | The data to send. Must be serializable. |
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+ctx.sendCustomData('subtitle-lang', { language: 'en', enabled: true })
+```
+
+### onCustomData
+
+<!-- eslint-skip -->
+
+```typescript
+onCustomData(key: string, handler: (data: unknown) => void): () => void
+```
+
+Subscribes to custom data sent by other party members for the given key.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The key to listen for. Must be 1-32 characters, alphanumeric with hyphens and underscores only. |
+| `handler` | `(data: unknown) => void` | Called when data is received for this key. |
+
+#### Returns
+
+An unsubscribe function. Call it to stop receiving data.
+
+::: warning
+The `key` parameter must be 1-32 characters long and can only contain alphanumeric characters, hyphens (`-`), and underscores (`_`).
+:::
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const unsubscribe = ctx.onCustomData('subtitle-lang', (data) => {
+  const { language, enabled } = data as { language: string, enabled: boolean }
+  setSubtitleLanguage(language, enabled)
+})
+
+// Later, when cleaning up
+unsubscribe()
+```
+
+## Iframe Messaging
+
+The `iframe` namespace provides methods for communicating between the content script and iframes on the page.
+
+### iframe.send
+
+<!-- eslint-skip -->
+
+```typescript
+iframe.send(frameId: string, key: string, data?: unknown): void
+```
+
+Sends a one-way message to a specific iframe.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `frameId` | `string` | The identifier of the target iframe. |
+| `key` | `string` | The message key. |
+| `data` | `unknown` | Optional data payload. |
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+ctx.iframe.send('player-frame', 'toggle-captions', { enabled: true })
+```
+
+### iframe.request
+
+<!-- eslint-skip -->
+
+```typescript
+iframe.request<T>(frameId: string, key: string, data?: unknown): Promise<T>
+```
+
+Sends a request to an iframe and waits for a response.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `frameId` | `string` | The identifier of the target iframe. |
+| `key` | `string` | The request key. |
+| `data` | `unknown` | Optional request payload. |
+
+#### Returns
+
+A `Promise` that resolves with the response data from the iframe.
+
+::: warning
+Requests have a 10-second timeout. If the iframe does not respond within that window, the promise will reject.
+:::
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const currentTime = await ctx.iframe.request<number>('player-frame', 'get-time')
+```
+
+### iframe.onMessage
+
+<!-- eslint-skip -->
+
+```typescript
+iframe.onMessage(key: string, handler: (data: unknown) => void): () => void
+```
+
+Listens for one-way messages from iframes.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The message key to listen for. |
+| `handler` | `(data: unknown) => void` | Called when a message with the given key is received. |
+
+#### Returns
+
+An unsubscribe function.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const unsubscribe = ctx.iframe.onMessage('player-state', (data) => {
+  console.log('Player state:', data)
+})
+```
+
+### iframe.onRequest
+
+<!-- eslint-skip -->
+
+```typescript
+iframe.onRequest(key: string, handler: (data: unknown) => unknown): () => void
+```
+
+Listens for requests from iframes and provides a response.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The request key to listen for. |
+| `handler` | `(data: unknown) => unknown` | Called when a request is received. The return value is sent back as the response. |
+
+#### Returns
+
+An unsubscribe function.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const unsubscribe = ctx.iframe.onRequest('get-page-title', () => {
+  return document.title
+})
+```
+
+## Main World Messaging
+
+The `mainworld` namespace provides methods for communicating with scripts running in the page's main world (outside the content script sandbox).
+
+### mainworld.send
+
+<!-- eslint-skip -->
+
+```typescript
+mainworld.send(key: string, data?: unknown): void
+```
+
+Sends a one-way message to the main world.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The message key. |
+| `data` | `unknown` | Optional data payload. |
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+ctx.mainworld.send('request-player-state')
+```
+
+### mainworld.request
+
+<!-- eslint-skip -->
+
+```typescript
+mainworld.request<T>(key: string, data?: unknown): Promise<T>
+```
+
+Sends a request to the main world and waits for a response.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The request key. |
+| `data` | `unknown` | Optional request payload. |
+
+#### Returns
+
+A `Promise` that resolves with the response data from the main world.
+
+::: warning
+Requests have a 10-second timeout. If the main world does not respond within that window, the promise will reject.
+:::
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const playerData = await ctx.mainworld.request<PlayerData>('get-player-data')
+```
+
+### mainworld.onMessage
+
+<!-- eslint-skip -->
+
+```typescript
+mainworld.onMessage(key: string, handler: (data: unknown) => void): () => void
+```
+
+Listens for one-way messages from the main world.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The message key to listen for. |
+| `handler` | `(data: unknown) => void` | Called when a message with the given key is received. |
+
+#### Returns
+
+An unsubscribe function.
+
+### mainworld.onRequest
+
+<!-- eslint-skip -->
+
+```typescript
+mainworld.onRequest(key: string, handler: (data: unknown) => unknown): () => void
+```
+
+Listens for requests from the main world and provides a response.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | The request key to listen for. |
+| `handler` | `(data: unknown) => unknown` | Called when a request is received. The return value is sent back as the response. |
+
+#### Returns
+
+An unsubscribe function.
+
+## Party State
+
+The `party` property exposes read-only state about the current Watch Party session and methods to subscribe to changes.
+
+### party.role
+
+<!-- eslint-skip -->
+
+```typescript
+party.role: string
+```
+
+The current user's role in the party (e.g., `"host"`, `"viewer"`). Read-only.
+
+### party.paused
+
+<!-- eslint-skip -->
+
+```typescript
+party.paused: boolean
+```
+
+Whether party playback is currently paused. Read-only.
+
+### party.active
+
+<!-- eslint-skip -->
+
+```typescript
+party.active: boolean
+```
+
+Whether the Watch Party session is currently active. Read-only.
+
+### party.isHost
+
+<!-- eslint-skip -->
+
+```typescript
+party.isHost: boolean
+```
+
+Whether the current user is the host of the party. Read-only.
+
+### party.onRoleChange
+
+<!-- eslint-skip -->
+
+```typescript
+party.onRoleChange(handler: (role: string) => void): () => void
+```
+
+Subscribes to role changes.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `handler` | `(role: string) => void` | Called when the user's role changes. |
+
+#### Returns
+
+An unsubscribe function.
+
+### party.onPauseChange
+
+<!-- eslint-skip -->
+
+```typescript
+party.onPauseChange(handler: (paused: boolean) => void): () => void
+```
+
+Subscribes to pause state changes.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `handler` | `(paused: boolean) => void` | Called when the party pause state changes. |
+
+#### Returns
+
+An unsubscribe function.
+
+### party.onActiveChange
+
+<!-- eslint-skip -->
+
+```typescript
+party.onActiveChange(handler: (active: boolean) => void): () => void
+```
+
+Subscribes to active state changes.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `handler` | `(active: boolean) => void` | Called when the party active state changes. |
+
+#### Returns
+
+An unsubscribe function.
+
+#### Example
+
+<!-- eslint-skip -->
+
+```typescript
+const unsubRole = ctx.party.onRoleChange((role) => {
+  console.log('Role changed to:', role)
+})
+
+const unsubPause = ctx.party.onPauseChange((paused) => {
+  if (paused) {
+    showPauseOverlay()
+  }
+  else {
+    hidePauseOverlay()
+  }
+})
+
+const unsubActive = ctx.party.onActiveChange((active) => {
+  if (!active) {
+    cleanup()
+  }
+})
+
+// Later, when cleaning up
+unsubRole()
+unsubPause()
+unsubActive()
+```

--- a/docs/v1/api/sync-script-context.md
+++ b/docs/v1/api/sync-script-context.md
@@ -21,10 +21,10 @@ Registers a sync script with the PreMiD extension. The `setup` function is calle
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `options.setup` | `(ctx: SyncScriptContext) => (() => void) \| void` | Called once on initialization. Receives the context object. May return a cleanup function. |
-| `options.onNavigate` | `(ctx: SyncScriptContext, url: string) => void` | Called when the user navigates to a new page within the same site. |
+| Parameter            | Type                                               | Description                                                                                |
+| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `options.setup`      | `(ctx: SyncScriptContext) => (() => void) \| void` | Called once on initialization. Receives the context object. May return a cleanup function. |
+| `options.onNavigate` | `(ctx: SyncScriptContext, url: string) => void`    | Called when the user navigates to a new page within the same site.                         |
 
 #### Returns
 
@@ -71,9 +71,9 @@ Declares which sync features this script supports. Must be called before using a
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `features.video` | `boolean` | Enable video synchronization. |
+| Parameter         | Type      | Description                    |
+| ----------------- | --------- | ------------------------------ |
+| `features.video`  | `boolean` | Enable video synchronization.  |
 | `features.cursor` | `boolean` | Enable cursor synchronization. |
 | `features.scroll` | `boolean` | Enable scroll synchronization. |
 
@@ -103,8 +103,8 @@ Attaches to a standard HTML media element for automatic video synchronization. P
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
+| Parameter | Type                         | Description                                                                             |
+| --------- | ---------------------------- | --------------------------------------------------------------------------------------- |
 | `element` | `HTMLMediaElement \| string` | A direct reference to the media element, or a CSS selector string that resolves to one. |
 
 #### Returns
@@ -143,13 +143,13 @@ Takes manual control of video synchronization for custom players that do not use
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `options.onPlay` | `() => void` | Called when the party requests playback to start. |
-| `options.onPause` | `() => void` | Called when the party requests playback to pause. |
-| `options.onSeek` | `(time: number) => void` | Called when the party requests a seek to a specific time in seconds. |
-| `options.onRate` | `(rate: number) => void` | Called when the party requests a playback rate change. |
-| `options.pauseAfterSeek` | `boolean \| number` | If `true`, pauses after seeking. If a number, pauses after a delay of that many milliseconds. |
+| Parameter                | Type                     | Description                                                                                   |
+| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------------- |
+| `options.onPlay`         | `() => void`             | Called when the party requests playback to start.                                             |
+| `options.onPause`        | `() => void`             | Called when the party requests playback to pause.                                             |
+| `options.onSeek`         | `(time: number) => void` | Called when the party requests a seek to a specific time in seconds.                          |
+| `options.onRate`         | `(rate: number) => void` | Called when the party requests a playback rate change.                                        |
+| `options.pauseAfterSeek` | `boolean \| number`      | If `true`, pauses after seeking. If a number, pauses after a delay of that many milliseconds. |
 
 #### Returns
 
@@ -200,9 +200,9 @@ video.reportAd(isInAd: boolean): void
 
 Convenience shortcut for reporting ad state directly from the context. Notifies the party that the user is viewing an ad so synchronization can be paused.
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `isInAd` | `boolean` | Whether an ad is currently playing. |
+| Parameter | Type      | Description                         |
+| --------- | --------- | ----------------------------------- |
+| `isInAd`  | `boolean` | Whether an ad is currently playing. |
 
 ::: tip
 Ad-exit transitions (`false`) have a 500ms debounce to prevent flickering when ads change rapidly between segments.
@@ -227,8 +227,8 @@ video.reportBuffering(isBuffering: boolean): void
 
 Convenience shortcut for reporting buffering state directly from the context. Notifies the party that the video is buffering so synchronization can account for it.
 
-| Parameter | Type | Description |
-| --- | --- | --- |
+| Parameter     | Type      | Description                               |
+| ------------- | --------- | ----------------------------------------- |
 | `isBuffering` | `boolean` | Whether the video is currently buffering. |
 
 ::: tip
@@ -258,11 +258,11 @@ Sets metadata about the current page that is displayed to other party members.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `info.title` | `string` | The title of the content being viewed. |
-| `info.subtitle` | `string` | A subtitle or secondary description. |
-| `info.thumbnail` | `string` | A URL to a thumbnail image. |
+| Parameter        | Type     | Description                            |
+| ---------------- | -------- | -------------------------------------- |
+| `info.title`     | `string` | The title of the content being viewed. |
+| `info.subtitle`  | `string` | A subtitle or secondary description.   |
+| `info.thumbnail` | `string` | A URL to a thumbnail image.            |
 
 #### Example
 
@@ -290,9 +290,9 @@ Reports that the user is blocked from viewing the content. Use this for login wa
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `reason` | `string` | A human-readable description of why access is blocked. |
+| Parameter | Type     | Description                                            |
+| --------- | -------- | ------------------------------------------------------ |
+| `reason`  | `string` | A human-readable description of why access is blocked. |
 
 #### Example
 
@@ -338,10 +338,10 @@ Sends arbitrary data to other party members. Useful for syncing application-spec
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | A unique key identifying the data type. Must be 1-32 characters, alphanumeric with hyphens and underscores only. |
-| `data` | `unknown` | The data to send. Must be serializable. |
+| Parameter | Type      | Description                                                                                                      |
+| --------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
+| `key`     | `string`  | A unique key identifying the data type. Must be 1-32 characters, alphanumeric with hyphens and underscores only. |
+| `data`    | `unknown` | The data to send. Must be serializable.                                                                          |
 
 #### Example
 
@@ -363,10 +363,10 @@ Subscribes to custom data sent by other party members for the given key.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The key to listen for. Must be 1-32 characters, alphanumeric with hyphens and underscores only. |
-| `handler` | `(data: unknown) => void` | Called when data is received for this key. |
+| Parameter | Type                      | Description                                                                                     |
+| --------- | ------------------------- | ----------------------------------------------------------------------------------------------- |
+| `key`     | `string`                  | The key to listen for. Must be 1-32 characters, alphanumeric with hyphens and underscores only. |
+| `handler` | `(data: unknown) => void` | Called when data is received for this key.                                                      |
 
 #### Returns
 
@@ -406,11 +406,11 @@ Sends a one-way message to a specific iframe.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `frameId` | `string` | The identifier of the target iframe. |
-| `key` | `string` | The message key. |
-| `data` | `unknown` | Optional data payload. |
+| Parameter | Type      | Description                          |
+| --------- | --------- | ------------------------------------ |
+| `frameId` | `string`  | The identifier of the target iframe. |
+| `key`     | `string`  | The message key.                     |
+| `data`    | `unknown` | Optional data payload.               |
 
 #### Example
 
@@ -432,11 +432,11 @@ Sends a request to an iframe and waits for a response.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `frameId` | `string` | The identifier of the target iframe. |
-| `key` | `string` | The request key. |
-| `data` | `unknown` | Optional request payload. |
+| Parameter | Type      | Description                          |
+| --------- | --------- | ------------------------------------ |
+| `frameId` | `string`  | The identifier of the target iframe. |
+| `key`     | `string`  | The request key.                     |
+| `data`    | `unknown` | Optional request payload.            |
 
 #### Returns
 
@@ -466,9 +466,9 @@ Listens for one-way messages from iframes.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The message key to listen for. |
+| Parameter | Type                      | Description                                           |
+| --------- | ------------------------- | ----------------------------------------------------- |
+| `key`     | `string`                  | The message key to listen for.                        |
 | `handler` | `(data: unknown) => void` | Called when a message with the given key is received. |
 
 #### Returns
@@ -497,9 +497,9 @@ Listens for requests from iframes and provides a response.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The request key to listen for. |
+| Parameter | Type                         | Description                                                                       |
+| --------- | ---------------------------- | --------------------------------------------------------------------------------- |
+| `key`     | `string`                     | The request key to listen for.                                                    |
 | `handler` | `(data: unknown) => unknown` | Called when a request is received. The return value is sent back as the response. |
 
 #### Returns
@@ -532,10 +532,10 @@ Sends a one-way message to the main world.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The message key. |
-| `data` | `unknown` | Optional data payload. |
+| Parameter | Type      | Description            |
+| --------- | --------- | ---------------------- |
+| `key`     | `string`  | The message key.       |
+| `data`    | `unknown` | Optional data payload. |
 
 #### Example
 
@@ -557,10 +557,10 @@ Sends a request to the main world and waits for a response.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The request key. |
-| `data` | `unknown` | Optional request payload. |
+| Parameter | Type      | Description               |
+| --------- | --------- | ------------------------- |
+| `key`     | `string`  | The request key.          |
+| `data`    | `unknown` | Optional request payload. |
 
 #### Returns
 
@@ -590,9 +590,9 @@ Listens for one-way messages from the main world.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The message key to listen for. |
+| Parameter | Type                      | Description                                           |
+| --------- | ------------------------- | ----------------------------------------------------- |
+| `key`     | `string`                  | The message key to listen for.                        |
 | `handler` | `(data: unknown) => void` | Called when a message with the given key is received. |
 
 #### Returns
@@ -611,9 +611,9 @@ Listens for requests from the main world and provides a response.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `key` | `string` | The request key to listen for. |
+| Parameter | Type                         | Description                                                                       |
+| --------- | ---------------------------- | --------------------------------------------------------------------------------- |
+| `key`     | `string`                     | The request key to listen for.                                                    |
 | `handler` | `(data: unknown) => unknown` | Called when a request is received. The return value is sent back as the response. |
 
 #### Returns
@@ -676,8 +676,8 @@ Subscribes to role changes.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
+| Parameter | Type                     | Description                          |
+| --------- | ------------------------ | ------------------------------------ |
 | `handler` | `(role: string) => void` | Called when the user's role changes. |
 
 #### Returns
@@ -696,8 +696,8 @@ Subscribes to pause state changes.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
+| Parameter | Type                        | Description                                |
+| --------- | --------------------------- | ------------------------------------------ |
 | `handler` | `(paused: boolean) => void` | Called when the party pause state changes. |
 
 #### Returns
@@ -716,8 +716,8 @@ Subscribes to active state changes.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| --- | --- | --- |
+| Parameter | Type                        | Description                                 |
+| --------- | --------------------------- | ------------------------------------------- |
 | `handler` | `(active: boolean) => void` | Called when the party active state changes. |
 
 #### Returns

--- a/docs/v1/api/sync-script-types.md
+++ b/docs/v1/api/sync-script-types.md
@@ -10,163 +10,163 @@ For a detailed guide on using the `SyncScriptContext` object, see the [Sync Scri
 
 Defines the entry point for a sync script. The `setup` function receives a [SyncScriptContext](#syncscriptcontext) and may return a cleanup function.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `setup` | `(ctx: SyncScriptContext) => (() => void) \| void` | Called when the sync script is initialized; may return a teardown function. |
-| `onNavigate` | `(ctx: SyncScriptContext, url: string) => void` | Called when the user navigates to a new URL within the same activity. |
+| Property     | Type                                               | Description                                                                 |
+| ------------ | -------------------------------------------------- | --------------------------------------------------------------------------- |
+| `setup`      | `(ctx: SyncScriptContext) => (() => void) \| void` | Called when the sync script is initialized; may return a teardown function. |
+| `onNavigate` | `(ctx: SyncScriptContext, url: string) => void`    | Called when the user navigates to a new URL within the same activity.       |
 
 ## SyncScriptHandle
 
 A handle returned when a sync script is loaded, used to tear it down.
 
-| Property | Type | Description |
-| --- | --- | --- |
+| Property  | Type         | Description                                                        |
+| --------- | ------------ | ------------------------------------------------------------------ |
 | `destroy` | `() => void` | Destroys the sync script and runs any cleanup returned by `setup`. |
 
 ## SyncScriptContext
 
 The main context object passed to sync script lifecycle hooks. See the [Sync Script Context API reference](/v1/api/sync-script-context) for full usage details.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `features` | `(features: { video?: boolean, cursor?: boolean, scroll?: boolean }) => void` | Declares which sync features this script supports. |
-| `video` | `object` | Namespace for video synchronization methods; see below. |
-| `video.attach` | `(element: HTMLMediaElement \| string) => AutoVideoHandle` | Attaches to a media element for automatic playback tracking. Returns an [AutoVideoHandle](#autovideohandle). |
-| `video.takeControl` | `(options: TakeControlOptions) => ManualVideoHandle` | Takes manual control of playback synchronization. Returns a [ManualVideoHandle](#manualvideohandle). |
-| `video.reportAd` | `(isInAd: boolean) => void` | Reports whether an ad is currently playing. |
-| `video.reportBuffering` | `(isBuffering: boolean) => void` | Reports whether the video is currently buffering. |
-| `setPageInfo` | `(info: PageInfo) => void` | Sets the current page metadata shown to party members. |
-| `reportBlocked` | `(reason: string) => void` | Reports that synchronization is blocked, with a human-readable reason. |
-| `reportUnblocked` | `() => void` | Clears a previously reported blocked state. |
-| `sendCustomData` | `(key: string, data: unknown) => void` | Sends custom data to other party members. |
-| `onCustomData` | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for custom data from other party members; returns an unsubscribe function. |
-| `iframe` | `IframeMessaging` | Messaging namespace for communicating with iframes. See [IframeMessaging](#iframemessaging). |
-| `mainworld` | `MessagingNamespace` | Messaging namespace for communicating with the main world context. See [MessagingNamespace](#messagingnamespace). |
-| `party` | `PartyState` | Reactive state of the current Watch Party session. See [PartyState](#partystate). |
+| Property                | Type                                                                          | Description                                                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `features`              | `(features: { video?: boolean, cursor?: boolean, scroll?: boolean }) => void` | Declares which sync features this script supports.                                                                |
+| `video`                 | `object`                                                                      | Namespace for video synchronization methods; see below.                                                           |
+| `video.attach`          | `(element: HTMLMediaElement \| string) => AutoVideoHandle`                    | Attaches to a media element for automatic playback tracking. Returns an [AutoVideoHandle](#autovideohandle).      |
+| `video.takeControl`     | `(options: TakeControlOptions) => ManualVideoHandle`                          | Takes manual control of playback synchronization. Returns a [ManualVideoHandle](#manualvideohandle).              |
+| `video.reportAd`        | `(isInAd: boolean) => void`                                                   | Reports whether an ad is currently playing.                                                                       |
+| `video.reportBuffering` | `(isBuffering: boolean) => void`                                              | Reports whether the video is currently buffering.                                                                 |
+| `setPageInfo`           | `(info: PageInfo) => void`                                                    | Sets the current page metadata shown to party members.                                                            |
+| `reportBlocked`         | `(reason: string) => void`                                                    | Reports that synchronization is blocked, with a human-readable reason.                                            |
+| `reportUnblocked`       | `() => void`                                                                  | Clears a previously reported blocked state.                                                                       |
+| `sendCustomData`        | `(key: string, data: unknown) => void`                                        | Sends custom data to other party members.                                                                         |
+| `onCustomData`          | `(key: string, handler: (data: unknown) => void) => () => void`               | Listens for custom data from other party members; returns an unsubscribe function.                                |
+| `iframe`                | `IframeMessaging`                                                             | Messaging namespace for communicating with iframes. See [IframeMessaging](#iframemessaging).                      |
+| `mainworld`             | `MessagingNamespace`                                                          | Messaging namespace for communicating with the main world context. See [MessagingNamespace](#messagingnamespace). |
+| `party`                 | `PartyState`                                                                  | Reactive state of the current Watch Party session. See [PartyState](#partystate).                                 |
 
 ## TakeControlOptions
 
 Options passed to `video.takeControl()` for manual playback synchronization.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `onPlay` | `(timeSeconds: number) => void` | Called when the party requests playback to start at the given time. |
-| `onPause` | `(timeSeconds: number) => void` | Called when the party requests playback to pause at the given time. |
-| `onSeek` | `(timeSeconds: number) => void` | Called when the party requests a seek to the given time. |
-| `onRate` | `(playbackRate: number) => void` | Called when the party requests a playback rate change. |
-| `pauseAfterSeek` | `boolean \| number` | Whether to pause after seeking, or a delay in milliseconds before resuming. |
+| Property         | Type                             | Description                                                                 |
+| ---------------- | -------------------------------- | --------------------------------------------------------------------------- |
+| `onPlay`         | `(timeSeconds: number) => void`  | Called when the party requests playback to start at the given time.         |
+| `onPause`        | `(timeSeconds: number) => void`  | Called when the party requests playback to pause at the given time.         |
+| `onSeek`         | `(timeSeconds: number) => void`  | Called when the party requests a seek to the given time.                    |
+| `onRate`         | `(playbackRate: number) => void` | Called when the party requests a playback rate change.                      |
+| `pauseAfterSeek` | `boolean \| number`              | Whether to pause after seeking, or a delay in milliseconds before resuming. |
 
 ## AutoVideoHandle
 
 Returned by `video.attach()`. Manages automatic video tracking for a media element.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `detach` | `() => void` | Detaches from the media element and stops tracking. |
-| `onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
-| `reportAd` | `(isInAd: boolean) => void` | Reports whether an ad is currently playing on this video. |
-| `reportBuffering` | `(isBuffering: boolean) => void` | Reports whether this video is currently buffering. |
+| Property          | Type                                                  | Description                                                                      |
+| ----------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `detach`          | `() => void`                                          | Detaches from the media element and stops tracking.                              |
+| `onSyncCommand`   | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
+| `reportAd`        | `(isInAd: boolean) => void`                           | Reports whether an ad is currently playing on this video.                        |
+| `reportBuffering` | `(isBuffering: boolean) => void`                      | Reports whether this video is currently buffering.                               |
 
 ## ManualVideoHandle
 
 Returned by `video.takeControl()`. Provides manual control over playback reporting.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `reportPlayback` | `(status: PlaybackReport) => void` | Reports the current playback state to the party. See [PlaybackReport](#playbackreport). |
-| `onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
-| `reportAd` | `(isInAd: boolean) => void` | Reports whether an ad is currently playing. |
-| `reportBuffering` | `(isBuffering: boolean) => void` | Reports whether the video is currently buffering. |
-| `release` | `() => void` | Releases manual control and stops reporting playback. |
+| Property          | Type                                                  | Description                                                                             |
+| ----------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `reportPlayback`  | `(status: PlaybackReport) => void`                    | Reports the current playback state to the party. See [PlaybackReport](#playbackreport). |
+| `onSyncCommand`   | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function.        |
+| `reportAd`        | `(isInAd: boolean) => void`                           | Reports whether an ad is currently playing.                                             |
+| `reportBuffering` | `(isBuffering: boolean) => void`                      | Reports whether the video is currently buffering.                                       |
+| `release`         | `() => void`                                          | Releases manual control and stops reporting playback.                                   |
 
 ## PlaybackReport
 
 Describes the current playback state, sent via `ManualVideoHandle.reportPlayback()`.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `playing` | `boolean` | Whether the video is currently playing. |
-| `currentTime` | `number` | Current playback position in seconds. |
-| `duration` | `number` | Total duration of the video in seconds. |
-| `playbackRate` | `number` | Current playback rate (e.g., `1.0` for normal speed). |
+| Property       | Type      | Description                                           |
+| -------------- | --------- | ----------------------------------------------------- |
+| `playing`      | `boolean` | Whether the video is currently playing.               |
+| `currentTime`  | `number`  | Current playback position in seconds.                 |
+| `duration`     | `number`  | Total duration of the video in seconds.               |
+| `playbackRate` | `number`  | Current playback rate (e.g., `1.0` for normal speed). |
 
 ## SyncCommand
 
 A synchronization command received from the Watch Party server.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `action` | `'play' \| 'pause' \| 'seek' \| 'rate'` | The type of synchronization action to perform. |
-| `currentTime` | `number` | The target playback time in seconds. |
-| `playbackRate` | `number` | The target playback rate. |
-| `capturedAt` | `number` | Timestamp when the command was captured by the sender. |
-| `serverTs` | `number` | Server timestamp when the command was processed. |
-| `clockOffset` | `number` | Estimated clock offset between client and server in milliseconds. |
-| `isHeartbeat` | `boolean` | Whether this command is a periodic heartbeat rather than a user action. |
+| Property       | Type                                    | Description                                                             |
+| -------------- | --------------------------------------- | ----------------------------------------------------------------------- |
+| `action`       | `'play' \| 'pause' \| 'seek' \| 'rate'` | The type of synchronization action to perform.                          |
+| `currentTime`  | `number`                                | The target playback time in seconds.                                    |
+| `playbackRate` | `number`                                | The target playback rate.                                               |
+| `capturedAt`   | `number`                                | Timestamp when the command was captured by the sender.                  |
+| `serverTs`     | `number`                                | Server timestamp when the command was processed.                        |
+| `clockOffset`  | `number`                                | Estimated clock offset between client and server in milliseconds.       |
+| `isHeartbeat`  | `boolean`                               | Whether this command is a periodic heartbeat rather than a user action. |
 
 ## PageInfo
 
 Metadata about the current page, displayed to party members.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `title` | `string` | The title of the current content (e.g., video title). |
-| `subtitle` | `string` | A subtitle or secondary label (e.g., channel name). |
-| `thumbnail` | `string` | URL of a thumbnail image for the current content. |
+| Property    | Type     | Description                                           |
+| ----------- | -------- | ----------------------------------------------------- |
+| `title`     | `string` | The title of the current content (e.g., video title). |
+| `subtitle`  | `string` | A subtitle or secondary label (e.g., channel name).   |
+| `thumbnail` | `string` | URL of a thumbnail image for the current content.     |
 
 ## PartyState
 
 Reactive state representing the current Watch Party session.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `role` | `'controller' \| 'follower'` | The current user's role in the party. |
-| `paused` | `boolean` | Whether the party playback is currently paused. |
-| `active` | `boolean` | Whether the Watch Party session is currently active. |
-| `isHost` | `boolean` | Whether the current user is the host of the party. |
-| `onRoleChange` | `(handler: (role: 'controller' \| 'follower') => void) => () => void` | Registers a handler called when the user's role changes; returns an unsubscribe function. |
-| `onPauseChange` | `(handler: (paused: boolean) => void) => () => void` | Registers a handler called when the pause state changes; returns an unsubscribe function. |
-| `onActiveChange` | `(handler: (active: boolean) => void) => () => void` | Registers a handler called when the active state changes; returns an unsubscribe function. |
+| Property         | Type                                                                  | Description                                                                                |
+| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `role`           | `'controller' \| 'follower'`                                          | The current user's role in the party.                                                      |
+| `paused`         | `boolean`                                                             | Whether the party playback is currently paused.                                            |
+| `active`         | `boolean`                                                             | Whether the Watch Party session is currently active.                                       |
+| `isHost`         | `boolean`                                                             | Whether the current user is the host of the party.                                         |
+| `onRoleChange`   | `(handler: (role: 'controller' \| 'follower') => void) => () => void` | Registers a handler called when the user's role changes; returns an unsubscribe function.  |
+| `onPauseChange`  | `(handler: (paused: boolean) => void) => () => void`                  | Registers a handler called when the pause state changes; returns an unsubscribe function.  |
+| `onActiveChange` | `(handler: (active: boolean) => void) => () => void`                  | Registers a handler called when the active state changes; returns an unsubscribe function. |
 
 ## MessagingNamespace
 
 A messaging namespace for sending and receiving messages between contexts (e.g., content script and main world).
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `send` | `(key: string, data: unknown) => void` | Sends a fire-and-forget message with the given key. |
-| `request` | `(key: string, data: unknown) => Promise<unknown>` | Sends a message and waits for a response. |
-| `onMessage` | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for messages with the given key; returns an unsubscribe function. |
+| Property    | Type                                                                                   | Description                                                                                      |
+| ----------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `send`      | `(key: string, data: unknown) => void`                                                 | Sends a fire-and-forget message with the given key.                                              |
+| `request`   | `(key: string, data: unknown) => Promise<unknown>`                                     | Sends a message and waits for a response.                                                        |
+| `onMessage` | `(key: string, handler: (data: unknown) => void) => () => void`                        | Listens for messages with the given key; returns an unsubscribe function.                        |
 | `onRequest` | `(key: string, handler: (data: unknown) => unknown \| Promise<unknown>) => () => void` | Listens for requests with the given key and returns a response; returns an unsubscribe function. |
 
 ## IframeMessaging
 
 A messaging namespace for communicating between content scripts and iframes, with frame identification.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `send` | `(frameId: number, key: string, data: unknown) => void` | Sends a fire-and-forget message to a specific iframe by frame ID. |
-| `request` | `(frameId: number, key: string, data: unknown) => Promise<unknown>` | Sends a message to a specific iframe and waits for a response. |
-| `onMessage` | `(key: string, handler: (data: unknown, frameId: number) => void) => () => void` | Listens for messages from any iframe; handler receives the sender's frame ID. Returns an unsubscribe function. |
+| Property    | Type                                                                                                    | Description                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `send`      | `(frameId: number, key: string, data: unknown) => void`                                                 | Sends a fire-and-forget message to a specific iframe by frame ID.                                              |
+| `request`   | `(frameId: number, key: string, data: unknown) => Promise<unknown>`                                     | Sends a message to a specific iframe and waits for a response.                                                 |
+| `onMessage` | `(key: string, handler: (data: unknown, frameId: number) => void) => () => void`                        | Listens for messages from any iframe; handler receives the sender's frame ID. Returns an unsubscribe function. |
 | `onRequest` | `(key: string, handler: (data: unknown, frameId: number) => unknown \| Promise<unknown>) => () => void` | Listens for requests from any iframe; handler receives the sender's frame ID. Returns an unsubscribe function. |
 
 ## SyncIframeContext
 
 Context object available inside an iframe sync script.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `video` | `object` | Namespace for video synchronization within the iframe. |
-| `video.attach` | `(element: HTMLMediaElement \| string) => AutoVideoHandle` | Attaches to a media element for automatic playback tracking. Returns an [AutoVideoHandle](#autovideohandle). |
-| `video.onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
-| `sendCustomData` | `(key: string, data: unknown) => void` | Sends custom data to the parent content script. |
-| `onCustomData` | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for custom data from the parent content script; returns an unsubscribe function. |
-| `content` | `MessagingNamespace` | Messaging namespace for communicating with the parent content script. See [MessagingNamespace](#messagingnamespace). |
+| Property              | Type                                                            | Description                                                                                                          |
+| --------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `video`               | `object`                                                        | Namespace for video synchronization within the iframe.                                                               |
+| `video.attach`        | `(element: HTMLMediaElement \| string) => AutoVideoHandle`      | Attaches to a media element for automatic playback tracking. Returns an [AutoVideoHandle](#autovideohandle).         |
+| `video.onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void`           | Registers a handler for incoming sync commands; returns an unsubscribe function.                                     |
+| `sendCustomData`      | `(key: string, data: unknown) => void`                          | Sends custom data to the parent content script.                                                                      |
+| `onCustomData`        | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for custom data from the parent content script; returns an unsubscribe function.                             |
+| `content`             | `MessagingNamespace`                                            | Messaging namespace for communicating with the parent content script. See [MessagingNamespace](#messagingnamespace). |
 
 ## SyncMainworldContext
 
 Context object available inside a main world sync script.
 
-| Property | Type | Description |
-| --- | --- | --- |
+| Property  | Type                 | Description                                                                                                   |
+| --------- | -------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `content` | `MessagingNamespace` | Messaging namespace for communicating with the content script. See [MessagingNamespace](#messagingnamespace). |

--- a/docs/v1/api/sync-script-types.md
+++ b/docs/v1/api/sync-script-types.md
@@ -1,0 +1,172 @@
+# Sync Script Types
+
+These are the TypeScript interfaces used by sync scripts to integrate with Watch Party functionality. Sync scripts allow activities to synchronize video playback, cursor positions, and scroll state across party members.
+
+::: tip
+For a detailed guide on using the `SyncScriptContext` object, see the [Sync Script Context API reference](/v1/api/sync-script-context).
+:::
+
+## SyncScriptDefinition
+
+Defines the entry point for a sync script. The `setup` function receives a [SyncScriptContext](#syncscriptcontext) and may return a cleanup function.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `setup` | `(ctx: SyncScriptContext) => (() => void) \| void` | Called when the sync script is initialized; may return a teardown function. |
+| `onNavigate` | `(ctx: SyncScriptContext, url: string) => void` | Called when the user navigates to a new URL within the same activity. |
+
+## SyncScriptHandle
+
+A handle returned when a sync script is loaded, used to tear it down.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `destroy` | `() => void` | Destroys the sync script and runs any cleanup returned by `setup`. |
+
+## SyncScriptContext
+
+The main context object passed to sync script lifecycle hooks. See the [Sync Script Context API reference](/v1/api/sync-script-context) for full usage details.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `features` | `(features: { video?: boolean, cursor?: boolean, scroll?: boolean }) => void` | Declares which sync features this script supports. |
+| `video` | `object` | Namespace for video synchronization methods; see below. |
+| `video.attach` | `(element: HTMLMediaElement \| string) => AutoVideoHandle` | Attaches to a media element for automatic playback tracking. Returns an [AutoVideoHandle](#autovideohandle). |
+| `video.takeControl` | `(options: TakeControlOptions) => ManualVideoHandle` | Takes manual control of playback synchronization. Returns a [ManualVideoHandle](#manualvideohandle). |
+| `video.reportAd` | `(isInAd: boolean) => void` | Reports whether an ad is currently playing. |
+| `video.reportBuffering` | `(isBuffering: boolean) => void` | Reports whether the video is currently buffering. |
+| `setPageInfo` | `(info: PageInfo) => void` | Sets the current page metadata shown to party members. |
+| `reportBlocked` | `(reason: string) => void` | Reports that synchronization is blocked, with a human-readable reason. |
+| `reportUnblocked` | `() => void` | Clears a previously reported blocked state. |
+| `sendCustomData` | `(key: string, data: unknown) => void` | Sends custom data to other party members. |
+| `onCustomData` | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for custom data from other party members; returns an unsubscribe function. |
+| `iframe` | `IframeMessaging` | Messaging namespace for communicating with iframes. See [IframeMessaging](#iframemessaging). |
+| `mainworld` | `MessagingNamespace` | Messaging namespace for communicating with the main world context. See [MessagingNamespace](#messagingnamespace). |
+| `party` | `PartyState` | Reactive state of the current Watch Party session. See [PartyState](#partystate). |
+
+## TakeControlOptions
+
+Options passed to `video.takeControl()` for manual playback synchronization.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `onPlay` | `(timeSeconds: number) => void` | Called when the party requests playback to start at the given time. |
+| `onPause` | `(timeSeconds: number) => void` | Called when the party requests playback to pause at the given time. |
+| `onSeek` | `(timeSeconds: number) => void` | Called when the party requests a seek to the given time. |
+| `onRate` | `(playbackRate: number) => void` | Called when the party requests a playback rate change. |
+| `pauseAfterSeek` | `boolean \| number` | Whether to pause after seeking, or a delay in milliseconds before resuming. |
+
+## AutoVideoHandle
+
+Returned by `video.attach()`. Manages automatic video tracking for a media element.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `detach` | `() => void` | Detaches from the media element and stops tracking. |
+| `onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
+| `reportAd` | `(isInAd: boolean) => void` | Reports whether an ad is currently playing on this video. |
+| `reportBuffering` | `(isBuffering: boolean) => void` | Reports whether this video is currently buffering. |
+
+## ManualVideoHandle
+
+Returned by `video.takeControl()`. Provides manual control over playback reporting.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `reportPlayback` | `(status: PlaybackReport) => void` | Reports the current playback state to the party. See [PlaybackReport](#playbackreport). |
+| `onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
+| `reportAd` | `(isInAd: boolean) => void` | Reports whether an ad is currently playing. |
+| `reportBuffering` | `(isBuffering: boolean) => void` | Reports whether the video is currently buffering. |
+| `release` | `() => void` | Releases manual control and stops reporting playback. |
+
+## PlaybackReport
+
+Describes the current playback state, sent via `ManualVideoHandle.reportPlayback()`.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `playing` | `boolean` | Whether the video is currently playing. |
+| `currentTime` | `number` | Current playback position in seconds. |
+| `duration` | `number` | Total duration of the video in seconds. |
+| `playbackRate` | `number` | Current playback rate (e.g., `1.0` for normal speed). |
+
+## SyncCommand
+
+A synchronization command received from the Watch Party server.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `action` | `'play' \| 'pause' \| 'seek' \| 'rate'` | The type of synchronization action to perform. |
+| `currentTime` | `number` | The target playback time in seconds. |
+| `playbackRate` | `number` | The target playback rate. |
+| `capturedAt` | `number` | Timestamp when the command was captured by the sender. |
+| `serverTs` | `number` | Server timestamp when the command was processed. |
+| `clockOffset` | `number` | Estimated clock offset between client and server in milliseconds. |
+| `isHeartbeat` | `boolean` | Whether this command is a periodic heartbeat rather than a user action. |
+
+## PageInfo
+
+Metadata about the current page, displayed to party members.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `title` | `string` | The title of the current content (e.g., video title). |
+| `subtitle` | `string` | A subtitle or secondary label (e.g., channel name). |
+| `thumbnail` | `string` | URL of a thumbnail image for the current content. |
+
+## PartyState
+
+Reactive state representing the current Watch Party session.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `role` | `'controller' \| 'follower'` | The current user's role in the party. |
+| `paused` | `boolean` | Whether the party playback is currently paused. |
+| `active` | `boolean` | Whether the Watch Party session is currently active. |
+| `isHost` | `boolean` | Whether the current user is the host of the party. |
+| `onRoleChange` | `(handler: (role: 'controller' \| 'follower') => void) => () => void` | Registers a handler called when the user's role changes; returns an unsubscribe function. |
+| `onPauseChange` | `(handler: (paused: boolean) => void) => () => void` | Registers a handler called when the pause state changes; returns an unsubscribe function. |
+| `onActiveChange` | `(handler: (active: boolean) => void) => () => void` | Registers a handler called when the active state changes; returns an unsubscribe function. |
+
+## MessagingNamespace
+
+A messaging namespace for sending and receiving messages between contexts (e.g., content script and main world).
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `send` | `(key: string, data: unknown) => void` | Sends a fire-and-forget message with the given key. |
+| `request` | `(key: string, data: unknown) => Promise<unknown>` | Sends a message and waits for a response. |
+| `onMessage` | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for messages with the given key; returns an unsubscribe function. |
+| `onRequest` | `(key: string, handler: (data: unknown) => unknown \| Promise<unknown>) => () => void` | Listens for requests with the given key and returns a response; returns an unsubscribe function. |
+
+## IframeMessaging
+
+A messaging namespace for communicating between content scripts and iframes, with frame identification.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `send` | `(frameId: number, key: string, data: unknown) => void` | Sends a fire-and-forget message to a specific iframe by frame ID. |
+| `request` | `(frameId: number, key: string, data: unknown) => Promise<unknown>` | Sends a message to a specific iframe and waits for a response. |
+| `onMessage` | `(key: string, handler: (data: unknown, frameId: number) => void) => () => void` | Listens for messages from any iframe; handler receives the sender's frame ID. Returns an unsubscribe function. |
+| `onRequest` | `(key: string, handler: (data: unknown, frameId: number) => unknown \| Promise<unknown>) => () => void` | Listens for requests from any iframe; handler receives the sender's frame ID. Returns an unsubscribe function. |
+
+## SyncIframeContext
+
+Context object available inside an iframe sync script.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `video` | `object` | Namespace for video synchronization within the iframe. |
+| `video.attach` | `(element: HTMLMediaElement \| string) => AutoVideoHandle` | Attaches to a media element for automatic playback tracking. Returns an [AutoVideoHandle](#autovideohandle). |
+| `video.onSyncCommand` | `(handler: (cmd: SyncCommand) => void) => () => void` | Registers a handler for incoming sync commands; returns an unsubscribe function. |
+| `sendCustomData` | `(key: string, data: unknown) => void` | Sends custom data to the parent content script. |
+| `onCustomData` | `(key: string, handler: (data: unknown) => void) => () => void` | Listens for custom data from the parent content script; returns an unsubscribe function. |
+| `content` | `MessagingNamespace` | Messaging namespace for communicating with the parent content script. See [MessagingNamespace](#messagingnamespace). |
+
+## SyncMainworldContext
+
+Context object available inside a main world sync script.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `content` | `MessagingNamespace` | Messaging namespace for communicating with the content script. See [MessagingNamespace](#messagingnamespace). |

--- a/docs/v1/examples/watch-party.md
+++ b/docs/v1/examples/watch-party.md
@@ -1,0 +1,325 @@
+# Watch Party Sync Script Example
+
+This page provides complete working examples of Watch Party sync scripts for common scenarios.
+
+## Simple Video Sync (Auto Mode)
+
+The simplest sync script — for sites with a standard `<video>` element:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    const video = document.querySelector('video')
+    if (!video) return
+
+    const handle = ctx.video.attach(video)
+
+    const title = document.querySelector('h1')?.textContent
+    if (title) {
+      ctx.setPageInfo({ title })
+    }
+
+    return () => {
+      handle.detach()
+    }
+  },
+
+  onNavigate(ctx, url) {
+    // SPA navigation — re-attach to the new video element
+    const video = document.querySelector('video')
+    if (video) {
+      ctx.video.attach(video)
+
+      const title = document.querySelector('h1')?.textContent
+      if (title) {
+        ctx.setPageInfo({ title })
+      }
+    }
+  },
+})
+```
+
+## Custom Player Sync (Manual Mode)
+
+For sites with a proprietary JavaScript player API (e.g., the player isn't a standard `<video>` element):
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    // Assume the site exposes a global player object
+    const player = (window as any).sitePlayer
+    if (!player) return
+
+    const handle = ctx.video.takeControl({
+      onPlay(timeSeconds) {
+        player.seekTo(timeSeconds)
+        player.play()
+      },
+      onPause(timeSeconds) {
+        player.pause()
+        player.seekTo(timeSeconds)
+      },
+      onSeek(timeSeconds) {
+        player.seekTo(timeSeconds)
+      },
+      onRate(rate) {
+        player.setPlaybackRate(rate)
+      },
+    })
+
+    // Report playback state every second
+    const interval = setInterval(() => {
+      handle.reportPlayback({
+        playing: player.isPlaying(),
+        currentTime: player.getCurrentTime(),
+        duration: player.getDuration(),
+        playbackRate: player.getPlaybackRate(),
+      })
+    }, 1000)
+
+    ctx.setPageInfo({
+      title: player.getTitle(),
+      subtitle: player.getEpisodeName(),
+      thumbnail: player.getThumbnailUrl(),
+    })
+
+    return () => {
+      clearInterval(interval)
+      handle.release()
+    }
+  },
+})
+```
+
+## Handling Ads
+
+Detect and report advertisements using a MutationObserver:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    const video = document.querySelector('video')
+    if (!video) return
+
+    const handle = ctx.video.attach(video)
+
+    // Watch for ad overlay appearance
+    const observer = new MutationObserver(() => {
+      const adOverlay = document.querySelector('.ytp-ad-player-overlay')
+      const adText = document.querySelector('.ytp-ad-text')
+      const isInAd = !!(adOverlay || adText)
+      handle.reportAd(isInAd)
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    })
+
+    return () => {
+      observer.disconnect()
+      handle.detach()
+    }
+  },
+})
+```
+
+::: tip
+Ad exit has a 500ms debounce built in, so rapid transitions between ad segments won't cause the party to constantly pause and resume.
+:::
+
+## iFrame Video Player
+
+When the video is embedded in an iframe (common for sites using third-party players):
+
+### Content Script (`content.ts`)
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    // Request current state from the iframe
+    ctx.iframe.onMessage('playback-update', (data, frameId) => {
+      const { title, episode } = data as { title: string, episode: string }
+      ctx.setPageInfo({ title, subtitle: episode })
+    })
+
+    return () => {}
+  },
+})
+```
+
+### iFrame Script (`iframe.ts`)
+
+<!-- eslint-skip -->
+
+```typescript
+SyncIframeScriptV1.register({
+  setup(ctx) {
+    const video = document.querySelector('video')
+    if (!video) return
+
+    // Attach to the iframe's video element
+    const handle = ctx.video.attach(video)
+
+    // Send metadata to the content script
+    const title = document.querySelector('.player-title')?.textContent ?? ''
+    const episode = document.querySelector('.episode-info')?.textContent ?? ''
+    ctx.content.send('playback-update', { title, episode })
+
+    return () => {
+      handle.detach()
+    }
+  },
+})
+```
+
+## Blocked State Reporting
+
+Detect login walls or geo-restrictions and report them:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    function checkAccess() {
+      const loginWall = document.querySelector('.login-gate, .paywall, .geo-block')
+      if (loginWall) {
+        const reason = loginWall.querySelector('.message')?.textContent || 'Content unavailable'
+        ctx.reportBlocked(reason)
+      } else {
+        ctx.reportUnblocked()
+
+        const video = document.querySelector('video')
+        if (video) {
+          ctx.video.attach(video)
+        }
+      }
+    }
+
+    checkAccess()
+
+    // Re-check when the page content changes
+    const observer = new MutationObserver(checkAccess)
+    observer.observe(document.body, { childList: true, subtree: true })
+
+    return () => {
+      observer.disconnect()
+    }
+  },
+})
+```
+
+## Reacting to Party State Changes
+
+Adapt sync script behavior based on role and party state:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true, cursor: true })
+
+    const video = document.querySelector('video')
+    if (!video) return
+
+    const handle = ctx.video.attach(video)
+
+    // Show a visual indicator based on role
+    const unsubRole = ctx.party.onRoleChange((role) => {
+      if (role === 'controller') {
+        showNotification('You now have control')
+      } else {
+        showNotification('Following the host')
+      }
+    })
+
+    // React to party pause/resume
+    const unsubPause = ctx.party.onPauseChange((paused) => {
+      if (paused) {
+        // Party is paused — you might want to show a "Paused" overlay
+        showPauseOverlay()
+      } else {
+        hidePauseOverlay()
+      }
+    })
+
+    return () => {
+      unsubRole()
+      unsubPause()
+      handle.detach()
+    }
+  },
+})
+```
+
+## Custom Data Between Participants
+
+Synchronize custom settings across party members:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    const video = document.querySelector('video')
+    if (!video) return
+
+    const handle = ctx.video.attach(video)
+
+    // Controller sends subtitle preference to all followers
+    if (ctx.party.role === 'controller') {
+      const subtitleTrack = video.textTracks[0]
+      if (subtitleTrack) {
+        ctx.sendCustomData('subtitles', {
+          lang: subtitleTrack.language,
+          enabled: subtitleTrack.mode === 'showing',
+        })
+      }
+    }
+
+    // All participants receive subtitle commands
+    const unsub = ctx.onCustomData('subtitles', (data) => {
+      const { lang, enabled } = data as { lang: string, enabled: boolean }
+      for (const track of video.textTracks) {
+        if (track.language === lang) {
+          track.mode = enabled ? 'showing' : 'hidden'
+        }
+      }
+    })
+
+    return () => {
+      unsub()
+      handle.detach()
+    }
+  },
+})
+```
+
+## Related
+
+- [Sync Script Guide](/v1/guide/watch-party-sync-scripts) — Step-by-step integration guide
+- [Sync Behavior](/v1/guide/watch-party-behavior) — How drift correction, desync detection, and coordination work
+- [SyncScriptContext API](/v1/api/sync-script-context) — Full API reference
+- [Sync Script Types](/v1/api/sync-script-types) — All TypeScript interfaces

--- a/docs/v1/guide/iframes.md
+++ b/docs/v1/guide/iframes.md
@@ -430,3 +430,4 @@ Now that you understand how to use iFrames in your activity, you can learn more 
 - [Slideshows](/v1/guide/slideshows): Learn how to create a slideshow that alternates between different presence data.
 - [Localization](/v1/guide/localization): Learn how to add support for multiple languages to your activity.
 - [Best Practices](/v1/guide/best-practices): Learn best practices for creating activities.
+- [Watch Party Sync Scripts](/v1/guide/watch-party-sync-scripts#iframe-communication): Learn how to use iFrame communication in Watch Party sync scripts for synchronized video playback.

--- a/docs/v1/guide/watch-party-advanced.md
+++ b/docs/v1/guide/watch-party-advanced.md
@@ -1,0 +1,183 @@
+# Advanced Sync Script Features
+
+This page covers iFrame and mainworld communication, custom data exchange between participants, and reading party state.
+
+## iFrame Communication
+
+When the video player lives inside an iframe, you need a separate sync script for the iframe. See the [iFrames guide](/v1/guide/iframes) for background on iframe communication in PreMiD.
+
+### Content Script Side
+
+<!-- eslint-skip -->
+
+```typescript
+// Send a message to iframe
+ctx.iframe.send(frameId, 'set-quality', { quality: '1080p' })
+
+// Request data from iframe (10s timeout)
+const state = await ctx.iframe.request(frameId, 'get-state', {})
+
+// Listen for messages from iframe
+const unsub = ctx.iframe.onMessage('player-event', (data, frameId) => {
+  console.log('Event from frame', frameId, data)
+})
+```
+
+### iFrame Script Side
+
+The iframe script registers separately and receives a [`SyncIframeContext`](/v1/api/sync-script-types#synciframecontext):
+
+<!-- eslint-skip -->
+
+```typescript
+SyncIframeScriptV1.register({
+  setup(ctx) {
+    const handle = ctx.video.attach('video')
+
+    ctx.content.onMessage('set-quality', (data) => {
+      // Handle quality change
+    })
+
+    return () => handle.detach()
+  },
+})
+```
+
+The iframe script has access to `ctx.video.attach()` for managing video elements inside the iframe, and `ctx.content` for communicating with the content script.
+
+### When to Use iFrame Scripts
+
+Use an iframe script when:
+- The site embeds its video player in an iframe (common for third-party players)
+- You need to access DOM elements inside the iframe
+- The iframe has a different origin than the main page
+
+Don't forget to set `iframeRegExp` in the sync script's `metadata.json` to specify which iframes the script should be injected into.
+
+## Mainworld Communication
+
+For sites that require access to the page's JavaScript context (e.g., proprietary player APIs attached to `window`), use a mainworld script.
+
+### Content Script Side
+
+<!-- eslint-skip -->
+
+```typescript
+// Request data from mainworld
+const playerState = await ctx.mainworld.request('get-player-state', {})
+
+// Listen for messages from mainworld
+const unsub = ctx.mainworld.onMessage('player-event', (data) => {
+  // Handle event from mainworld
+})
+```
+
+### Mainworld Script Side
+
+The mainworld script registers separately and receives a [`SyncMainworldContext`](/v1/api/sync-script-types#syncmainworldcontext):
+
+<!-- eslint-skip -->
+
+```typescript
+SyncMainworldScriptV1.register({
+  setup(ctx) {
+    ctx.content.onRequest('get-player-state', () => {
+      return {
+        playing: window.playerAPI.isPlaying(),
+        currentTime: window.playerAPI.getCurrentTime(),
+      }
+    })
+
+    return () => {
+      // Cleanup
+    }
+  },
+})
+```
+
+::: warning
+Mainworld scripts run in the page's JavaScript context, not the extension's. They cannot access extension APIs or the DOM utilities available to content scripts. Communication with the content script happens exclusively via `ctx.content`.
+:::
+
+### When to Use Mainworld Scripts
+
+Use a mainworld script when:
+- The site exposes a player API on `window` that isn't accessible from the content script
+- You need to intercept or call page-level JavaScript functions
+- The site uses a custom player that can only be controlled through its JS API
+
+## Custom Data
+
+Send arbitrary data between party participants:
+
+<!-- eslint-skip -->
+
+```typescript
+// Controller sends subtitle selection
+ctx.sendCustomData('subtitle-lang', { lang: 'en', enabled: true })
+
+// All participants receive it
+const unsub = ctx.onCustomData('subtitle-lang', (data) => {
+  const { lang, enabled } = data as { lang: string, enabled: boolean }
+  player.setSubtitles(lang, enabled)
+})
+
+// Clean up
+return () => unsub()
+```
+
+::: warning
+Custom data keys must be 1-32 characters, using only letters, numbers, hyphens, and underscores (matching the pattern `[\w-]{1,32}`).
+:::
+
+Custom data is sent to all participants in the party. There's no built-in filtering — the receiving side should check `ctx.party.role` if it only wants to process data from the controller.
+
+## Party State
+
+Read the current party state and react to changes:
+
+<!-- eslint-skip -->
+
+```typescript
+setup(ctx) {
+  console.log(ctx.party.role)    // 'controller' or 'follower'
+  console.log(ctx.party.paused)  // true or false
+  console.log(ctx.party.active)  // true when party is active
+  console.log(ctx.party.isHost)  // true if user created the party
+
+  const unsubRole = ctx.party.onRoleChange((role) => {
+    if (role === 'controller') {
+      // User just became the controller
+    }
+  })
+
+  const unsubPause = ctx.party.onPauseChange((paused) => {
+    if (paused) {
+      player.pause()
+    }
+  })
+
+  return () => {
+    unsubRole()
+    unsubPause()
+  }
+}
+```
+
+All subscription methods return an unsubscribe function. Always call these in your cleanup.
+
+### When Do State Changes Fire?
+
+| Event | Fires when |
+|-------|-----------|
+| `onRoleChange` | The host transfers control to this user, or reclaims it. Also fires if the current controller leaves and control is reassigned. |
+| `onPauseChange` | The host pauses or resumes the party (party-wide pause, not individual video pause). |
+| `onActiveChange` | The Watch Party starts or ends. Note: when the party ends, the cleanup function also runs, so this is rarely needed. |
+
+::: tip
+`ctx.party.role`, `ctx.party.paused`, etc. are always up-to-date — they can be read at any time, not just in callbacks. The callbacks are for reacting to changes, not for initial state.
+:::
+
+### Messaging Timeout
+
+Both `ctx.iframe.request()` and `ctx.mainworld.request()` have a 10-second timeout. If the target doesn't respond within that time, the promise rejects. Make sure the target script is loaded and has a matching `onRequest` handler registered before making requests.

--- a/docs/v1/guide/watch-party-advanced.md
+++ b/docs/v1/guide/watch-party-advanced.md
@@ -48,6 +48,7 @@ The iframe script has access to `ctx.video.attach()` for managing video elements
 ### When to Use iFrame Scripts
 
 Use an iframe script when:
+
 - The site embeds its video player in an iframe (common for third-party players)
 - You need to access DOM elements inside the iframe
 - The iframe has a different origin than the main page
@@ -102,6 +103,7 @@ Mainworld scripts run in the page's JavaScript context, not the extension's. The
 ### When to Use Mainworld Scripts
 
 Use a mainworld script when:
+
 - The site exposes a player API on `window` that isn't accessible from the content script
 - You need to intercept or call page-level JavaScript functions
 - The site uses a custom player that can only be controlled through its JS API
@@ -168,11 +170,11 @@ All subscription methods return an unsubscribe function. Always call these in yo
 
 ### When Do State Changes Fire?
 
-| Event | Fires when |
-|-------|-----------|
-| `onRoleChange` | The host transfers control to this user, or reclaims it. Also fires if the current controller leaves and control is reassigned. |
-| `onPauseChange` | The host pauses or resumes the party (party-wide pause, not individual video pause). |
-| `onActiveChange` | The Watch Party starts or ends. Note: when the party ends, the cleanup function also runs, so this is rarely needed. |
+| Event            | Fires when                                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `onRoleChange`   | The host transfers control to this user, or reclaims it. Also fires if the current controller leaves and control is reassigned. |
+| `onPauseChange`  | The host pauses or resumes the party (party-wide pause, not individual video pause).                                            |
+| `onActiveChange` | The Watch Party starts or ends. Note: when the party ends, the cleanup function also runs, so this is rarely needed.            |
 
 ::: tip
 `ctx.party.role`, `ctx.party.paused`, etc. are always up-to-date — they can be read at any time, not just in callbacks. The callbacks are for reacting to changes, not for initial state.

--- a/docs/v1/guide/watch-party-behavior.md
+++ b/docs/v1/guide/watch-party-behavior.md
@@ -6,10 +6,10 @@ This page explains how the Watch Party synchronization system works under the ho
 
 Every Watch Party has two roles:
 
-| Role | Description |
-|------|-------------|
+| Role           | Description                                                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | **Controller** | The participant whose playback is the source of truth. When the controller plays, pauses, or seeks, all followers mirror the action. |
-| **Follower** | Receives sync commands from the controller and applies them locally. |
+| **Follower**   | Receives sync commands from the controller and applies them locally.                                                                 |
 
 The **host** (party creator) starts as the controller but can transfer control to another participant. The host can also reclaim control at any time.
 
@@ -27,17 +27,18 @@ Even with synchronized commands, network latency causes playback positions to dr
 
 The corrector compares the follower's local playback position against the controller's reported position (adjusted for latency) and applies one of three actions:
 
-| Drift | Action | What Happens |
-|-------|--------|------------|
-| < ~0.15s | Ignore | Within acceptable tolerance, no correction needed |
+| Drift          | Action     | What Happens                                                    |
+| -------------- | ---------- | --------------------------------------------------------------- |
+| < ~0.15s       | Ignore     | Within acceptable tolerance, no correction needed               |
 | ~0.15s - ~3.0s | Rate nudge | Slightly speeds up or slows down playback to gradually converge |
-| > ~3.0s | Hard seek | Jumps directly to the correct position |
+| > ~3.0s        | Hard seek  | Jumps directly to the correct position                          |
 
 Rate nudging adjusts the follower's playback rate by a small amount (up to ±0.03x) to catch up or slow down. Once the drift falls below the tolerance threshold, the original playback rate is restored.
 
 ### Latency Estimation
 
 The extension estimates network latency using two methods:
+
 1. **Server timestamps + clock offset** — The WebSocket server attaches a timestamp, and periodic clock synchronization establishes the offset between client and server clocks.
 2. **Capture timestamps** — When the controller captures a playback event, it records the local timestamp. The follower uses the difference between now and that timestamp as a rough latency estimate.
 
@@ -63,11 +64,11 @@ When a participant encounters an ad, the party can coordinate to prevent desynch
 
 The party host configures how ads are handled:
 
-| Setting | Behavior |
-|---------|----------|
-| **Wait for everyone** | All participants pause when anyone is in an ad |
-| **Wait for host** | Participants only pause when the controller is in an ad |
-| **Ignore** | Ads don't affect synchronization — participants continue playing |
+| Setting               | Behavior                                                         |
+| --------------------- | ---------------------------------------------------------------- |
+| **Wait for everyone** | All participants pause when anyone is in an ad                   |
+| **Wait for host**     | Participants only pause when the controller is in an ad          |
+| **Ignore**            | Ads don't affect synchronization — participants continue playing |
 
 ### Debouncing
 
@@ -102,6 +103,7 @@ The extension detects navigation from the controller's active tab, including bot
 ### Follower Side
 
 When a follower receives a navigation command:
+
 1. The extension navigates the follower's tab to the new URL
 2. If the follower already has an active party tab, it updates that tab
 3. If no party tab exists yet (first navigation after joining), it creates a new tab
@@ -116,6 +118,7 @@ The sync script's `onNavigate` callback fires on SPA navigations so you can re-a
 ### Navigation Settling Window
 
 After a follower navigates, there's a **5-second settling window** where URL changes from the follower's tab are not treated as desyncs. This prevents false desync detection from:
+
 - Server-side redirects (e.g., locale redirects like `/en-us/title/123`)
 - Authentication redirects
 - CDN routing
@@ -136,6 +139,7 @@ When a follower's URL changes outside of a sync-initiated navigation, the extens
 ### What Triggers Desync
 
 A desync is reported when:
+
 - The follower manually navigates to a different site
 - The follower's URL doesn't match after locale and canonical normalization
 - A URL fails to parse entirely
@@ -152,16 +156,16 @@ When desync is detected, the follower sends a `desynced` status with the current
 
 The extension tracks each participant's status:
 
-| Status | Meaning |
-|--------|---------|
-| `ready` | Synchronized and watching normally |
-| `waiting` | Waiting for initial sync or reconnection |
-| `navigating` | Currently navigating to a new page |
-| `in-ad` | Watching an advertisement |
-| `buffering` | Player is buffering content |
-| `not-buffering` | Buffering has ended (transient — resolves to `ready`) |
-| `desynced` | On a different page than the controller |
-| `blocked` | Cannot access the content (login wall, geo-restriction) |
+| Status          | Meaning                                                 |
+| --------------- | ------------------------------------------------------- |
+| `ready`         | Synchronized and watching normally                      |
+| `waiting`       | Waiting for initial sync or reconnection                |
+| `navigating`    | Currently navigating to a new page                      |
+| `in-ad`         | Watching an advertisement                               |
+| `buffering`     | Player is buffering content                             |
+| `not-buffering` | Buffering has ended (transient — resolves to `ready`)   |
+| `desynced`      | On a different page than the controller                 |
+| `blocked`       | Cannot access the content (login wall, geo-restriction) |
 
 Status messages are deduplicated — sending the same status twice in a row is suppressed to reduce WebSocket traffic.
 

--- a/docs/v1/guide/watch-party-behavior.md
+++ b/docs/v1/guide/watch-party-behavior.md
@@ -1,0 +1,182 @@
+# Watch Party Sync Behavior
+
+This page explains how the Watch Party synchronization system works under the hood. Understanding these behaviors helps you write sync scripts that handle edge cases gracefully.
+
+## Role System
+
+Every Watch Party has two roles:
+
+| Role | Description |
+|------|-------------|
+| **Controller** | The participant whose playback is the source of truth. When the controller plays, pauses, or seeks, all followers mirror the action. |
+| **Follower** | Receives sync commands from the controller and applies them locally. |
+
+The **host** (party creator) starts as the controller but can transfer control to another participant. The host can also reclaim control at any time.
+
+The sync script receives role information via `ctx.party.role` and can listen for changes with `ctx.party.onRoleChange()`.
+
+::: tip
+If the sync script needs to behave differently based on role (e.g., only the controller should report playback), check `ctx.party.role` before sending data.
+:::
+
+## Drift Correction
+
+Even with synchronized commands, network latency causes playback positions to drift apart over time. The extension runs a drift correction algorithm on followers to keep them aligned with the controller.
+
+### How It Works
+
+The corrector compares the follower's local playback position against the controller's reported position (adjusted for latency) and applies one of three actions:
+
+| Drift | Action | What Happens |
+|-------|--------|------------|
+| < ~0.15s | Ignore | Within acceptable tolerance, no correction needed |
+| ~0.15s - ~3.0s | Rate nudge | Slightly speeds up or slows down playback to gradually converge |
+| > ~3.0s | Hard seek | Jumps directly to the correct position |
+
+Rate nudging adjusts the follower's playback rate by a small amount (up to ±0.03x) to catch up or slow down. Once the drift falls below the tolerance threshold, the original playback rate is restored.
+
+### Latency Estimation
+
+The extension estimates network latency using two methods:
+1. **Server timestamps + clock offset** — The WebSocket server attaches a timestamp, and periodic clock synchronization establishes the offset between client and server clocks.
+2. **Capture timestamps** — When the controller captures a playback event, it records the local timestamp. The follower uses the difference between now and that timestamp as a rough latency estimate.
+
+### Gentle-Seek Mode
+
+When rate nudging isn't available (e.g., the site doesn't support playback rate changes), the corrector uses gentle-seek mode with a wider tolerance (~0.5s) to avoid excessive seeking.
+
+### Buffering Suspension
+
+Drift correction is automatically suspended while the follower is buffering. This prevents the corrector from repeatedly seeking into an unloaded portion of the video.
+
+## Ad Coordination
+
+When a participant encounters an ad, the party can coordinate to prevent desynchronization.
+
+### How It Works
+
+1. The sync script calls `reportAd(true)` when an ad starts
+2. The extension sends the ad state to all participants
+3. Based on the party's **ad behavior setting**, participants may pause and wait
+
+### Ad Behavior Settings
+
+The party host configures how ads are handled:
+
+| Setting | Behavior |
+|---------|----------|
+| **Wait for everyone** | All participants pause when anyone is in an ad |
+| **Wait for host** | Participants only pause when the controller is in an ad |
+| **Ignore** | Ads don't affect synchronization — participants continue playing |
+
+### Debouncing
+
+Ad exit has a 500ms debounce to prevent flapping. If a site rapidly transitions between ad segments (common on YouTube), the debounce ensures the party doesn't constantly pause and resume.
+
+## Buffering Coordination
+
+Buffering coordination works identically to ad coordination:
+
+1. The sync script calls `reportBuffering(true)` when the player starts buffering
+2. The party can pause and wait based on the **buffering behavior setting**
+3. Buffering exit has a 500ms debounce
+
+The same three settings apply: wait for everyone, wait for host, or ignore.
+
+::: tip
+In auto video mode, buffering is detected automatically via the element's `waiting` and `playing` events. You only need to report buffering manually if the site's player doesn't fire standard media events.
+:::
+
+### Deadlock Prevention
+
+To prevent a deadlock where everyone is waiting for everyone else to stop buffering, the extension ensures that `not-buffering` status is always sent even when the party is in a buffer-pause state. This allows the coordination to resolve once the buffering participant catches up.
+
+## Navigation Sync
+
+When the controller navigates to a new page, the extension synchronizes the URL across all followers.
+
+### Controller Side
+
+The extension detects navigation from the controller's active tab, including both standard page loads and SPA navigations (pushState/replaceState). Duplicate navigate messages for the same URL within 2 seconds are deduplicated.
+
+### Follower Side
+
+When a follower receives a navigation command:
+1. The extension navigates the follower's tab to the new URL
+2. If the follower already has an active party tab, it updates that tab
+3. If no party tab exists yet (first navigation after joining), it creates a new tab
+4. If the tab update fails (e.g., browser error), it falls back to creating a new tab
+
+::: tip
+If a follower closes their party tab, they **automatically leave the party**. The host's tab closure behaves differently — the party migrates to another open web tab instead.
+:::
+
+The sync script's `onNavigate` callback fires on SPA navigations so you can re-attach to new player elements.
+
+### Navigation Settling Window
+
+After a follower navigates, there's a **5-second settling window** where URL changes from the follower's tab are not treated as desyncs. This prevents false desync detection from:
+- Server-side redirects (e.g., locale redirects like `/en-us/title/123`)
+- Authentication redirects
+- CDN routing
+
+## Desync Detection
+
+The extension monitors whether followers are actually on the same page as the controller.
+
+### URL Comparison
+
+When a follower's URL changes outside of a sync-initiated navigation, the extension compares it against the expected URL using several normalization steps:
+
+1. **www-stripping** — `www.netflix.com` and `netflix.com` are treated as the same host
+2. **Locale prefix stripping** — `/nl/title/123` and `/en-us/title/123` are treated as the same path (strips prefixes matching `/xx/` or `/xx-xxxx/` patterns)
+3. **Sync script service matching** — If both URLs match the same sync script (by service name), they're considered the same site even with different hostnames. This is useful for regional domains like `anime-site.jp` and `anime-site.com`. Note that this only bypasses the hostname check — the pathname is still compared. If two regional domains use different URL structures for the same content (e.g., `/anime/123` on one domain vs `/watch/123` on another), desync will still be flagged. This is intentional: the system errs toward flagging desyncs rather than silently allowing mismatched content.
+4. **Canonical URL fallback** — If the path comparison fails, the extension asks the content script for the page's canonical URL (`<link rel="canonical">`) and retries the comparison
+
+### What Triggers Desync
+
+A desync is reported when:
+- The follower manually navigates to a different site
+- The follower's URL doesn't match after locale and canonical normalization
+- A URL fails to parse entirely
+
+### Fallback Timeout
+
+If a follower's page never finishes loading (no `status: 'complete'` event), a 15-second fallback timeout triggers a desync check to ensure followers aren't stuck indefinitely.
+
+### Desync Status
+
+When desync is detected, the follower sends a `desynced` status with the current URL. The Watch Party overlay shows this to other participants, and the follower can click to re-sync.
+
+## Status States
+
+The extension tracks each participant's status:
+
+| Status | Meaning |
+|--------|---------|
+| `ready` | Synchronized and watching normally |
+| `waiting` | Waiting for initial sync or reconnection |
+| `navigating` | Currently navigating to a new page |
+| `in-ad` | Watching an advertisement |
+| `buffering` | Player is buffering content |
+| `not-buffering` | Buffering has ended (transient — resolves to `ready`) |
+| `desynced` | On a different page than the controller |
+| `blocked` | Cannot access the content (login wall, geo-restriction) |
+
+Status messages are deduplicated — sending the same status twice in a row is suppressed to reduce WebSocket traffic.
+
+## Heartbeats and Throttling
+
+### Heartbeats
+
+The controller periodically sends heartbeat messages containing the current playback position, rate, and paused state. Followers use these to run drift correction even when no explicit play/pause/seek events occur.
+
+Identical consecutive heartbeats (same currentTime rounded to 0.1s, same playbackRate, same paused state) are deduplicated to reduce network traffic.
+
+### Sync Throttling
+
+High-frequency sync messages (cursor position, scroll events, input events) are throttled to a 100ms flush interval. The extension buffers the latest event per sync type and flushes them all at once, preventing network saturation during rapid interaction.
+
+### Participant Count Optimization
+
+When only one person is in the party, high-frequency sync messages (cursor, scroll, clicks, input) are not sent at all. This avoids unnecessary WebSocket traffic when there's no one to receive the data.

--- a/docs/v1/guide/watch-party-sync-scripts.md
+++ b/docs/v1/guide/watch-party-sync-scripts.md
@@ -38,11 +38,11 @@ The sync script's `metadata.json` defines which URLs the script should run on:
 }
 ```
 
-| Property | Type | Required | Description |
-|----------|------|----------|-------------|
-| `service` | `string` | Yes | A unique identifier for the service. Used for [regional domain matching](/v1/guide/watch-party-behavior#desync-detection). |
-| `regExp` | `string` | Yes | A regular expression pattern that matches the URLs where the content script should activate. |
-| `iframeRegExp` | `string` | No | A regular expression pattern for iframes where the iframe script should be injected. Only needed if the site embeds video in iframes. |
+| Property       | Type     | Required | Description                                                                                                                           |
+| -------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `service`      | `string` | Yes      | A unique identifier for the service. Used for [regional domain matching](/v1/guide/watch-party-behavior#desync-detection).            |
+| `regExp`       | `string` | Yes      | A regular expression pattern that matches the URLs where the content script should activate.                                          |
+| `iframeRegExp` | `string` | No       | A regular expression pattern for iframes where the iframe script should be injected. Only needed if the site embeds video in iframes. |
 
 ::: tip
 The `service` field is important for regional domain matching during desync detection. If a site has multiple regional domains (e.g., `anime-site.jp` and `anime-site.com`), use the same `service` value for both so the extension knows they're the same site.
@@ -50,11 +50,11 @@ The `service` field is important for regional domain matching during desync dete
 
 ### Script Files
 
-| File | Context | Purpose |
-|------|---------|---------|
-| `content.ts` | Content script (page DOM access) | Main sync script — registers via `SyncScriptV1.register()` |
-| `iframe.ts` | iFrame content script | Runs inside matched iframes — registers via `SyncIframeScriptV1.register()` |
-| `mainworld.ts` | Page's JavaScript context | Access page globals (e.g., `window.player`) — registers via `SyncMainworldScriptV1.register()` |
+| File           | Context                          | Purpose                                                                                        |
+| -------------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `content.ts`   | Content script (page DOM access) | Main sync script — registers via `SyncScriptV1.register()`                                     |
+| `iframe.ts`    | iFrame content script            | Runs inside matched iframes — registers via `SyncIframeScriptV1.register()`                    |
+| `mainworld.ts` | Page's JavaScript context        | Access page globals (e.g., `window.player`) — registers via `SyncMainworldScriptV1.register()` |
 
 ## Quick Start
 
@@ -137,6 +137,7 @@ The cleanup function (returned from `setup`) runs when:
 2. **The call happens after the tab has navigated** — By the time `onNavigate` fires, the DOM has already changed. Use it to find and attach to the new video element.
 
 `onNavigate` does **not** fire for:
+
 - The controller's own navigation (the controller drives navigation, it doesn't receive it)
 - Full page loads (the entire script re-initializes via `setup` instead)
 - Hash-only changes (e.g., `#section` anchors)

--- a/docs/v1/guide/watch-party-sync-scripts.md
+++ b/docs/v1/guide/watch-party-sync-scripts.md
@@ -1,0 +1,153 @@
+# Watch Party Sync Scripts
+
+Sync scripts let activities integrate with PreMiD's Watch Party feature. When a user starts or joins a Watch Party, the sync script takes over video playback synchronization, cursor sharing, and scroll mirroring for the supported site.
+
+::: warning Sync scripts are separate from presence scripts
+Sync scripts are a **completely independent system** from presence/activity scripts. They don't share code, lifecycle, or context:
+
+- **Presence scripts** use the `Presence` class, fire on `UpdateData`, and set Discord Rich Presence data
+- **Sync scripts** use `SyncScriptV1.register()`, activate only when a Watch Party is running, and control video playback synchronization
+
+A site can have a presence script without a sync script (most do), a sync script without a presence script, or both. They are separate files with separate APIs — the only connection is that they run on the same site.
+:::
+
+## Project Structure
+
+Sync scripts live in a separate `syncScripts/` directory at the repository root, independent from the activity's `websites/` directory:
+
+```
+syncScripts/
+└── YouTube/
+    ├── metadata.json   # Sync script metadata
+    ├── content.ts      # Main sync script (required)
+    ├── iframe.ts       # iFrame sync script (optional)
+    └── mainworld.ts    # Mainworld sync script (optional)
+```
+
+This is separate from the activity's presence script, which lives in `websites/Y/YouTube/`.
+
+### Sync Script metadata.json
+
+The sync script's `metadata.json` defines which URLs the script should run on:
+
+```json
+{
+  "service": "YouTube",
+  "regExp": "^https?://([a-z0-9-]+\\.)*youtube\\.com/",
+  "iframeRegExp": "^https?://([a-z0-9-]+\\.)*youtube\\.com/embed/"
+}
+```
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `service` | `string` | Yes | A unique identifier for the service. Used for [regional domain matching](/v1/guide/watch-party-behavior#desync-detection). |
+| `regExp` | `string` | Yes | A regular expression pattern that matches the URLs where the content script should activate. |
+| `iframeRegExp` | `string` | No | A regular expression pattern for iframes where the iframe script should be injected. Only needed if the site embeds video in iframes. |
+
+::: tip
+The `service` field is important for regional domain matching during desync detection. If a site has multiple regional domains (e.g., `anime-site.jp` and `anime-site.com`), use the same `service` value for both so the extension knows they're the same site.
+:::
+
+### Script Files
+
+| File | Context | Purpose |
+|------|---------|---------|
+| `content.ts` | Content script (page DOM access) | Main sync script — registers via `SyncScriptV1.register()` |
+| `iframe.ts` | iFrame content script | Runs inside matched iframes — registers via `SyncIframeScriptV1.register()` |
+| `mainworld.ts` | Page's JavaScript context | Access page globals (e.g., `window.player`) — registers via `SyncMainworldScriptV1.register()` |
+
+## Quick Start
+
+A minimal sync script that synchronizes a `<video>` element:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+
+    const handle = ctx.video.attach('video')
+
+    ctx.setPageInfo({
+      title: document.querySelector('.video-title')?.textContent ?? undefined,
+    })
+
+    return () => {
+      handle.detach()
+    }
+  },
+})
+```
+
+This is enough for sites with a standard HTML5 `<video>` element. The extension handles drift correction, play/pause sync, and seek alignment automatically.
+
+## Registration and Lifecycle
+
+Sync scripts register via `SyncScriptV1.register()`:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    // Called when a Watch Party activates on this tab
+    // Return a cleanup function (or nothing)
+    return () => {
+      // Called when the party ends or the tab is no longer active
+    }
+  },
+
+  onNavigate(ctx, url) {
+    // Called when a follower receives a navigation URL from the controller
+    // Use this to re-attach to new video elements after page transitions
+  },
+})
+```
+
+The `setup` function receives a [`SyncScriptContext`](/v1/api/sync-script-context) — the primary interface to the Watch Party system.
+
+::: tip
+Always return a cleanup function from `setup` to detach video handles, clear intervals, and remove event listeners. Leaked state causes bugs when parties end and restart.
+:::
+
+### When Does `setup` Run?
+
+The extension calls `setup` (activates the sync script) when:
+
+1. **Party creation** — The user creates a Watch Party while on a tab that matches the sync script's URL pattern. The extension injects and activates the script immediately.
+2. **Party join** — The user joins a Watch Party and is navigated to the controller's URL. Once the tab loads, the script activates.
+3. **Tab switch** — The controller moves the Watch Party to a different tab that matches the sync script. The old tab's script is deactivated, and the new tab's script is activated.
+4. **Reconnect** — After a WebSocket reconnect, the extension re-sends the activation message with the current role and pause state. If the script is already active, it updates the role/pause state without re-running `setup`.
+
+### When Does the Cleanup Function Run?
+
+The cleanup function (returned from `setup`) runs when:
+
+1. **Party ends** — The host ends the party, or the user leaves
+2. **Tab switch** — The controller moves the party to a different tab (the old tab's script gets deactivated)
+3. **No matching sync script** — The user navigates to a URL that doesn't match any sync script's pattern (the extension sends a deactivate message)
+4. **Page navigation** — On full page navigations (not SPA), the content script is destroyed entirely, which also runs cleanup
+
+### When Does `onNavigate` Fire?
+
+`onNavigate` fires when:
+
+1. **Follower receives a navigation URL** — The controller navigated to a new page, and the extension tells the sync script the new URL via `onNavigate(ctx, url)`. This fires **only on followers**, not the controller.
+2. **The call happens after the tab has navigated** — By the time `onNavigate` fires, the DOM has already changed. Use it to find and attach to the new video element.
+
+`onNavigate` does **not** fire for:
+- The controller's own navigation (the controller drives navigation, it doesn't receive it)
+- Full page loads (the entire script re-initializes via `setup` instead)
+- Hash-only changes (e.g., `#section` anchors)
+
+::: warning
+`onNavigate` only fires while the sync script is active (i.e., a Watch Party is running). It is not a general-purpose navigation listener.
+:::
+
+## What's Next
+
+- [Video Sync](/v1/guide/watch-party-video) — Auto and manual video synchronization modes
+- [Advanced Features](/v1/guide/watch-party-advanced) — iFrame/mainworld communication, custom data, party state
+- [Sync Behavior](/v1/guide/watch-party-behavior) — How drift correction, desync detection, and ad coordination work
+- [Watch Party Example](/v1/examples/watch-party) — Complete working examples

--- a/docs/v1/guide/watch-party-video.md
+++ b/docs/v1/guide/watch-party-video.md
@@ -21,6 +21,7 @@ setup(ctx) {
 ```
 
 Auto mode automatically:
+
 - Listens to `play`, `pause`, `seeked`, `ratechange` events
 - Reports playback status to the party
 - Applies sync commands (play/pause/seek) from the party controller
@@ -30,21 +31,21 @@ Auto mode automatically:
 
 The handle returned by `attach()` provides:
 
-| Method | Description |
-|--------|-------------|
-| `detach()` | Stop managing the element |
-| `onSyncCommand(handler)` | Listen to incoming sync commands (returns unsubscribe) |
-| `reportAd(isInAd)` | Report ad playback state |
-| `reportBuffering(isBuffering)` | Report buffering state |
+| Method                         | Description                                            |
+| ------------------------------ | ------------------------------------------------------ |
+| `detach()`                     | Stop managing the element                              |
+| `onSyncCommand(handler)`       | Listen to incoming sync commands (returns unsubscribe) |
+| `reportAd(isInAd)`             | Report ad playback state                               |
+| `reportBuffering(isBuffering)` | Report buffering state                                 |
 
 In auto mode, `onSyncCommand` fires **after** the command has already been applied to the element. This is useful for reacting to sync events (e.g., updating UI) without needing to apply them yourself. The commands that fire are:
 
-| Command | When it fires |
-|---------|--------------|
-| `play` | The controller started playback — element was seeked and played |
-| `pause` | The controller paused — element was paused and seeked |
-| `seek` | The controller seeked to a new position |
-| `rate` | The controller changed playback rate |
+| Command                         | When it fires                                                               |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| `play`                          | The controller started playback — element was seeked and played             |
+| `pause`                         | The controller paused — element was paused and seeked                       |
+| `seek`                          | The controller seeked to a new position                                     |
+| `rate`                          | The controller changed playback rate                                        |
 | Heartbeat (`isHeartbeat: true`) | Periodic position update from the controller — drift correction was applied |
 
 ### Re-attaching After SPA Navigation
@@ -119,21 +120,21 @@ setup(ctx) {
 
 ### ManualVideoHandle
 
-| Method | Description |
-|--------|-------------|
-| `reportPlayback(status)` | Report current playback state to the party |
-| `onSyncCommand(handler)` | Listen to raw sync commands (returns unsubscribe) |
-| `reportAd(isInAd)` | Report ad playback state |
-| `reportBuffering(isBuffering)` | Report buffering state |
-| `release()` | Stop manual control |
+| Method                         | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| `reportPlayback(status)`       | Report current playback state to the party        |
+| `onSyncCommand(handler)`       | Listen to raw sync commands (returns unsubscribe) |
+| `reportAd(isInAd)`             | Report ad playback state                          |
+| `reportBuffering(isBuffering)` | Report buffering state                            |
+| `release()`                    | Stop manual control                               |
 
 In manual mode, the `TakeControlOptions` callbacks fire **instead of** automatic element control:
 
-| Callback | When it fires |
-|----------|--------------|
-| `onPlay(timeSeconds)` | The controller started playback. Seek to `timeSeconds` and play. |
-| `onPause(timeSeconds)` | The controller paused. Pause and seek to `timeSeconds`. |
-| `onSeek(timeSeconds)` | The controller seeked. Seek to `timeSeconds`. |
+| Callback               | When it fires                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `onPlay(timeSeconds)`  | The controller started playback. Seek to `timeSeconds` and play.                       |
+| `onPause(timeSeconds)` | The controller paused. Pause and seek to `timeSeconds`.                                |
+| `onSeek(timeSeconds)`  | The controller seeked. Seek to `timeSeconds`.                                          |
 | `onRate(playbackRate)` | The controller changed playback rate. Set the rate. Optional — only fires if provided. |
 
 These callbacks fire for **followers only**. The controller doesn't receive its own commands back.

--- a/docs/v1/guide/watch-party-video.md
+++ b/docs/v1/guide/watch-party-video.md
@@ -1,0 +1,218 @@
+# Video Synchronization
+
+This page covers how to synchronize video playback in Watch Party sync scripts, including auto mode for standard `<video>` elements and manual mode for custom players.
+
+## Auto Video Mode
+
+For sites with standard `<video>` or `<audio>` elements, use auto mode:
+
+<!-- eslint-skip -->
+
+```typescript
+setup(ctx) {
+  ctx.features({ video: true })
+
+  // Pass an element or CSS selector
+  const handle = ctx.video.attach(document.querySelector('.player video')!)
+  // or: ctx.video.attach('.player video')
+
+  return () => handle.detach()
+}
+```
+
+Auto mode automatically:
+- Listens to `play`, `pause`, `seeked`, `ratechange` events
+- Reports playback status to the party
+- Applies sync commands (play/pause/seek) from the party controller
+- Runs drift correction to keep followers aligned
+
+### AutoVideoHandle
+
+The handle returned by `attach()` provides:
+
+| Method | Description |
+|--------|-------------|
+| `detach()` | Stop managing the element |
+| `onSyncCommand(handler)` | Listen to incoming sync commands (returns unsubscribe) |
+| `reportAd(isInAd)` | Report ad playback state |
+| `reportBuffering(isBuffering)` | Report buffering state |
+
+In auto mode, `onSyncCommand` fires **after** the command has already been applied to the element. This is useful for reacting to sync events (e.g., updating UI) without needing to apply them yourself. The commands that fire are:
+
+| Command | When it fires |
+|---------|--------------|
+| `play` | The controller started playback — element was seeked and played |
+| `pause` | The controller paused — element was paused and seeked |
+| `seek` | The controller seeked to a new position |
+| `rate` | The controller changed playback rate |
+| Heartbeat (`isHeartbeat: true`) | Periodic position update from the controller — drift correction was applied |
+
+### Re-attaching After SPA Navigation
+
+Many sites destroy and recreate their video player during navigation. Use `onNavigate` to re-attach:
+
+<!-- eslint-skip -->
+
+```typescript
+SyncScriptV1.register({
+  setup(ctx) {
+    ctx.features({ video: true })
+    let handle = ctx.video.attach('video')
+
+    return () => handle.detach()
+  },
+
+  onNavigate(ctx, url) {
+    // Player was destroyed during navigation — find the new one
+    const video = document.querySelector('video')
+    if (video) {
+      const handle = ctx.video.attach(video)
+    }
+  },
+})
+```
+
+## Manual Video Mode
+
+For custom players that don't use standard `<video>` elements (canvas-based players, Flash wrappers, or sites with proprietary player APIs), use manual mode:
+
+<!-- eslint-skip -->
+
+```typescript
+setup(ctx) {
+  ctx.features({ video: true })
+
+  const handle = ctx.video.takeControl({
+    onPlay(timeSeconds) {
+      player.seekTo(timeSeconds)
+      player.play()
+    },
+    onPause(timeSeconds) {
+      player.pause()
+      player.seekTo(timeSeconds)
+    },
+    onSeek(timeSeconds) {
+      player.seekTo(timeSeconds)
+    },
+    onRate(playbackRate) {
+      player.setPlaybackRate(playbackRate)
+    },
+    pauseAfterSeek: true,
+  })
+
+  // Report current playback state periodically
+  const interval = setInterval(() => {
+    handle.reportPlayback({
+      playing: player.isPlaying(),
+      currentTime: player.getCurrentTime(),
+      duration: player.getDuration(),
+      playbackRate: player.getPlaybackRate(),
+    })
+  }, 1000)
+
+  return () => {
+    clearInterval(interval)
+    handle.release()
+  }
+}
+```
+
+### ManualVideoHandle
+
+| Method | Description |
+|--------|-------------|
+| `reportPlayback(status)` | Report current playback state to the party |
+| `onSyncCommand(handler)` | Listen to raw sync commands (returns unsubscribe) |
+| `reportAd(isInAd)` | Report ad playback state |
+| `reportBuffering(isBuffering)` | Report buffering state |
+| `release()` | Stop manual control |
+
+In manual mode, the `TakeControlOptions` callbacks fire **instead of** automatic element control:
+
+| Callback | When it fires |
+|----------|--------------|
+| `onPlay(timeSeconds)` | The controller started playback. Seek to `timeSeconds` and play. |
+| `onPause(timeSeconds)` | The controller paused. Pause and seek to `timeSeconds`. |
+| `onSeek(timeSeconds)` | The controller seeked. Seek to `timeSeconds`. |
+| `onRate(playbackRate)` | The controller changed playback rate. Set the rate. Optional — only fires if provided. |
+
+These callbacks fire for **followers only**. The controller doesn't receive its own commands back.
+
+`reportPlayback()` should be called periodically (every ~1s) by the **controller** so followers can run drift correction. Followers can also call it, but it's primarily used by the controller.
+
+### pauseAfterSeek
+
+The `pauseAfterSeek` option controls what happens after a seek command:
+
+- `true` — Pause immediately after seeking (useful for sites that auto-play on seek)
+- `number` — Pause after the specified milliseconds (e.g., `200` for a 200ms delay)
+- `false` or omitted — Don't pause after seeking
+
+::: warning
+Only one video control mode can be active at a time. Calling `takeControl()` while `attach()` is active (or vice versa) will cause unexpected behavior. Always `detach()` or `release()` the current handle first.
+:::
+
+## Page Information
+
+Provide metadata about what the party is watching:
+
+<!-- eslint-skip -->
+
+```typescript
+ctx.setPageInfo({
+  title: 'Breaking Bad',
+  subtitle: 'S5 E16 - Felina',
+  thumbnail: 'https://example.com/poster.jpg',
+})
+```
+
+This information is displayed in the Watch Party overlay for all participants.
+
+## Reporting Ads
+
+When the site plays advertisements, report this so the party can coordinate:
+
+<!-- eslint-skip -->
+
+```typescript
+const observer = new MutationObserver(() => {
+  const adOverlay = document.querySelector('.ad-overlay')
+  handle.reportAd(!!adOverlay)
+})
+
+observer.observe(document.body, { childList: true, subtree: true })
+```
+
+Ad reporting has a 500ms debounce on exit to prevent flapping from rapid ad transitions. The party host's settings control how participants respond — see [Ad Coordination](/v1/guide/watch-party-behavior#ad-coordination) for details.
+
+## Reporting Buffering
+
+Report buffering state so the party can wait:
+
+<!-- eslint-skip -->
+
+```typescript
+video.addEventListener('waiting', () => handle.reportBuffering(true))
+video.addEventListener('playing', () => handle.reportBuffering(false))
+```
+
+::: tip
+In auto mode, you typically don't need to report buffering manually — the attached element's events are monitored automatically. Use explicit reporting only when the default detection doesn't work for the site.
+:::
+
+## Blocked State
+
+If the site requires authentication or has geo-restrictions, report this so other party members see a clear status:
+
+<!-- eslint-skip -->
+
+```typescript
+const loginWall = document.querySelector('.login-required')
+if (loginWall) {
+  ctx.reportBlocked('Login required')
+} else {
+  ctx.reportUnblocked()
+}
+```
+
+The blocked reason is shown to other participants so they understand why someone isn't syncing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2163,7 +2163,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2714,7 +2713,6 @@
       "integrity": "sha512-WNPVF/FfBAjyi3OA7gok8swRiImNLKI4dmV3iK/GC/0xSJR7eCzBFsw9hLZVgb1+MYNLy7aDsjohxN1hA/FIfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/types": "^8.54.0",
@@ -2872,7 +2870,6 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2953,7 +2950,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3346,6 +3342,7 @@
       "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "@vue/shared": "3.5.13",
@@ -3360,6 +3357,7 @@
       "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -3390,6 +3388,7 @@
       "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -3400,7 +3399,8 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
       "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -3408,7 +3408,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3659,7 +3658,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4280,6 +4278,7 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -4414,7 +4413,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4672,7 +4670,6 @@
       "integrity": "sha512-6o3fBJENUZPXlg01ab0vTldr6YThw0dxb49QMVp1V9bI7k22dtXYuWWMm3mitAsntJOt8V4pa7BWHUalTrSBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dprint/formatter": "^0.5.1",
         "@dprint/markdown": "^0.20.0",
@@ -5360,7 +5357,8 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -6361,7 +6359,6 @@
       "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -8954,7 +8951,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9120,7 +9116,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9196,7 +9191,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -9275,7 +9269,6 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",

--- a/syncScripts/Disney+/content.ts
+++ b/syncScripts/Disney+/content.ts
@@ -1,0 +1,36 @@
+SyncScript.register({
+  setup(ctx) {
+    ctx.features({ cursor: false, scroll: false, video: true })
+
+    let lastBuffering = false
+
+    const handle = ctx.video.takeControl({
+      onPlay: () => ctx.mainworld.send('command', { action: 'play' }),
+      onPause: () => ctx.mainworld.send('command', { action: 'pause' }),
+      onSeek: t => ctx.mainworld.send('command', { action: 'seek', timeMs: t * 1000 }),
+      pauseAfterSeek: true,
+    })
+
+    const offState = ctx.mainworld.onMessage('state', (data: any) => {
+      handle.reportPlayback({
+        playing: data.playing,
+        currentTime: data.currentTime,
+        duration: data.duration,
+        playbackRate: 1,
+      })
+
+      if (data.buffering !== lastBuffering) {
+        lastBuffering = data.buffering
+        handle.reportBuffering(data.buffering)
+      }
+
+      if (data.title)
+        ctx.setPageInfo({ title: data.title, subtitle: data.subtitle })
+    })
+
+    return () => {
+      offState()
+      handle.release()
+    }
+  },
+})

--- a/syncScripts/Disney+/mainworld.ts
+++ b/syncScripts/Disney+/mainworld.ts
@@ -1,0 +1,42 @@
+SyncMainworldScript.register({
+  setup(ctx) {
+    function getPlayer() {
+      const el = document.querySelector('disney-web-player') as any
+      return el?.mediaPlayer ?? null
+    }
+
+    const interval = setInterval(() => {
+      const mp = getPlayer()
+      if (!mp)
+        return
+
+      const status = mp.playbackStatus
+      const info = mp.timeline?.info
+      const metadata = mp.mediaPlaybackCriteria?.metadata
+
+      ctx.content.send('state', {
+        playing: !!status?.playing,
+        paused: !!status?.paused,
+        buffering: (status?.currentState === 'SEEKING' && !status?.paused) || !!status?.buffering,
+        currentTime: info ? info.playheadPositionMs / 1000 : 0,
+        duration: info ? info.seekableDurationMs / 1000 : 0,
+        title: metadata?.title?.text,
+        subtitle: metadata?.subtitle?.text,
+      })
+    }, 100)
+
+    ctx.content.onMessage('command', (data: any) => {
+      const mp = getPlayer()
+      if (!mp)
+        return
+      if (data.action === 'play')
+        mp.play()
+      else if (data.action === 'pause')
+        mp.pause()
+      else if (data.action === 'seek')
+        mp.seek(data.timeMs)
+    })
+
+    return () => clearInterval(interval)
+  },
+})

--- a/syncScripts/Disney+/metadata.json
+++ b/syncScripts/Disney+/metadata.json
@@ -1,0 +1,4 @@
+{
+  "service": "Disney+",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*(disneyplus|hotstar)[.]com[/]"
+}

--- a/syncScripts/YouTube/content.ts
+++ b/syncScripts/YouTube/content.ts
@@ -1,0 +1,79 @@
+SyncScript.register({
+  setup(ctx) {
+    ctx.features({ cursor: false, scroll: false })
+
+    let lastPageInfoKey: string | null = null
+
+    function updatePageInfo() {
+      const title
+        = document.querySelector<HTMLElement>('#title h1 yt-formatted-string')?.textContent
+          ?? document.querySelector<HTMLElement>('ytm-slim-video-metadata-section-renderer h2 span')?.textContent
+          ?? document.title
+
+      const uploader
+        = document.querySelector<HTMLElement>('#owner #channel-name yt-formatted-string a')?.textContent
+          ?? document.querySelector<HTMLElement>('ytm-slim-owner-renderer .slim-owner-channel-name')?.textContent
+
+      const thumbnail = document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content
+
+      const key = `${title}|${uploader}|${thumbnail}`
+      if (key === lastPageInfoKey)
+        return
+      lastPageInfoKey = key
+
+      ctx.setPageInfo({
+        title: title || undefined,
+        subtitle: uploader || undefined,
+        thumbnail: thumbnail || undefined,
+      })
+    }
+
+    let lastAdState: boolean | null = null
+
+    function detectAd() {
+      const inAd = !!document.querySelector('.ad-showing, .ytp-ad-player-overlay')
+      if (inAd === lastAdState)
+        return
+      lastAdState = inAd
+      ctx.video.reportAd(inAd)
+    }
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+    const observer = new MutationObserver(() => {
+      if (debounceTimer)
+        return
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null
+        updatePageInfo()
+        detectAd()
+      }, 250)
+    })
+
+    function start(root: Node) {
+      updatePageInfo()
+      detectAd()
+      observer.observe(root, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] })
+    }
+
+    if (document.body) {
+      start(document.body)
+    }
+    else {
+      const bodyObserver = new MutationObserver(() => {
+        if (document.body) {
+          bodyObserver.disconnect()
+          start(document.body)
+        }
+      })
+      bodyObserver.observe(document.documentElement, { childList: true })
+    }
+
+    const adPoll = setInterval(detectAd, 500)
+
+    return () => {
+      observer.disconnect()
+      clearInterval(adPoll)
+    }
+  },
+})

--- a/syncScripts/YouTube/metadata.json
+++ b/syncScripts/YouTube/metadata.json
@@ -1,0 +1,4 @@
+{
+  "service": "YouTube",
+  "regExp": "^https?[:][/][/](www|studio|m)[.]youtube[.]com[/]"
+}


### PR DESCRIPTION
## Summary

Adds the complete sync script infrastructure for Watch Party video synchronization across party members.

- **CLI tooling**: `sync-new`, `sync-dev`, `sync-build` commands with hot-reload dev server and compiler
- **Sync script implementations**: YouTube and Disney+ sync scripts with auto video attach, ad detection, and mainworld communication
- **Type definitions**: Global types for `SyncScriptV1`, `SyncIframeScriptV1`, `SyncMainworldScriptV1` and all related interfaces
- **Developer documentation**: Full guide (getting started, video sync, advanced features, sync behavior), API reference, and working examples
- **Build config**: `.gitignore` rules for syncScripts build artifacts

## Test plan

- [ ] `pnpm sync-dev YouTube` starts dev server with hot reload
- [ ] `pnpm sync-build --all` compiles all sync scripts to dist/
- [ ] `pnpm sync-new "ExampleService"` scaffolds a new sync script
- [ ] Documentation renders correctly via `cd docs && pnpm dev`
- [ ] YouTube sync script synchronizes video playback in a Watch Party
- [ ] Disney+ sync script synchronizes via mainworld player API