### PR TITLE
feat(Quran.com): improve reading, reciter, and page activities

### DIFF
--- a/websites/Q/Quran.com/Quran.com.json
+++ b/websites/Q/Quran.com/Quran.com.json
@@ -1,0 +1,62 @@
+{
+  "quran.aboutUs": {
+    "description": "Shown when viewing Quran.com's about page.",
+    "message": "Viewing the about us page"
+  },
+  "quran.apps": {
+    "description": "Shown when viewing Quran.com's apps page.",
+    "message": "Looking at Quran apps"
+  },
+  "quran.ayah": {
+    "description": "The label for a Quran verse number.",
+    "message": "Ayah"
+  },
+  "quran.dailyVerse": {
+    "description": "Shown when viewing Quran.com's verse of the day.",
+    "message": "Viewing the Quran verse of the day"
+  },
+  "quran.developers": {
+    "description": "Shown when viewing Quran.com's developers page.",
+    "message": "Looking at the developers page"
+  },
+  "quran.duas": {
+    "description": "Shown when browsing Quranic duas.",
+    "message": "Browsing Quranic duas"
+  },
+  "quran.learningPlans": {
+    "description": "Shown when browsing Quran learning plans.",
+    "message": "Browsing Quran learning plans"
+  },
+  "quran.radio": {
+    "description": "Shown when browsing Quran radio stations.",
+    "message": "Looking through radio stations"
+  },
+  "quran.readingFallback": {
+    "description": "Shown when reading the Quran and no chapter name is available.",
+    "message": "Reading the Holy Quran"
+  },
+  "quran.readingTafsir": {
+    "description": "Shown when reading a Quran tafsir.",
+    "message": "Reading a tafsir"
+  },
+  "quran.reciters": {
+    "description": "Shown when browsing Quran reciters.",
+    "message": "Browsing through reciters"
+  },
+  "quran.support": {
+    "description": "Shown when viewing Quran.com's support page.",
+    "message": "Looking at the support page"
+  },
+  "quran.viewingDua": {
+    "description": "Shown when viewing a specific Quranic dua.",
+    "message": "Viewing a Quranic dua"
+  },
+  "quran.viewingLearningPlan": {
+    "description": "Shown when viewing a specific Quran learning plan.",
+    "message": "Viewing a Quran learning plan"
+  },
+  "quran.viewingReciter": {
+    "description": "Shown when viewing a specific Quran reciter.",
+    "message": "Viewing a reciter"
+  }
+}

--- a/websites/Q/Quran.com/metadata.json
+++ b/websites/Q/Quran.com/metadata.json
@@ -5,13 +5,19 @@
     "id": "853932304257908746",
     "name": "BigBoi"
   },
+  "contributors": [
+    {
+      "name": "rhuda21",
+      "id": "898224513160982569"
+    }
+  ],
   "service": "Quran.com",
   "description": {
     "en": "The Quran translated into many languages in a simple and easy interface."
   },
   "url": "quran.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*quran[.]com[/]",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/Q/Quran.com/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/Q/Quran.com/assets/thumbnail.png",
   "color": "#1c1c1c",
@@ -21,5 +27,11 @@
     "book",
     "quran",
     "holy"
+  ],
+  "settings": [
+    {
+      "id": "lang",
+      "multiLanguage": true
+    }
   ]
 }

--- a/websites/Q/Quran.com/presence.ts
+++ b/websites/Q/Quran.com/presence.ts
@@ -1,86 +1,347 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
 const presence = new Presence({
   clientId: '969064871310282813',
 })
-const browsingTimestamp = Math.floor(Date.now() / 1000)
 
