### PR TITLE
feat(Kakuyomu): add activity

### DIFF
--- a/websites/K/Kakuyomu/metadata.json
+++ b/websites/K/Kakuyomu/metadata.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "644840234671931392",
+    "name": "Phumipat-2005"
+  },
+  "service": "Kakuyomu",
+  "description": {
+    "en": "Rich Presence for Kakuyomu web novel reader."
+  },
+  "url": "kakuyomu.jp",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])?kakuyomu[.]jp[/]",
+  "version": "1.0.0",
+  "logo": "https://i.postimg.cc/JhcZ6VyH/kakuyomu.png",
+  "thumbnail": "https://i.postimg.cc/JhcZ6VyH/kakuyomu.png",
+  "color": "#1782c5",
+  "category": "other",
+  "tags": [
+    "novel",
+    "webnovel",
+    "reading",
+    "japanese"
+  ]
+}

--- a/websites/K/Kakuyomu/metadata.json
+++ b/websites/K/Kakuyomu/metadata.json
@@ -12,8 +12,8 @@
   "url": "kakuyomu.jp",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])?kakuyomu[.]jp[/]",
   "version": "1.0.0",
-  "logo": "https://i.postimg.cc/JhcZ6VyH/kakuyomu.png",
-  "thumbnail": "https://i.postimg.cc/JhcZ6VyH/kakuyomu.png",
+  "logo": "https://i.postimg.cc/HnHybSWR/kakuyomu.png",
+  "thumbnail": "https://i.postimg.cc/HnHybSWR/kakuyomu.png",
   "color": "#1782c5",
   "category": "other",
   "tags": [

--- a/websites/K/Kakuyomu/presence.ts
+++ b/websites/K/Kakuyomu/presence.ts
@@ -1,0 +1,56 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1539531465811828777',
+})
+
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+enum ActivityAssets {
+  Logo = 'https://i.postimg.cc/JhcZ6VyH/kakuyomu.png',
+}
+
+presence.on('UpdateData', async () => {
+  const { pathname } = document.location
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: ActivityAssets.Logo,
+    largeImageText: 'Kakuyomu (カクヨム)',
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (pathname.includes('/episodes/')) {
+    const workTitle
+      = document.querySelector('#contentMain header h1 a, #workTitle a, .widget-toc-work-title a')?.textContent?.trim()
+        || document.title.split(' - ')[1]
+        || 'Web Novel'
+
+    const episodeTitle
+      = document.querySelector('.widget-episode-title, h1.widget-episodeTitle')?.textContent?.trim()
+        || document.title.split(' - ')[0]
+        || 'Reading Episode'
+
+    presenceData.details = `Reading: ${workTitle}`
+    presenceData.state = episodeTitle
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Reading'
+  }
+  else if (pathname.includes('/works/')) {
+    const workTitle
+      = document.querySelector('#workTitle, h1#work-title')?.textContent?.trim()
+        || document.title.split(' - ')[0]
+        || 'Novel Overview'
+
+    presenceData.details = 'Browsing Novel'
+    presenceData.state = workTitle
+    presenceData.smallImageKey = Assets.Reading
+    presenceData.smallImageText = 'Viewing'
+  }
+  else {
+    presenceData.details = 'Browsing Kakuyomu'
+    presenceData.state = 'Finding stories...'
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/K/Kakuyomu/presence.ts
+++ b/websites/K/Kakuyomu/presence.ts
@@ -7,7 +7,7 @@ const presence = new Presence({
 const browsingTimestamp = Math.floor(Date.now() / 1000)
 
 enum ActivityAssets {
-  Logo = 'https://i.postimg.cc/JhcZ6VyH/kakuyomu.png',
+  Logo = 'https://i.postimg.cc/HnHybSWR/kakuyomu.png',
 }
 
 presence.on('UpdateData', async () => {


### PR DESCRIPTION
## Description
Adds Rich Presence support for Kakuyomu (kakuyomu.jp).

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary>Browsing main page and Discord presence</summary>

<img width="1223" height="916" alt="image" src="https://github.com/user-attachments/assets/ccead00a-60c8-4b72-ae6b-941e0678bfed" />
<img width="264" height="94" alt="image" src="https://github.com/user-attachments/assets/da960e3e-b131-4380-b1fb-99ed11c42e9d" />

</details>

<details>
<summary>Viewing novel overview and Discord presence</summary>

<img width="1142" height="907" alt="image" src="https://github.com/user-attachments/assets/49ff5cd5-09a3-46d3-878e-1f4ff3cf3d69" />
<img width="264" height="95" alt="image" src="https://github.com/user-attachments/assets/62fee558-709d-46da-9659-84dc65404316" />

</details>

<details>
<summary>Reading an episode and Discord presence</summary>

<img width="1856" height="910" alt="image" src="https://github.com/user-attachments/assets/e5dc4643-fd81-40f3-bb2b-0a3f92ba3be3" />
<img width="260" height="95" alt="image" src="https://github.com/user-attachments/assets/3ce8f878-905b-4201-a849-268b1cb1299a" />

</details>