### PR TITLE
fix(Planet Minecraft): fix activity state, largeImageKey for /member

### DIFF
--- a/websites/P/Planet Minecraft/metadata.json
+++ b/websites/P/Planet Minecraft/metadata.json
@@ -11,7 +11,7 @@
   },
   "url": "www.planetminecraft.com",
   "regExp": "^https?[:][/][/](www[.])?planetminecraft[.]com[/]",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Planet%20Minecraft/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Planet%20Minecraft/assets/thumbnail.jpg",
   "color": "#014E96",

--- a/websites/P/Planet Minecraft/presence.ts
+++ b/websites/P/Planet Minecraft/presence.ts
@@ -324,11 +324,13 @@ function memberActivity(
       else {
         presenceData.details = strings.viewMember
         presenceData.state = document
-          .querySelector('meta[name="og:profile:username"]')
+          .querySelector('meta[property="profile:username"]')
           ?.getAttribute('content')
-        presenceData.largeImageKey = document
-          .querySelector('meta[name="og:image:secure_url"]')
+        const avatarFilename = document
+          .querySelector('meta[property="og:image:secure_url"]')
           ?.getAttribute('content')
+        if (avatarFilename)
+          presenceData.largeImageKey = `https://static.planetminecraft.com/files/avatar/${avatarFilename}`
       }
     }
   }


### PR DESCRIPTION
## Description
Updated some broken selectors to set more accurate values for `presenceData.state` and `presenceData.largeImageKey` when viewing member pages.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

## Before
<img width="660" height="242" alt="image" src="https://github.com/user-attachments/assets/10b542cc-b25d-424a-afba-f6737223c7a4" />

## After
<img width="664" height="240" alt="image" src="https://github.com/user-attachments/assets/6ed17c44-8165-45d2-92c8-577c99a342f9" />

</details>