-function getElementByXpath(path: string) {
-  return document.evaluate(
-    path,
-    document,
-    null,
-    XPathResult.FIRST_ORDERED_NODE_TYPE,
-    null,
-  ).singleNodeValue
+enum ActivityAssets {
+  Logo = 'https://cdn.rcd.gg/PreMiD/websites/Q/Quran.com/assets/logo.png',
 }
-presence.on('UpdateData', async () => {
-  const presenceData: PresenceData = {
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/Q/Quran.com/assets/logo.png',
-    startTimestamp: browsingTimestamp,
+
+let browsingTimestamp = Math.floor(Date.now() / 1000)
+let lastCategory: 'browsing' | 'reading' | 'reciters' | 'search' | null = null
+
+async function getStrings() {
+  return presence.getStrings({
+    buttonViewPage: 'general.buttonViewPage',
+    paused: 'general.paused',
+    privacy: 'general.privacy',
+    reading: 'general.reading',
+    searchFor: 'general.searchFor',
+    searchSomething: 'general.searchSomething',
+    viewHome: 'general.viewHome',
+    viewPage: 'general.viewPage',
+  })
+}
+
+let strings: Awaited<ReturnType<typeof getStrings>>
+let oldLang: string | undefined
+
+function setCategory(category: typeof lastCategory) {
+  if (lastCategory !== category) {
+    browsingTimestamp = Math.floor(Date.now() / 1000)
+    lastCategory = category
   }
-  const { pathname } = window.location
-  switch (pathname) {
-    case '/': {
-      presenceData.details = 'Browsing the homepage...'
-      break
+}
+
+function query<T extends Element = Element>(selectors: string[]): T | null {
+  for (const selector of selectors) {
+    const el = document.querySelector<T>(selector)
+    if (el)
+      return el
+  }
+  return null
+}
+
+interface ChapterEntry {
+  translatedName: string
+}
+
+function getEnglishName(chapterNumber: string): string | undefined {
+  try {
+    const nextData = JSON.parse(document.getElementById('__NEXT_DATA__')?.textContent ?? '')
+    const chaptersData = nextData?.props?.pageProps?.chaptersData as Record<string, ChapterEntry> | undefined
+    return chaptersData?.[chapterNumber]?.translatedName
+  }
+  catch {
+    return undefined
+  }
+}
+
+const reciterNames: Record<string, string> = {
+  'qdc/abdul_baset/mujawwad': 'AbdulBaset AbdulSamad (Mujawwad)',
+  'qdc/abdul_baset/murattal': 'AbdulBaset AbdulSamad (Murattal)',
+  'qdc/abdurrahmaan_as_sudais/murattal': 'Abdur-Rahman as-Sudais (Murattal)',
+  'qdc/abu_bakr_shatri/murattal': 'Abu Bakr al-Shatri (Murattal)',
+  'qdc/hani_ar_rifai/murattal': 'Hani ar-Rifai (Murattal)',
+  'qdc/khalifah_taniji/murattal': 'Khalifah Al Tunaiji (Murattal)',
+  'qdc/khalil_al_husary/muallim': 'Mahmoud Khalil Al-Husary (Muallim)',
+  'qdc/khalil_al_husary/murattal': 'Mahmoud Khalil Al-Husary (Murattal)',
+  'qdc/mishari_al_afasy/murattal': 'Mishari Rashid al-`Afasy (Murattal)',
+  'qdc/mishari_al_afasy/streaming/mp3': 'Mishari Rashid al-`Afasy (Murattal)',
+  'qdc/saud_ash-shuraym/murattal': 'Sa`ud ash-Shuraym (Murattal)',
+  'qdc/siddiq_al-minshawi/mujawwad': 'Mohamed Siddiq al-Minshawi (Mujawwad)',
+  'qdc/siddiq_minshawi/kids_repeat': 'Mohamed Siddiq al-Minshawi (Kids repeat)',
+  'qdc/siddiq_minshawi/murattal': 'Mohamed Siddiq al-Minshawi (Murattal)',
+  'qdc/yasser_ad-dussary/mp3': 'Yasser Ad Dussary - beta (Murattal)',
+  'quran/ahmed_ibn_3ali_al-3ajamy': 'Ahmed ibn Ali al-Ajmy - beta (Murattal)',
+  'quran/ali_jaber': 'Abdullah Ali Jabir - beta (Murattal)',
+  'quran/bandar_baleela/complete': 'Bandar Baleela - beta (Murattal)',
+  'quran/maher_almu3aiqly/year1440': 'Maher al-Muaiqly - beta (Murattal)',
+  'quran/sa3d_al-ghaamidi/complete': 'Saad al-Ghamdi (Murattal)',
+}
+
+function getReciterName(audioSrc: string): string | undefined {
+  const pathname = new URL(audioSrc).pathname.replace(/\/+/g, '/')
+  return Object.entries(reciterNames)
+    .find(([path]) => pathname.startsWith(`/${path}/`))?.[1]
+}
+
+function getVerseKey(pathname: string, audio: HTMLAudioElement | null): string | undefined {
+  const audioSrc = audio?.currentSrc || audio?.src
+  if (audioSrc) {
+    return query(['[data-verse-key][class*="highlightedContainer"]'])
+      ?.getAttribute('data-verse-key') ?? undefined
+  }
+
+  if (/^\/[^/]+\/\d+\/?$/.test(pathname)) {
+    const verseKey = query(['[data-verse-key]'])?.getAttribute('data-verse-key')
+    if (verseKey)
+      return verseKey
+  }
+
+  const verseNumber = pathname.match(/^\/[^/]+\/(\d+)\/?$/)?.[1]
+  const chapterNumber = query(['[data-testid="chapter-navigation"]'])?.textContent?.match(/^(\d+)\./)?.[1]
+  return verseNumber && chapterNumber ? `${chapterNumber}:${verseNumber}` : undefined
+}
+
+const translations = {
+  en: {
+    radio: 'Looking through radio stations',
+    aboutUs: 'Viewing the about us page',
+    apps: 'Looking at Quran apps',
+    developers: 'Looking at the developers page',
+    support: 'Looking at the support page',
+    reciters: 'Browsing through reciters',
+    viewingReciter: 'Viewing a reciter',
+    dailyVerse: 'Viewing the Quran verse of the day',
+    duas: 'Browsing Quranic duas',
+    viewingDua: 'Viewing a Quranic dua',
+    readingTafsir: 'Reading a tafsir',
+    learningPlans: 'Browsing Quran learning plans',
+    viewingLearningPlan: 'Viewing a Quran learning plan',
+    readingFallback: 'Reading the Holy Quran',
+    ayah: 'Ayah',
+  },
+  ar: {
+    radio: 'تصفح محطات الراديو',
+    aboutUs: 'عرض صفحة من نحن',
+    apps: 'تصفح تطبيقات القرآن',
+    developers: 'عرض صفحة المطورين',
+    support: 'عرض صفحة الدعم',
+    reciters: 'تصفح القراء',
+    viewingReciter: 'عرض قارئ',
+    dailyVerse: 'عرض آية اليوم من القرآن',
+    duas: 'تصفح الأدعية القرآنية',
+    viewingDua: 'عرض دعاء قرآني',
+    readingTafsir: 'قراءة تفسير',
+    learningPlans: 'تصفح خطط تعلم القرآن',
+    viewingLearningPlan: 'عرض خطة لتعلم القرآن',
+    readingFallback: 'قراءة القرآن الكريم',
+    ayah: 'آية',
+  },
+} as const
+
+type LangCode = keyof typeof translations
+
+presence.on('UpdateData', async () => {
+  try {
+    const newLang = await presence.getSetting<string>('lang').catch(() => 'en') || 'en'
+    if (oldLang !== newLang || !strings) {
+      oldLang = newLang
+      strings = await getStrings()
     }
-    case '/radio': {
-      presenceData.details = 'Looking through radio stations'
-      break
+
+    const lang: LangCode = newLang.toLowerCase().startsWith('ar') ? 'ar' : 'en'
+    const t = translations[lang]
+
+    let presenceData: PresenceData = {
+      largeImageKey: ActivityAssets.Logo,
+      type: ActivityType.Playing,
     }
-    case '/about-us': {
-      presenceData.details = 'Viewing the about us page'
-      break
-    }
-    case '/apps': {
-      presenceData.details = 'Looking at Quran apps'
-      break
-    }
-    case '/developers': {
-      presenceData.details = 'Looking at the developers page'
-      break
-    }
-    case '/privacy': {
-      presenceData.details = 'Reading the privacy policy'
-      break
-    }
-    case '/support': {
-      presenceData.details = 'Looking at the support page'
-      break
-    }
-    case '/search': {
-      const searchQuery = document.querySelector<HTMLInputElement>('#searchQuery')?.value
-      if (searchQuery)
-        presenceData.details = `Searching for ${searchQuery}`
-      else presenceData.details = 'Searching for something...'
-      break
-    }
-    default: {
-      if (pathname.includes('/reciters')) {
-        if (pathname.includes('/reciters/')) {
-          presenceData.details = 'Viewing a reciter:'
-          presenceData.state = document.querySelector<HTMLDivElement>(
-            '.ReciterInfo_reciterName__SiK59',
-          )?.textContent
+
+    const { pathname } = window.location
+
+    switch (pathname) {
+      case '/': {
+        setCategory('browsing')
+        presenceData.details = strings.viewHome
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/radio': {
+        setCategory('browsing')
+        presenceData.details = t.radio
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/about-us': {
+        setCategory('browsing')
+        presenceData.details = t.aboutUs
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/apps': {
+        setCategory('browsing')
+        presenceData.details = t.apps
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/developers': {
+        setCategory('browsing')
+        presenceData.details = t.developers
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/privacy': {
+        setCategory('browsing')
+        presenceData.details = strings.privacy
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/support': {
+        setCategory('browsing')
+        presenceData.details = t.support
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      case '/search': {
+        setCategory('search')
+        const searchQuery = query<HTMLInputElement>(['#searchQuery', 'input[type="search"]'])?.value?.trim()
+        presenceData.details = searchQuery ? strings.searchFor : strings.searchSomething
+        if (searchQuery)
+          presenceData.state = searchQuery.slice(0, 60)
+        presenceData.startTimestamp = browsingTimestamp
+        break
+      }
+      default: {
+        const pageTitle = document.title.replace(/\s*[-–—]\s*Quran\.com\s*$/i, '').trim()
+
+        if (pathname.includes('/reciters')) {
+          if (pathname.includes('/reciters/')) {
+            setCategory('reciters')
+            presenceData.details = t.viewingReciter
+            const reciter = query(['[class*="ReciterInfo_reciterName"]', '[data-testid="reciter-name"]'])?.textContent
+            if (reciter)
+              presenceData.state = reciter
+            presenceData.startTimestamp = browsingTimestamp
+          }
+          else {
+            setCategory('browsing')
+            presenceData.details = t.reciters
+            presenceData.startTimestamp = browsingTimestamp
+          }
+          break
+        }
+
+        if (pathname === '/daily') {
+          setCategory('reading')
+          presenceData.details = t.dailyVerse
+          const verseKey = query(['[data-verse-key]'])?.getAttribute('data-verse-key')
+          if (verseKey)
+            presenceData.state = `${t.ayah} ${verseKey}`
+          presenceData.startTimestamp = browsingTimestamp
+          break
+        }
+
+        if (pathname === '/duas' || pathname.startsWith('/duas/')) {
+          setCategory('reading')
+          presenceData.details = pathname === '/duas' ? t.duas : t.viewingDua
+          if (pathname !== '/duas' && pageTitle)
+            presenceData.state = pageTitle
+          presenceData.startTimestamp = browsingTimestamp
+          break
+        }
+
+        if (/^\/[^/]+\/\d+\/tafsirs(?:\/|$)/.test(pathname)) {
+          setCategory('reading')
+          presenceData.details = t.readingTafsir
+          const tafsirSeparator = [' — Tafsir ', ' – Tafsir ', ' - Tafsir ']
+            .find(separator => pageTitle.includes(separator))
+          const tafsirTitle = tafsirSeparator ? pageTitle.split(tafsirSeparator)[0] : undefined
+          const tafsirContext = pageTitle.split('Tafsir Surah ')[1]
+          const verseKey = query(['[data-verse-key]'])?.getAttribute('data-verse-key')
+          const state = [verseKey ? `${t.ayah} ${verseKey}` : tafsirContext, tafsirTitle]
+            .filter(Boolean)
+            .join(' • ')
+          if (state)
+            presenceData.state = state
+          presenceData.startTimestamp = browsingTimestamp
+          break
+        }
+
+        if (pathname === '/learning-plans' || pathname.startsWith('/learning-plans/')) {
+          setCategory('reading')
+          presenceData.details = pathname === '/learning-plans'
+            ? t.learningPlans
+            : t.viewingLearningPlan
+          if (pathname !== '/learning-plans' && pageTitle)
+            presenceData.state = pageTitle
+          presenceData.startTimestamp = browsingTimestamp
+          break
+        }
+
+        const audio = document.getElementById('audio-player') as HTMLAudioElement | null
+        const directVerseSurah = /^\/[^/]+\/\d+\/?$/.test(pathname)
+          ? document.title.match(/^Surah (.+?) Ayah \d+/)?.[1]
+          : undefined
+        const surahName = query(['[data-testid="chapter-navigation"]'])?.textContent
+          ?? (directVerseSurah ? `Surah ${directVerseSurah}` : undefined)
+        const pageInfo = query(['[data-testid="page-info"]'])?.textContent
+
+        if (!surahName) {
+          setCategory('browsing')
+          presenceData.details = strings.viewPage
+          if (pageTitle)
+            presenceData.state = pageTitle
+          presenceData.startTimestamp = browsingTimestamp
+          break
+        }
+
+        const verseKey = getVerseKey(pathname, audio)
+
+        const chapterNumber = surahName?.match(/^(\d+)\./)?.[1]
+        const englishName = chapterNumber ? getEnglishName(chapterNumber) : undefined
+        const audioSrc = audio?.currentSrc || audio?.src
+        const reciterName = audioSrc ? getReciterName(audioSrc) : undefined
+
+        presenceData.details = surahName
+          ? `${strings.reading} ${surahName}${englishName ? ` (${englishName})` : ''}`
+          : t.readingFallback
+
+        const ayahPart = verseKey ? `${t.ayah} ${verseKey}` : pageInfo
+        const state = [ayahPart, reciterName].filter(Boolean).join(' • ')
+        if (state)
+          presenceData.state = state
+
+        if (audio && !audio.paused && !Number.isNaN(audio.duration) && audio.duration > 0) {
+          setCategory('reading')
+          presenceData = { ...presenceData, type: ActivityType.Listening }
+          ;[presenceData.startTimestamp, presenceData.endTimestamp] = getTimestampsFromMedia(audio)
         }
         else {
-          presenceData.details = 'Browsing through reciters'
+          setCategory('reading')
+          presenceData.startTimestamp = browsingTimestamp
+          if (audioSrc) {
+            presenceData.smallImageKey = Assets.Pause
+            presenceData.smallImageText = strings.paused
+          }
         }
       }
-      else {
-        presenceData.details = 'Reading the Holy Quran'
-        presenceData.state = `Surah: Surat ${
-          getElementByXpath('/html/body/div[1]/div/div[2]/div/div[1]/div/p')
-            ?.textContent
-        } (${
-          getElementByXpath(
-            '/html/body/div[1]/div/div[2]/div/div[2]/div/p[2]/span[2]',
-          )?.textContent
-          ?? getElementByXpath(
-            '/html/body/div[1]/div/div[2]/div/div[2]/div/p[2]/span',
-          )?.textContent
-        })`
-      }
     }
+
+    if (pathname !== '/') {
+      presenceData.buttons = [
+        {
+          label: strings.buttonViewPage,
+          url: window.location.href,
+        },
+      ]
+    }
+
+    presence.setActivity(presenceData)
   }
-  presence.setActivity(presenceData)
+  catch (error) {
+    presence.error(`Failed to update presence: ${error}`)
+  }
 })

--- a/websites/Q/Quran.com/presence.ts
+++ b/websites/Q/Quran.com/presence.ts
@@ -160,7 +160,7 @@ presence.on('UpdateData', async () => {
       type: ActivityType.Playing,
     }
 
-    const { pathname } = window.location
+    const { pathname } = document.location
 
     switch (pathname) {
       case '/': {
@@ -334,7 +334,7 @@ presence.on('UpdateData', async () => {
       presenceData.buttons = [
         {
           label: strings.buttonViewPage,
-          url: window.location.href,
+          url: document.location.href,
         },
       ]
     }

--- a/websites/Q/Quran.com/presence.ts
+++ b/websites/Q/Quran.com/presence.ts
@@ -13,19 +13,31 @@ let lastCategory: 'browsing' | 'reading' | 'reciters' | 'search' | null = null
 
 async function getStrings() {
   return presence.getStrings({
+    aboutUs: 'quran.aboutUs',
+    apps: 'quran.apps',
+    ayah: 'quran.ayah',
     buttonViewPage: 'general.buttonViewPage',
+    dailyVerse: 'quran.dailyVerse',
+    developers: 'quran.developers',
+    duas: 'quran.duas',
+    learningPlans: 'quran.learningPlans',
     paused: 'general.paused',
     privacy: 'general.privacy',
+    radio: 'quran.radio',
     reading: 'general.reading',
+    readingFallback: 'quran.readingFallback',
+    readingTafsir: 'quran.readingTafsir',
+    reciters: 'quran.reciters',
     searchFor: 'general.searchFor',
     searchSomething: 'general.searchSomething',
+    support: 'quran.support',
+    viewingDua: 'quran.viewingDua',
+    viewingLearningPlan: 'quran.viewingLearningPlan',
+    viewingReciter: 'quran.viewingReciter',
     viewHome: 'general.viewHome',
     viewPage: 'general.viewPage',
   })
 }
-
-let strings: Awaited<ReturnType<typeof getStrings>>
-let oldLang: string | undefined
 
 function setCategory(category: typeof lastCategory) {
   if (lastCategory !== category) {
@@ -105,55 +117,9 @@ function getVerseKey(pathname: string, audio: HTMLAudioElement | null): string |
   return verseNumber && chapterNumber ? `${chapterNumber}:${verseNumber}` : undefined
 }
 
-const translations = {
-  en: {
-    radio: 'Looking through radio stations',
-    aboutUs: 'Viewing the about us page',
-    apps: 'Looking at Quran apps',
-    developers: 'Looking at the developers page',
-    support: 'Looking at the support page',
-    reciters: 'Browsing through reciters',
-    viewingReciter: 'Viewing a reciter',
-    dailyVerse: 'Viewing the Quran verse of the day',
-    duas: 'Browsing Quranic duas',
-    viewingDua: 'Viewing a Quranic dua',
-    readingTafsir: 'Reading a tafsir',
-    learningPlans: 'Browsing Quran learning plans',
-    viewingLearningPlan: 'Viewing a Quran learning plan',
-    readingFallback: 'Reading the Holy Quran',
-    ayah: 'Ayah',
-  },
-  ar: {
-    radio: 'تصفح محطات الراديو',
-    aboutUs: 'عرض صفحة من نحن',
-    apps: 'تصفح تطبيقات القرآن',
-    developers: 'عرض صفحة المطورين',
-    support: 'عرض صفحة الدعم',
-    reciters: 'تصفح القراء',
-    viewingReciter: 'عرض قارئ',
-    dailyVerse: 'عرض آية اليوم من القرآن',
-    duas: 'تصفح الأدعية القرآنية',
-    viewingDua: 'عرض دعاء قرآني',
-    readingTafsir: 'قراءة تفسير',
-    learningPlans: 'تصفح خطط تعلم القرآن',
-    viewingLearningPlan: 'عرض خطة لتعلم القرآن',
-    readingFallback: 'قراءة القرآن الكريم',
-    ayah: 'آية',
-  },
-} as const
-
-type LangCode = keyof typeof translations
-
 presence.on('UpdateData', async () => {
   try {
-    const newLang = await presence.getSetting<string>('lang').catch(() => 'en') || 'en'
-    if (oldLang !== newLang || !strings) {
-      oldLang = newLang
-      strings = await getStrings()
-    }
-
-    const lang: LangCode = newLang.toLowerCase().startsWith('ar') ? 'ar' : 'en'
-    const t = translations[lang]
+    const strings = await getStrings()
 
     let presenceData: PresenceData = {
       largeImageKey: ActivityAssets.Logo,
@@ -171,25 +137,25 @@ presence.on('UpdateData', async () => {
       }
       case '/radio': {
         setCategory('browsing')
-        presenceData.details = t.radio
+        presenceData.details = strings.radio
         presenceData.startTimestamp = browsingTimestamp
         break
       }
       case '/about-us': {
         setCategory('browsing')
-        presenceData.details = t.aboutUs
+        presenceData.details = strings.aboutUs
         presenceData.startTimestamp = browsingTimestamp
         break
       }
       case '/apps': {
         setCategory('browsing')
-        presenceData.details = t.apps
+        presenceData.details = strings.apps
         presenceData.startTimestamp = browsingTimestamp
         break
       }
       case '/developers': {
         setCategory('browsing')
-        presenceData.details = t.developers
+        presenceData.details = strings.developers
         presenceData.startTimestamp = browsingTimestamp
         break
       }
@@ -201,7 +167,7 @@ presence.on('UpdateData', async () => {
       }
       case '/support': {
         setCategory('browsing')
-        presenceData.details = t.support
+        presenceData.details = strings.support
         presenceData.startTimestamp = browsingTimestamp
         break
       }
@@ -220,7 +186,7 @@ presence.on('UpdateData', async () => {
         if (pathname.includes('/reciters')) {
           if (pathname.includes('/reciters/')) {
             setCategory('reciters')
-            presenceData.details = t.viewingReciter
+            presenceData.details = strings.viewingReciter
             const reciter = query(['[class*="ReciterInfo_reciterName"]', '[data-testid="reciter-name"]'])?.textContent
             if (reciter)
               presenceData.state = reciter
@@ -228,7 +194,7 @@ presence.on('UpdateData', async () => {
           }
           else {
             setCategory('browsing')
-            presenceData.details = t.reciters
+            presenceData.details = strings.reciters
             presenceData.startTimestamp = browsingTimestamp
           }
           break
@@ -236,17 +202,17 @@ presence.on('UpdateData', async () => {
 
         if (pathname === '/daily') {
           setCategory('reading')
-          presenceData.details = t.dailyVerse
+          presenceData.details = strings.dailyVerse
           const verseKey = query(['[data-verse-key]'])?.getAttribute('data-verse-key')
           if (verseKey)
-            presenceData.state = `${t.ayah} ${verseKey}`
+            presenceData.state = `${strings.ayah} ${verseKey}`
           presenceData.startTimestamp = browsingTimestamp
           break
         }
 
         if (pathname === '/duas' || pathname.startsWith('/duas/')) {
           setCategory('reading')
-          presenceData.details = pathname === '/duas' ? t.duas : t.viewingDua
+          presenceData.details = pathname === '/duas' ? strings.duas : strings.viewingDua
           if (pathname !== '/duas' && pageTitle)
             presenceData.state = pageTitle
           presenceData.startTimestamp = browsingTimestamp
@@ -255,13 +221,13 @@ presence.on('UpdateData', async () => {
 
         if (/^\/[^/]+\/\d+\/tafsirs(?:\/|$)/.test(pathname)) {
           setCategory('reading')
-          presenceData.details = t.readingTafsir
+          presenceData.details = strings.readingTafsir
           const tafsirSeparator = [' — Tafsir ', ' – Tafsir ', ' - Tafsir ']
             .find(separator => pageTitle.includes(separator))
           const tafsirTitle = tafsirSeparator ? pageTitle.split(tafsirSeparator)[0] : undefined
           const tafsirContext = pageTitle.split('Tafsir Surah ')[1]
           const verseKey = query(['[data-verse-key]'])?.getAttribute('data-verse-key')
-          const state = [verseKey ? `${t.ayah} ${verseKey}` : tafsirContext, tafsirTitle]
+          const state = [verseKey ? `${strings.ayah} ${verseKey}` : tafsirContext, tafsirTitle]
             .filter(Boolean)
             .join(' • ')
           if (state)
@@ -273,8 +239,8 @@ presence.on('UpdateData', async () => {
         if (pathname === '/learning-plans' || pathname.startsWith('/learning-plans/')) {
           setCategory('reading')
           presenceData.details = pathname === '/learning-plans'
-            ? t.learningPlans
-            : t.viewingLearningPlan
+            ? strings.learningPlans
+            : strings.viewingLearningPlan
           if (pathname !== '/learning-plans' && pageTitle)
             presenceData.state = pageTitle
           presenceData.startTimestamp = browsingTimestamp
@@ -307,9 +273,9 @@ presence.on('UpdateData', async () => {
 
         presenceData.details = surahName
           ? `${strings.reading} ${surahName}${englishName ? ` (${englishName})` : ''}`
-          : t.readingFallback
+          : strings.readingFallback
 
-        const ayahPart = verseKey ? `${t.ayah} ${verseKey}` : pageInfo
+        const ayahPart = verseKey ? `${strings.ayah} ${verseKey}` : pageInfo
         const state = [ayahPart, reciterName].filter(Boolean).join(' • ')
         if (state)
           presenceData.state = state


### PR DESCRIPTION
## Description

Improves the Quran.com activity with more accurate and detailed presence information. The existing activity no longer matched Quran.com's current structure and functionality.
### Changes

- Added Quran reading details with the current surah, ayah, and page.
- Added listening activity with playback timestamps and pause status.
- Added reliable names for Quran.com's currently playable reciters.
- Updated reciter information when the selected reciter changes.
- Added specific support for:
  - Direct ayah pages
  - Tafsir pages
  - Quranic duas
  - Verse of the Day
  - Learning plans
  - Search and reciter pages
- Added a title fallback for unsupported or informational pages.
- Added English and Arabic activity text.
- Connected common activity strings to PreMiD localization.
- Improved selectors and removed outdated XPath usage.
- Updated buttons to follow the Activity Guidelines.
- Bumped the activity version from `1.1.0` to `1.2.0`.

### Settings

- Added activity language selection.
- Quran.com also has its own separate language setting. For consistent activity text, users should select the same language in Quran.com and the PreMiD activity settings.
- Reciter names use their official English transliterations.

## Acknowledgements

- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots

<details>
<summary>Proof showing the modification is working as expected</summary>

<img width="363" height="178" alt="Quran.com Discord activity" src="https://github.com/user-attachments/assets/5e3c945e-9f2d-4354-81db-ea580a031a18" />

<img width="932" height="395" alt="Quran.com activity demonstration" src="https://github.com/user-attachments/assets/ff19c1f1-fefc-4272-82e3-3a92a88333b0" />

<img width="348" height="167" alt="Quran.com activity language settings" src="https://github.com/user-attachments/assets/b899465e-37bf-41ea-b1fe-7a0a349257aa" />

</details>