### PR TITLE
fix(Netflix): preserve browsing timer and expand genre & page presence details

### DIFF
--- a/websites/N/Netflix/Netflix.json
+++ b/websites/N/Netflix/Netflix.json
@@ -27,14 +27,6 @@
     "description": "Shown when watching a movie, example: 2024 • 120 minutes",
     "message": "{0} • {1} minutes"
   },
-  "netflix.searching": {
-    "description": "Shown when searching without a search term",
-    "message": "Searching"
-  },
-  "netflix.searchingFor": {
-    "description": "Shown when searching with a query",
-    "message": "Searching for {0}"
-  },
   "netflix.myList": {
     "description": "Shown when viewing My List",
     "message": "Viewing My List"

--- a/websites/N/Netflix/Netflix.json
+++ b/websites/N/Netflix/Netflix.json
@@ -26,5 +26,37 @@
   "netflix.movieDisplay": {
     "description": "Shown when watching a movie, example: 2024 • 120 minutes",
     "message": "{0} • {1} minutes"
+  },
+  "netflix.searching": {
+    "description": "Shown when searching without a search term",
+    "message": "Searching"
+  },
+  "netflix.searchingFor": {
+    "description": "Shown when searching with a query",
+    "message": "Searching for {0}"
+  },
+  "netflix.myList": {
+    "description": "Shown when viewing My List",
+    "message": "Viewing My List"
+  },
+  "netflix.games": {
+    "description": "Shown when browsing Games",
+    "message": "Browsing Games"
+  },
+  "netflix.originalAudio": {
+    "description": "Shown when browsing by original audio",
+    "message": "Browsing by Original Language"
+  },
+  "netflix.audio": {
+    "description": "Shown when browsing by dubbing",
+    "message": "Browsing by Dubbing"
+  },
+  "netflix.subtitles": {
+    "description": "Shown when browsing by subtitles",
+    "message": "Browsing by Subtitles"
+  },
+  "netflix.browsingGenre": {
+    "description": "Shown when browsing a specific genre or category",
+    "message": "Browsing {0}"
   }
 }

--- a/websites/N/Netflix/metadata.json
+++ b/websites/N/Netflix/metadata.json
@@ -13,6 +13,10 @@
     {
       "name": "N0chteil ^^",
       "id": "495901098926669825"
+    },
+    {
+      "name": "JuJuplayz",
+      "id": "960971439996035083"
     }
   ],
   "service": "Netflix",
