### PR TITLE
feat(Yoru): add activity

### DIFF
--- a/websites/Y/Yoru/metadata.json
+++ b/websites/Y/Yoru/metadata.json
@@ -10,7 +10,7 @@
     "en": "Yoru is an ad-light anime streaming site. Show the anime and episode you are watching, the audio track you picked, and how far into the episode you are."
   },
   "url": "watchyoru.uk",
-  "regExp": "^https?[:][/][/](?:www[.])?watchyoru[.]uk(?:[/]|$)",
+  "regExp": "^https?[:][/][/](www[.])?watchyoru[.]uk[/]",
   "version": "1.0.0",
   "logo": "https://i.imgur.com/fpEpgJD.png",
   "thumbnail": "https://i.imgur.com/28ZLhZo.png",

--- a/websites/Y/Yoru/metadata.json
+++ b/websites/Y/Yoru/metadata.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "name": "trionic2",
+    "id": "1064357832742416494"
+  },
+  "service": "Yoru",
+  "description": {
+    "en": "Yoru is an ad-light anime streaming site. Show the anime and episode you are watching, the audio track you picked, and how far into the episode you are."
+  },
+  "url": "watchyoru.uk",
+  "regExp": "^https?[:][/][/](?:www[.])?watchyoru[.]uk(?:[/]|$)",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/fpEpgJD.png",
+  "thumbnail": "https://i.imgur.com/28ZLhZo.png",
+  "color": "#7C22FF",
+  "category": "anime",
+  "tags": [
+    "anime",
+    "watchyoru",
+    "streaming",
+    "episodes"
+  ],
+  "settings": [
+    {
+      "id": "privacy",
+      "title": "Privacy Mode",
+      "description": "Hide anime titles, episodes and search terms, and show only that you are on Yoru.",
+      "icon": "fa-solid fa-user-secret",
+      "value": false
+    },
+    {
+      "id": "showCover",
+      "title": "Show Cover Art",
+      "description": "Use the cover of the anime you are watching as the large image instead of the Yoru logo.",
+      "icon": "fa-solid fa-image",
+      "value": true
+    },
+    {
+      "id": "showTimestamps",
+      "title": "Show Timestamps",
+      "description": "Show how much time is left in the episode you are watching.",
+      "icon": "fa-solid fa-clock",
+      "value": true
+    },
+    {
+      "id": "showButtons",
+      "title": "Show Buttons",
+      "description": "Show buttons linking to the episode and the anime you are watching.",
+      "icon": "fa-solid fa-link",
+      "value": true
+    }
+  ]
+}

