### PR TITLE
feat(AnimeOn): add Show Browsing Status setting

### DIFF
--- a/websites/A/AnimeOn/metadata.json
+++ b/websites/A/AnimeOn/metadata.json
@@ -15,7 +15,7 @@
     "v1.animeon.co"
   ],
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*animeon[.](cc|co)[/]",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeOn/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AnimeOn/assets/thumbnail.png",
   "color": "#8B5CF6",
@@ -40,6 +40,12 @@
       "id": "cover",
       "title": "Show Anime Cover",
       "icon": "fas fa-image",
+      "value": true
+    },
+    {
+      "id": "showBrowsingStatus",
+      "title": "Show Browsing Status",
+      "icon": "fad fa-book-reader",
       "value": true
     },
     {

--- a/websites/A/AnimeOn/presence.ts
+++ b/websites/A/AnimeOn/presence.ts
@@ -125,12 +125,13 @@ function togetherStream(): { title: string | null, line: string | null } {
 presence.on('UpdateData', async () => {
   const { pathname, href, search } = document.location
   const searchParams = new URLSearchParams(search)
-  const [showTimestamps, showCover, showButtons, showJoinButton, privacy] = await Promise.all([
+  const [showTimestamps, showCover, showButtons, showJoinButton, privacy, showBrowsingStatus] = await Promise.all([
     presence.getSetting<boolean>('timestamps'),
     presence.getSetting<boolean>('cover'),
     presence.getSetting<boolean>('buttons'),
     presence.getSetting<boolean>('joinButton'),
     presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('showBrowsingStatus'),
   ])
   const {
     browsing,
@@ -161,6 +162,8 @@ presence.on('UpdateData', async () => {
     startTimestamp: browsingTimestamp,
   }
   let buttonLabel: string | null = null
+  //* With Show Browsing Status off, only the player survives.
+  let watching = false
 
   switch (true) {
     case pathname === '/': {
@@ -183,6 +186,7 @@ presence.on('UpdateData', async () => {
 
         const epLine = [number && `${episode} ${number}`, dub].filter(Boolean).join(' • ')
 
+        watching = true
         presenceData.details = title
         if (epLine)
           presenceData.state = epLine
@@ -267,7 +271,7 @@ presence.on('UpdateData', async () => {
       //* /together itself cannot be paused, its only control is "Остановить эфир",
       //* which tears the element back down to the stills, but a room host can pause,
       //* and there the element stays mounted reporting paused.
-      const watching = video !== null && video.readyState > 0
+      watching = video !== null && video.readyState > 0
       const streamPaused = watching && video?.paused === true
 
       if (streamPaused) {
@@ -302,9 +306,7 @@ presence.on('UpdateData', async () => {
       }
 
       //* Only offer the invite when something is actually on; otherwise it leads nowhere.
-      //* An extension that has not picked the setting up yet reports undefined, so the
-      //* declared default of true has to survive that.
-      if (showJoinButton !== false && title)
+      if (showJoinButton && title)
         buttonLabel = pathname === '/together' ? 'Join Stream' : 'Join Room'
       break
     }
@@ -345,6 +347,9 @@ presence.on('UpdateData', async () => {
       break
     }
   }
+
+  if (!showBrowsingStatus && !watching)
+    return presence.clearActivity()
 
   //* Privacy Mode has to leave nothing behind that says what is being watched.
   if (privacy) {

--- a/websites/A/AnimeOn/presence.ts
+++ b/websites/A/AnimeOn/presence.ts
@@ -306,7 +306,7 @@ presence.on('UpdateData', async () => {
       }
 
       //* Only offer the invite when something is actually on; otherwise it leads nowhere.
-      if (showJoinButton && title)
+      if (showJoinButton !== false && title)
         buttonLabel = pathname === '/together' ? 'Join Stream' : 'Join Room'
       break
     }
@@ -348,7 +348,7 @@ presence.on('UpdateData', async () => {
     }
   }
 
-  if (!showBrowsingStatus && !watching)
+  if (showBrowsingStatus === false && !watching)
     return presence.clearActivity()
 
   //* Privacy Mode has to leave nothing behind that says what is being watched.


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Adds the `showBrowsingStatus` setting to AnimeOn, matching the id, title, icon and `true` default used by the other activities that offer it (Netflix, HBO Max, Jellyfin, HDrezka, Peacock and others).

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->



</details>