@@ -57,7 +61,7 @@
     "netflix.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?netflix[.]com[/]",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/N/Netflix/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/N/Netflix/assets/thumbnail.jpg",
   "color": "#db0000",

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -15,25 +15,24 @@ enum ActivityAssets {
 const presence = new Presence({
   clientId: '926541425682829352',
 })
-async function getStrings() {
-  return presence.getStrings(
-    {
-      play: 'general.playing',
-      pause: 'general.paused',
-      browse: 'general.browsing',
-      watchingMovie: 'general.watchingMovie',
-      watchingSeries: 'general.watchingSeries',
-      viewSeries: 'general.buttonViewSeries',
-      viewMovies: 'general.buttonViewMovie',
-      watchEpisode: 'general.buttonViewEpisode',
-      watchMovie: 'general.buttonWatchMovie',
-      seriesDisplayFull: 'netflix.seriesDisplay.full',
-      seriesDisplayShort: 'netflix.seriesDisplay.short',
-      movieDisplay: 'netflix.movieDisplay',
-    },
 
-  )
+async function getStrings() {
+  return presence.getStrings({
+    play: 'general.playing',
+    pause: 'general.paused',
+    browse: 'general.browsing',
+    watchingMovie: 'general.watchingMovie',
+    watchingSeries: 'general.watchingSeries',
+    viewSeries: 'general.buttonViewSeries',
+    viewMovies: 'general.buttonViewMovie',
+    watchEpisode: 'general.buttonViewEpisode',
+    watchMovie: 'general.buttonWatchMovie',
+    seriesDisplayFull: 'netflix.seriesDisplay.full',
+    seriesDisplayShort: 'netflix.seriesDisplay.short',
+    movieDisplay: 'netflix.movieDisplay',
+  })
 }
+
 let oldLang: string | null = null
 let strings: Awaited<ReturnType<typeof getStrings>>
 
@@ -68,42 +67,11 @@ presence.on('UpdateData', async () => {
   }
 
   const path = document.location.href
-  //* Match /title/id and get id (When you load the page / reload while browsing)
-  const browsingMediaId = path.match(/\/title\/(\d+)/)
-  //* /browse?jbv=id when normally browsing and clicking on smth
-    ?? path.match(/jbv=(\d+)/)
-
-  if (browsingMediaId) {
-    if (privacyMode)
-      return presence.clearActivity()
-
-    await fetchMetadata(browsingMediaId[1]!)
-
-    return await presence.setActivity({
-      details: metadata?.data?.video.title,
-      state: metadata?.data?.video.synopsis.slice(0, 128),
-      largeImageKey: !showCover
-        ? [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][logoType]
-        || ActivityAssets.Logo
-        : metadata?.data?.video.boxart.at(0)?.url,
-      ...(showSmallImages && {
-        smallImageKey: Assets.Reading,
-      }),
-      smallImageText: strings.browse,
-      buttons: [
-        {
-          label: metadata?.data?.video.type === 'show'
-            ? strings.viewSeries
-            : strings.viewMovies,
-          url: document.location.href,
-        },
-      ],
-    })
-  }
-
-  //* Match /watch/id and get id
   const watchingMediaId = path.match(/\/watch\/(\d+)/)
+
+  // 1. ACTIVE PLAYBACK (Resets browsing timer when starting a video)
   if (watchingMediaId) {
+    browsingTimestamp = null
     await fetchMetadata(watchingMediaId[1]!)
     const video = document.querySelector('video')
 
@@ -122,7 +90,6 @@ presence.on('UpdateData', async () => {
         })
       }
 
-      //* Typescript type breaks overwise
       const videoData = metadata.data.video as ShowVideo
       const season = metadata.data.video.seasons.find(s =>
         s.episodes.map(e => e.episodeId).includes(videoData.currentEpisode),
@@ -139,18 +106,15 @@ presence.on('UpdateData', async () => {
           .replace('{1}', episode?.seq.toString() ?? '')
           .replace('{2}', episode?.title ?? ''),
         largeImageKey: !showCover
-          ? [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][
-              logoType
-            ] || ActivityAssets.Logo
+          ? [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][logoType]
+          || ActivityAssets.Logo
           : metadata?.data?.video.boxart.at(0)?.url,
         largeImageText: `Season ${season?.seq.toString()}, Episode ${episode?.seq.toString()}`,
-        ...(showSmallImages
-          && paused && {
+        ...(showSmallImages && paused && {
           smallImageKey: Assets.Pause,
           smallImageText: strings.pause,
         }),
-        ...(showTimestamp
-          && !paused && {
+        ...(showTimestamp && !paused && {
           startTimestamp,
           endTimestamp,
         }),
@@ -191,16 +155,14 @@ presence.on('UpdateData', async () => {
             Math.floor(metadata.data.video.runtime / 60).toString(),
           ),
         largeImageKey: !showCover
-          ? [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][
-              logoType
-            ] || ActivityAssets.Logo
+          ? [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][logoType]
+          || ActivityAssets.Logo
           : metadata.data.video.boxart.at(0)?.url,
         ...(showSmallImages && {
           smallImageKey: paused ? Assets.Pause : Assets.Play,
         }),
         smallImageText: paused ? strings.pause : strings.play,
-        ...(showTimestamp
-          && !paused && {
+        ...(showTimestamp && !paused && {
           startTimestamp,
           endTimestamp,
         }),
@@ -216,21 +178,145 @@ presence.on('UpdateData', async () => {
       })
     }
 
-    //* show Series & Movies disabled, clearactivity, nothing to show?
     return presence.clearActivity()
   }
 
-  //* Reset because no data can be fetched
+  // 2. BROWSING STATES (Maintain continuous timestamp across all browsing)
+  if (!browsingTimestamp)
+    browsingTimestamp = Math.floor(Date.now() / 1000)
+
+  const browsingMediaId = path.match(/\/title\/(\d+)/) ?? path.match(/jbv=(\d+)/)
+
+  if (browsingMediaId) {
+    if (privacyMode)
+      return presence.clearActivity()
+
+    await fetchMetadata(browsingMediaId[1]!)
+
+    return await presence.setActivity({
+      details: metadata?.data?.video.title,
+      state: metadata?.data?.video.synopsis.slice(0, 128),
+      ...(showTimestamp && { startTimestamp: browsingTimestamp }),
+      largeImageKey: !showCover
+        ? [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][logoType]
+        || ActivityAssets.Logo
+        : metadata?.data?.video.boxart.at(0)?.url,
+      ...(showSmallImages && {
+        smallImageKey: Assets.Reading,
+      }),
+      smallImageText: strings.browse,
+      buttons: [
+        {
+          label: metadata?.data?.video.type === 'show'
+            ? strings.viewSeries
+            : strings.viewMovies,
+          url: document.location.href,
+        },
+      ],
+    })
+  }
+
   clearMetadata()
 
   if (showBrowsingStatus && !privacyMode) {
+    const url = new URL(document.location.href)
+    const pathname = url.pathname
+
+    let details: string = strings.browse
+
+    if (pathname.startsWith('/search')) {
+      const query = url.searchParams.get('q')
+      details = query ? `Searching for ${query}` : 'Searching'
+    }
+    else if (pathname.includes('/my-list')) {
+      details = 'Viewing My List'
+    }
+    else if (pathname.includes('/latest')) {
+      details = 'Browsing New & Popular'
+    }
+    else if (pathname.includes('/games')) {
+      details = 'Browsing Games'
+    }
+    else if (pathname.includes('/browse/original-audio')) {
+      details = 'Browsing by Original Language'
+    }
+    else if (pathname.includes('/browse/audio')) {
+      details = 'Browsing by Dubbing'
+    }
+    else if (pathname.includes('/browse/subtitles')) {
+      details = 'Browsing by Subtitles'
+    }
+    else if (pathname.includes('/browse/genre/')) {
+      const genreId = pathname.split('/browse/genre/')[1]?.split('?')[0]?.replace('/', '')
+      const mappedGenre = genreId ? GENRE_MAP[genreId] : undefined
+      const domGenre = document.querySelector('.genre-title, .header-title, h1')?.textContent?.trim()
+
+      const genreName = mappedGenre || domGenre
+      details = genreName ? `Browsing ${genreName}` : strings.browse
+    }
+
     return await presence.setActivity({
-      details: strings.browse,
+      details,
+      ...(showTimestamp && { startTimestamp: browsingTimestamp }),
       largeImageKey: [ActivityAssets.Animated, ActivityAssets.Logo, ActivityAssets.Noback][logoType]
         || ActivityAssets.Logo,
       smallImageKey: Assets.Reading,
       smallImageText: strings.browse,
     })
   }
+
+  browsingTimestamp = null
   return presence.clearActivity()
 })
+
+let browsingTimestamp: number | null = null
+
+const GENRE_MAP: Record<string, string> = {
+  '34399': 'Films',
+  '801362': 'Action Films',
+  '7442': 'Adventure Films',
+  '3063': 'Anime Films',
+  '89844': 'Award-Winning Films',
+  '90139': 'Blockbuster Films',
+  '6548': 'Comedy Films',
+  '5824': 'Crime Films',
+  '2243108': 'Documentaries',
+  '5763': 'Drama Films',
+  '89708': 'European Films',
+  '9744': 'Fantasy Films',
+  '58886': 'German Films',
+  '8711': 'Horror Films',
+  '7077': 'Independent Films',
+  '78367': 'International Films',
+  '783': 'Kids & Family',
+  '52852': 'Music & Musicals',
+  '8883': 'Romantic Films',
+  '3276033': 'Sci-Fi Films',
+  '3345391': 'Short Films & Documentaries',
+  '4370': 'Sport Films',
+  '11559': 'Stand-Up Comedy',
+  '8933': 'Thriller Films',
+  '83': 'Series',
+  '10673': 'Action & Adventure Series',
+  '6721': 'Anime Series',
+  '52117': 'British Series',
+  '10375': 'Comedy Series',
+  '26146': 'Crime Series',
+  '10105': 'Documentary Series',
+  '11714': 'Drama Series',
+  '82900738': 'Netflix EmmyÂ® Collection',
+  '89663': 'European Series',
+  '65198': 'German Series',
+  '83059': 'Horror Series',
+  '1195213': 'International Series',
+  '27346': 'Kids TV',
+  '4366': 'Mystery Series',
+  '2070390': 'Reality, Variety & Chat Shows',
+  '26156': 'Romantic Series',
+  '1372': 'Sci-Fi & Fantasy Series',
+  '52780': 'Science & Nature Series',
+  '25788': 'Sport Series',
+  '60951': 'Teen Series',
+  '89811': 'Thriller Series',
+  '72404': 'US Series',
+}

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -35,6 +35,57 @@ async function getStrings() {
 
 let oldLang: string | null = null
 let strings: Awaited<ReturnType<typeof getStrings>>
+let browsingTimestamp: number | null = null
+
+const GENRE_MAP: Record<string, string> = {
+  34399: 'Films',
+  801362: 'Action Films',
+  7442: 'Adventure Films',
+  3063: 'Anime Films',
+  89844: 'Award-Winning Films',
+  90139: 'Blockbuster Films',
+  6548: 'Comedy Films',
+  5824: 'Crime Films',
+  2243108: 'Documentaries',
+  5763: 'Drama Films',
+  89708: 'European Films',
+  9744: 'Fantasy Films',
+  58886: 'German Films',
+  8711: 'Horror Films',
+  7077: 'Independent Films',
+  78367: 'International Films',
+  783: 'Kids & Family',
+  52852: 'Music & Musicals',
+  8883: 'Romantic Films',
+  3276033: 'Sci-Fi Films',
+  3345391: 'Short Films & Documentaries',
+  4370: 'Sport Films',
+  11559: 'Stand-Up Comedy',
+  8933: 'Thriller Films',
+  83: 'Series',
+  10673: 'Action & Adventure Series',
+  6721: 'Anime Series',
+  52117: 'British Series',
+  10375: 'Comedy Series',
+  26146: 'Crime Series',
+  10105: 'Documentary Series',
+  11714: 'Drama Series',
+  82900738: 'Netflix Emmy® Collection',
+  89663: 'European Series',
+  65198: 'German Series',
+  83059: 'Horror Series',
+  1195213: 'International Series',
+  27346: 'Kids TV',
+  4366: 'Mystery Series',
+  2070390: 'Reality, Variety & Chat Shows',
+  26156: 'Romantic Series',
+  1372: 'Sci-Fi & Fantasy Series',
+  52780: 'Science & Nature Series',
+  25788: 'Sport Series',
+  60951: 'Teen Series',
+  89811: 'Thriller Series',
+  72404: 'US Series',
+}
 
 presence.on('UpdateData', async () => {
   const [
@@ -69,7 +120,6 @@ presence.on('UpdateData', async () => {
   const path = document.location.href
   const watchingMediaId = path.match(/\/watch\/(\d+)/)
 
-  // 1. ACTIVE PLAYBACK (Resets browsing timer when starting a video)
   if (watchingMediaId) {
     browsingTimestamp = null
     await fetchMetadata(watchingMediaId[1]!)
@@ -181,7 +231,6 @@ presence.on('UpdateData', async () => {
     return presence.clearActivity()
   }
 
-  // 2. BROWSING STATES (Maintain continuous timestamp across all browsing)
   if (!browsingTimestamp)
     browsingTimestamp = Math.floor(Date.now() / 1000)
 
@@ -268,55 +317,3 @@ presence.on('UpdateData', async () => {
   browsingTimestamp = null
   return presence.clearActivity()
 })
-
-let browsingTimestamp: number | null = null
-
-const GENRE_MAP: Record<string, string> = {
-  '34399': 'Films',
-  '801362': 'Action Films',
-  '7442': 'Adventure Films',
-  '3063': 'Anime Films',
-  '89844': 'Award-Winning Films',
-  '90139': 'Blockbuster Films',
-  '6548': 'Comedy Films',
-  '5824': 'Crime Films',
-  '2243108': 'Documentaries',
-  '5763': 'Drama Films',
-  '89708': 'European Films',
-  '9744': 'Fantasy Films',
-  '58886': 'German Films',
-  '8711': 'Horror Films',
-  '7077': 'Independent Films',
-  '78367': 'International Films',
-  '783': 'Kids & Family',
-  '52852': 'Music & Musicals',
-  '8883': 'Romantic Films',
-  '3276033': 'Sci-Fi Films',
-  '3345391': 'Short Films & Documentaries',
-  '4370': 'Sport Films',
-  '11559': 'Stand-Up Comedy',
-  '8933': 'Thriller Films',
-  '83': 'Series',
-  '10673': 'Action & Adventure Series',
-  '6721': 'Anime Series',
-  '52117': 'British Series',
-  '10375': 'Comedy Series',
-  '26146': 'Crime Series',
-  '10105': 'Documentary Series',
-  '11714': 'Drama Series',
-  '82900738': 'Netflix EmmyÂ® Collection',
-  '89663': 'European Series',
-  '65198': 'German Series',
-  '83059': 'Horror Series',
-  '1195213': 'International Series',
-  '27346': 'Kids TV',
-  '4366': 'Mystery Series',
-  '2070390': 'Reality, Variety & Chat Shows',
-  '26156': 'Romantic Series',
-  '1372': 'Sci-Fi & Fantasy Series',
-  '52780': 'Science & Nature Series',
-  '25788': 'Sport Series',
-  '60951': 'Teen Series',
-  '89811': 'Thriller Series',
-  '72404': 'US Series',
-}

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -30,6 +30,15 @@ async function getStrings() {
     seriesDisplayFull: 'netflix.seriesDisplay.full',
     seriesDisplayShort: 'netflix.seriesDisplay.short',
     movieDisplay: 'netflix.movieDisplay',
+    searching: 'netflix.searching',
+    searchingFor: 'netflix.searchingFor',
+    myList: 'netflix.myList',
+    latest: 'netflix.latest',
+    games: 'netflix.games',
+    originalAudio: 'netflix.originalAudio',
+    audio: 'netflix.audio',
+    subtitles: 'netflix.subtitles',
+    browsingGenre: 'netflix.browsingGenre',
   })
 }
 
@@ -275,25 +284,25 @@ presence.on('UpdateData', async () => {
 
     if (pathname.startsWith('/search')) {
       const query = url.searchParams.get('q')
-      details = query ? `Searching for ${query}` : 'Searching'
+      details = query ? strings.searchingFor.replace('{0}', query) : strings.searching
     }
     else if (pathname.includes('/my-list')) {
-      details = 'Viewing My List'
+      details = strings.myList
     }
     else if (pathname.includes('/latest')) {
-      details = 'Browsing New & Popular'
+      details = strings.latest.replace('{0}', ' ')
     }
     else if (pathname.includes('/games')) {
-      details = 'Browsing Games'
+      details = strings.games
     }
     else if (pathname.includes('/browse/original-audio')) {
-      details = 'Browsing by Original Language'
+      details = strings.originalAudio
     }
     else if (pathname.includes('/browse/audio')) {
-      details = 'Browsing by Dubbing'
+      details = strings.audio
     }
     else if (pathname.includes('/browse/subtitles')) {
-      details = 'Browsing by Subtitles'
+      details = strings.subtitles
     }
     else if (pathname.includes('/browse/genre/')) {
       const genreId = pathname.split('/browse/genre/')[1]?.split('?')[0]?.replace('/', '')
@@ -301,7 +310,7 @@ presence.on('UpdateData', async () => {
       const domGenre = document.querySelector('.genre-title, .header-title, h1')?.textContent?.trim()
 
       const genreName = mappedGenre || domGenre
-      details = genreName ? `Browsing ${genreName}` : strings.browse
+      details = genreName ? strings.browsingGenre.replace('{0}', genreName) : strings.browse
     }
 
     return await presence.setActivity({

--- a/websites/N/Netflix/presence.ts
+++ b/websites/N/Netflix/presence.ts
@@ -21,6 +21,8 @@ async function getStrings() {
     play: 'general.playing',
     pause: 'general.paused',
     browse: 'general.browsing',
+    search: 'general.search',
+    searchFor: 'general.searchFor',
     watchingMovie: 'general.watchingMovie',
     watchingSeries: 'general.watchingSeries',
     viewSeries: 'general.buttonViewSeries',
@@ -30,8 +32,6 @@ async function getStrings() {
     seriesDisplayFull: 'netflix.seriesDisplay.full',
     seriesDisplayShort: 'netflix.seriesDisplay.short',
     movieDisplay: 'netflix.movieDisplay',
-    searching: 'netflix.searching',
-    searchingFor: 'netflix.searchingFor',
     myList: 'netflix.myList',
     latest: 'netflix.latest',
     games: 'netflix.games',
@@ -284,7 +284,7 @@ presence.on('UpdateData', async () => {
 
     if (pathname.startsWith('/search')) {
       const query = url.searchParams.get('q')
-      details = query ? strings.searchingFor.replace('{0}', query) : strings.searching
+      details = query ? `${strings.searchFor} ${query}` : strings.search
     }
     else if (pathname.includes('/my-list')) {
       details = strings.myList


### PR DESCRIPTION
## Description
Adds detailed browsing statuses for category pages and genres.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

<img width="1865" height="961" alt="Screenshot 2026-08-23 185647" src="https://github.com/user-attachments/assets/44725349-2078-4663-ae89-f9df43dca543" />
<img width="1859" height="959" alt="Screenshot 2026-08-23 185701" src="https://github.com/user-attachments/assets/00b23971-c85c-4010-b9db-7188c3cfa695" />
<img width="1861" height="959" alt="Screenshot 2026-08-23 185744" src="https://github.com/user-attachments/assets/f82ee129-ec35-4903-b486-7638b66b36aa" />

</details>