--- a/websites/Y/Yoru/presence.ts
+++ b/websites/Y/Yoru/presence.ts
@@ -1,0 +1,196 @@
+import { ActivityType, Assets, getTimestampsFromMedia } from 'premid'
+
+const presence = new Presence({
+  clientId: '1526166989419315270',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1_000)
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/fpEpgJD.png',
+}
+
+// Yoru serves every episode as Hard Sub, Soft Sub or Dub. The chosen track is
+// in the "type" query parameter, and mirrored by the active pill in the player.
+function audioLabel(type: string | null | undefined): string {
+  switch (type?.toLowerCase()) {
+    case 'sub':
+      return 'Hard Sub'
+    case 'softsub':
+      return 'Soft Sub'
+    case 'dub':
+      return 'Dub'
+    default:
+      return ''
+  }
+}
+
+// Discord caps the details and state rows at 128 characters.
+function clamp(text: string): string {
+  return text.length > 128 ? `${text.slice(0, 127)}…` : text
+}
+
+function textOf(selector: string): string {
+  const text = document.querySelector(selector)?.textContent?.trim() ?? ''
+  // Empty fields on Yoru render as an em dash placeholder until data arrives.
+  return text === '—' ? '' : text
+}
+
+function coverOf(selector: string): string | null {
+  const source = document.querySelector<HTMLImageElement>(selector)?.src
+  return source?.startsWith('https://') ? source : null
+}
+
+// "/watch/one-piece-episode-12" and "/watch/one-piece/" both point at the
+// "/anime/one-piece" detail page.
+function animeSlug(pathname: string): string {
+  const slug = pathname.slice('/watch/'.length).replace(/\/+$/, '')
+  return slug.replace(/(?:-episode-|\/episode\/)\d+$/i, '')
+}
+
+presence.on('UpdateData', async () => {
+  const [privacy, showCover, showTimestamps, showButtons] = await Promise.all([
+    presence.getSetting<boolean>('privacy'),
+    presence.getSetting<boolean>('showCover'),
+    presence.getSetting<boolean>('showTimestamps'),
+    presence.getSetting<boolean>('showButtons'),
+  ])
+  const { pathname, href, origin, search } = document.location
+  const searchParams = new URLSearchParams(search)
+  const presenceData: PresenceData = {
+    name: 'Yoru',
+    type: ActivityType.Watching,
+    details: 'Browsing Yoru',
+    largeImageKey: ActivityAssets.Logo,
+    largeImageText: 'Yoru',
+    startTimestamp: browsingTimestamp,
+  }
+
+  if (pathname.startsWith('/watch/')) {
+    const video = document.querySelector<HTMLVideoElement>('#vid')
+    const title = textOf('#watch-info-title')
+    const episode = textOf('#watch-ep-title')
+    const audio = audioLabel(
+      searchParams.get('type')
+      ?? document.querySelector<HTMLElement>('#type-pills .type-pill.active')?.dataset.type,
+    )
+
+    presenceData.details = privacy || !title ? 'Watching an anime' : clamp(title)
+
+    if (!privacy) {
+      const state = [episode, audio].filter(Boolean).join(' • ')
+
+      if (state)
+        presenceData.state = clamp(state)
+
+      const cover = showCover ? coverOf('#watch-info-cover') : null
+
+      if (cover) {
+        presenceData.largeImageKey = cover
+        // The title already occupies the details row, so name the site here
+        // instead of repeating it.
+        presenceData.largeImageText = 'Watching on Yoru'
+      }
+
+      presenceData.detailsUrl = href
+    }
+
+    if (video) {
+      const paused = video.paused || video.ended
+
+      presenceData.smallImageKey = paused ? Assets.Pause : Assets.Play
+      presenceData.smallImageText = paused ? 'Paused' : 'Playing'
+
+      if (showTimestamps && !paused && video.duration > 0) {
+        [presenceData.startTimestamp, presenceData.endTimestamp]
+          = getTimestampsFromMedia(video)
+      }
+      else {
+        // Leaving startTimestamp in place would make Discord count up from the
+        // moment the page loaded, which has nothing to do with playback.
+        delete presenceData.startTimestamp
+        delete presenceData.endTimestamp
+      }
+    }
+
+    if (showButtons && !privacy) {
+      const slug = animeSlug(pathname)
+
+      presenceData.buttons = slug
+        ? [
+            { label: 'Watch Episode', url: href },
+            { label: 'View Anime', url: `${origin}/anime/${slug}` },
+          ]
+        : [{ label: 'Watch Episode', url: href }]
+    }
+  }
+  else if (pathname.startsWith('/anime/')) {
+    const title = textOf('#detail-title')
+
+    presenceData.details = 'Looking at an anime'
+
+    if (!privacy && title) {
+      presenceData.state = clamp(title)
+      presenceData.detailsUrl = href
+
+      const cover = showCover ? coverOf('#detail-cover') : null
+
+      if (cover) {
+        presenceData.largeImageKey = cover
+        presenceData.largeImageText = title
+        // Nothing is competing for the badge on this page, unlike the player
+        // where it carries the playing/paused state.
+        presenceData.smallImageKey = ActivityAssets.Logo
+        presenceData.smallImageText = 'Yoru'
+      }
+
+      if (showButtons)
+        presenceData.buttons = [{ label: 'View Anime', url: href }]
+    }
+  }
+  else if (pathname.startsWith('/user/')) {
+    const username = decodeURIComponent(pathname.slice('/user/'.length))
+
+    presenceData.details = 'Looking at a profile'
+
+    if (!privacy && username) {
+      presenceData.state = clamp(username)
+      presenceData.detailsUrl = href
+    }
+  }
+  else {
+    switch (pathname) {
+      case '/search': {
+        const query = searchParams.get('q')?.trim()
+
+        presenceData.details = 'Searching for an anime'
+
+        if (!privacy && query)
+          presenceData.state = clamp(query)
+
+        presenceData.smallImageKey = Assets.Search
+        presenceData.smallImageText = 'Searching'
+        break
+      }
+      case '/latest':
+        presenceData.details = 'Browsing the latest episodes'
+        break
+      case '/schedule':
+        presenceData.details = 'Browsing the airing schedule'
+        break
+      case '/changelog':
+        presenceData.details = 'Reading the changelog'
+        break
+      case '/profile':
+        presenceData.details = 'Looking at their profile'
+        break
+      case '/':
+      case '/index.html':
+        presenceData.details = 'Browsing the homepage'
+        break
+      default:
+        break
+    }
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

Adds an activity for [Yoru](https://watchyoru.uk), an ad-light anime streaming site.

Yoru is a single-page app, so the activity reads `document.location` for the route and the page's own elements for the content — `#watch-info-title`, `#watch-ep-title`, `#watch-info-cover` and the `#vid` player on the watch page, `#detail-title` and `#detail-cover` on an anime page. No DOM is modified and no requests are made.

| Page | Status |
| --- | --- |
| `/watch/<slug>?ep=N&type=…` | Anime title, `Episode N: Title • Hard Sub/Soft Sub/Dub`, cover art, playing/paused small image, time remaining, buttons to the episode and the anime |
| `/anime/<slug>` | "Looking at an anime" + title, cover art badged with the site logo, button to the anime |
| `/search?q=…` | "Searching for an anime" + the query |
| `/latest` | "Browsing the latest episodes" |
| `/schedule` | "Browsing the airing schedule" |
| `/changelog` | "Reading the changelog" |
| `/profile`, `/user/<name>` | "Looking at their profile" / "Looking at a profile" + username |
| `/` | "Browsing the homepage" |

Timestamps are taken from the player with `getTimestampsFromMedia` and both are removed while playback is paused. Settings: **Privacy Mode** (reduces every status to a generic "on Yoru"), **Show Cover Art**, **Show Timestamps** and **Show Buttons**.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

**Episode playing**

<img width="1919" height="1079" alt="Episode playing" src="https://github.com/user-attachments/assets/389ffe34-dfb3-4504-91d6-a698c29fbb1b" />

**Episode paused**

<img width="1919" height="1078" alt="Episode paused" src="https://github.com/user-attachments/assets/ef300341-12a0-4dbc-8fdd-f8a69b89a797" />

**Anime page**

<img width="1900" height="1079" alt="Anime page" src="https://github.com/user-attachments/assets/282d1ceb-945b-4932-b0e6-1d5c08b9699d" />

**Search**

<img width="1919" height="1079" alt="Search" src="https://github.com/user-attachments/assets/300137ae-d624-460f-a162-9f895951714a" />

**Activity settings**

<img width="1919" height="1079" alt="Activity settings" src="https://github.com/user-attachments/assets/cc7f9994-a7fa-486d-bdc6-5f4581476f42" />

</details>