### PR TITLE
feat(SoloLatino): add activity

### DIFF
--- a/websites/S/SoloLatino/iframe.ts
+++ b/websites/S/SoloLatino/iframe.ts
@@ -1,0 +1,13 @@
+const iframe = new iFrame()
+
+iframe.on('UpdateData', async () => {
+  const video = document.querySelector('video')
+
+  if (video && !Number.isNaN(video.duration)) {
+    iframe.send({
+      duration: video.duration,
+      currentTime: video.currentTime,
+      paused: video.paused,
+    })
+  }
+})

--- a/websites/S/SoloLatino/metadata.json
+++ b/websites/S/SoloLatino/metadata.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "0immagic0",
+    "id": "1545854937341239306"
+  },
+  "contributors": [],
+  "service": "SoloLatino",
+  "description": {
+    "en": "SoloLatino.Net is a free streaming website where you can watch movies, series, animes and doramas dubbed in Latin Spanish.",
+    "es": "SoloLatino.Net es un sitio de streaming gratuito donde puedes ver películas, series, animes y doramas doblados al español latino."
+  },
+  "url": "sololatino.net",
+  "regExp": "^https?[:][/][/]sololatino[.]net[/]",
+  "version": "1.1.0",
+  "logo": "https://i.imgur.com/Rwq5vaF.png",
+  "thumbnail": "https://i.imgur.com/Rwq5vaF.png",
+  "color": "#e50914",
+  "category": "videos",
+  "tags": [
+    "streaming",
+    "peliculas",
+    "series",
+    "anime",
+    "doramas",
+    "latino",
+    "espanol",
+    "movies",
+    "tv"
+  ],
+  "iframe": true,
+  "iFrameRegExp": "player[.]pelisserieshoy[.]com|embed69[.]org|xupalace[.]org|drive[.]google[.]com|.*vidhide.*|.*streamhide.*",
+  "settings": [
+    {
+      "id": "brand",
+      "title": "Mostrar SoloLatino en el estado",
+      "icon": "fas fa-signature",
+      "value": true,
+      "description": "Muestra \"Viendo SoloLatino\" como título de la actividad. Si lo desactivas, se muestra \"Viendo\" seguido únicamente del nombre de la serie o película."
+    },
+    {
+      "id": "showTempEp",
+      "title": "Mostrar temporada y episodio",
+      "icon": "fas fa-list-ol",
+      "value": true,
+      "description": "Muestra la temporada y el episodio actual mientras ves una serie."
+    },
+    {
+      "id": "showTime",
+      "title": "Mostrar tiempo restante",
+      "icon": "fas fa-stopwatch",
+      "value": true,
+      "description": "Muestra el minuto en el que vas, con un contador sincronizado al reproductor."
+    },
+    {
+      "id": "showCover",
+      "title": "Mostrar portada",
+      "icon": "fas fa-image",
+      "value": true,
+      "description": "Usa la portada de la serie o película como imagen grande en lugar del logo."
+    },
+    {
+      "id": "showPlayState",
+      "title": "Mostrar estado de reproducción",
+      "icon": "fas fa-play-circle",
+      "value": true,
+      "description": "Muestra un pequeño icono que indica si el video está en reproducción o en pausa."
+    },
+    {
+      "id": "showButton",
+      "title": "Mostrar botón Ver ahora",
+      "icon": "fas fa-external-link-alt",
+      "value": true,
+      "description": "Añade un botón que abre directamente la página de la serie, episodio o película que estás viendo."
+    }
+  ]
+}

--- a/websites/S/SoloLatino/metadata.json
+++ b/websites/S/SoloLatino/metadata.json
@@ -13,9 +13,9 @@
   },
   "url": "sololatino.net",
   "regExp": "^https?[:][/][/]sololatino[.]net[/]",
-  "version": "1.1.0",
-  "logo": "https://i.imgur.com/Rwq5vaF.png",
-  "thumbnail": "https://i.imgur.com/Rwq5vaF.png",
+  "version": "1.0.0",
+  "logo": "https://i.imgur.com/WTlbzGb.png",
+  "thumbnail": "https://i.imgur.com/WTlbzGb.png",
   "color": "#e50914",
   "category": "videos",
   "tags": [

--- a/websites/S/SoloLatino/presence.ts
+++ b/websites/S/SoloLatino/presence.ts
@@ -1,0 +1,258 @@
+import { ActivityType, Assets, getTimestamps } from 'premid'
+
+const presence = new Presence({
+  // Crea tu aplicación en https://discord.com/developers/applications y pega aquí su Client ID
+  clientId: '1545854937341239306',
+})
+
+enum ActivityAssets {
+  Logo = 'https://i.imgur.com/Rwq5vaF.png',
+}
+
+interface VideoData {
+  duration: number
+  currentTime: number
+  paused: boolean
+}
+
+interface SchemaNode {
+  '@type'?: string | string[]
+  name?: string
+  image?: string
+  partOfSeason?: { seasonNumber?: number }
+  partOfSeries?: { name?: string }
+}
+
+let video: VideoData = { duration: 0, currentTime: 0, paused: true }
+let lastIFrameUpdate = 0
+const iframeCacheDuration = 5000
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+const strings = presence.getStrings({
+  play: 'general.playing',
+  pause: 'general.paused',
+  browse: 'general.browsing',
+})
+
+presence.on('iFrameData', (data: unknown) => {
+  video = data as VideoData
+  lastIFrameUpdate = Date.now()
+})
+
+function getSchemaNode(): SchemaNode | null {
+  for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+    try {
+      const parsed = JSON.parse(script.textContent ?? '') as SchemaNode & { '@graph'?: SchemaNode[] }
+      const graph = parsed['@graph']
+      const nodes = Array.isArray(graph) ? graph : [parsed]
+      for (const node of nodes) {
+        const type = Array.isArray(node['@type']) ? node['@type'][0] : node['@type']
+        if (type === 'TVEpisode' || type === 'Movie' || type === 'TVSeries')
+          return node
+      }
+    }
+    catch {
+      continue
+    }
+  }
+  return null
+}
+
+function cleanTitle(raw: string): string {
+  return raw
+    .replace(/^\s*Ver\s+/i, '')
+    .replace(/\s*\(\d{4}\)\s*Online.*$/i, '')
+    .replace(/\s+Online.*$/i, '')
+    .replace(/\s*\|\s*SoloLatino\.Net\s*$/i, '')
+    .trim()
+}
+
+function getOgTitle(): string {
+  return document.querySelector<HTMLMetaElement>('meta[property="og:title"]')?.content ?? ''
+}
+
+function getOgImage(): string {
+  return document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.content ?? ''
+}
+
+function getYear(): string {
+  return getOgTitle().match(/\((\d{4})\)/)?.[1] ?? ''
+}
+
+function prettify(value: string): string {
+  return value
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength)
+    return text
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`
+}
+
+function getParentVideo(): VideoData | null {
+  const el = document.querySelector<HTMLVideoElement>('#player-frame video')
+  if (!el || Number.isNaN(el.duration) || el.duration <= 0 || Number.isNaN(el.currentTime))
+    return null
+  return { duration: el.duration, currentTime: el.currentTime, paused: el.paused }
+}
+
+function getVideoData(): VideoData | null {
+  if (Date.now() - lastIFrameUpdate < iframeCacheDuration && video.duration > 0)
+    return video
+  const parentVideo = getParentVideo()
+  return parentVideo || (video.duration > 0 ? video : null)
+}
+
+function applyVideoState(
+  presenceData: PresenceData,
+  showTime: boolean,
+  showPlayState: boolean,
+  playLabel: string,
+  pauseLabel: string,
+): void {
+  const currentVideo = getVideoData()
+  if (!currentVideo || currentVideo.duration <= 0 || Number.isNaN(currentVideo.duration) || Number.isNaN(currentVideo.currentTime))
+    return
+
+  if (showTime && !currentVideo.paused) {
+    [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(
+      Math.floor(currentVideo.currentTime),
+      Math.floor(currentVideo.duration),
+    )
+  }
+
+  if (showPlayState) {
+    presenceData.smallImageKey = currentVideo.paused ? Assets.Pause : Assets.Play
+    presenceData.smallImageText = currentVideo.paused ? pauseLabel : playLabel
+  }
+}
+
+function applyButton(presenceData: PresenceData, showButton: boolean, url: string): void {
+  if (showButton)
+    presenceData.buttons = [{ label: 'Ver ahora', url }]
+}
+
+presence.on('UpdateData', async () => {
+  const s = await strings
+  const brand = await presence.getSetting<boolean>('brand')
+  const showTempEp = await presence.getSetting<boolean>('showTempEp')
+  const showTime = await presence.getSetting<boolean>('showTime')
+  const showCover = await presence.getSetting<boolean>('showCover')
+  const showPlayState = await presence.getSetting<boolean>('showPlayState')
+  const showButton = await presence.getSetting<boolean>('showButton')
+
+  const { pathname, href, search } = document.location
+  const schema = getSchemaNode()
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    name: 'SoloLatino',
+    largeImageKey: ActivityAssets.Logo,
+  }
+
+  const episodeMatch = pathname.match(/^\/serie\/([^/]+)\/temporada-(\d+)\/episodio-(\d+)/)
+  const seriesMatch = pathname.match(/^\/serie\/([^/]+)\/?$/)
+  const movieMatch = pathname.match(/^\/pelicula\/([^/]+)\/?$/)
+
+  if (episodeMatch) {
+    const seasonNumber = episodeMatch[2]
+    const episodeNumber = episodeMatch[3]
+    const seriesName = schema?.partOfSeries?.name || cleanTitle(getOgTitle()) || 'Serie'
+    const episodeTitle = schema?.name || document.querySelector('h1')?.textContent?.trim() || ''
+    const cover = getOgImage()
+    const tempEp = `Temporada ${seasonNumber} · Episodio ${episodeNumber}`
+
+    if (brand) {
+      presenceData.details = `Viendo ${seriesName}`
+      if (showTempEp)
+        presenceData.state = episodeTitle ? truncate(`${tempEp} · ${episodeTitle}`, 120) : tempEp
+      else if (episodeTitle)
+        presenceData.state = truncate(episodeTitle, 120)
+    }
+    else {
+      presenceData.name = seriesName
+      if (showTempEp)
+        presenceData.details = tempEp
+      if (episodeTitle)
+        presenceData.state = truncate(episodeTitle, 120)
+    }
+
+    presenceData.largeImageKey = showCover && cover ? cover : ActivityAssets.Logo
+    presenceData.largeImageText = seriesName
+    applyVideoState(presenceData, showTime, showPlayState, s.play, s.pause)
+    applyButton(presenceData, showButton, href)
+    return presence.setActivity(presenceData)
+  }
+
+  if (movieMatch) {
+    const movieName = schema?.name || cleanTitle(getOgTitle()) || 'Película'
+    const cover = getOgImage()
+    const year = getYear()
+    const movieLabel = year ? `Película · ${year}` : 'Película'
+
+    if (brand) {
+      presenceData.details = `Viendo ${movieName}`
+      presenceData.state = movieLabel
+    }
+    else {
+      presenceData.name = movieName
+      presenceData.details = movieLabel
+    }
+
+    presenceData.largeImageKey = showCover && cover ? cover : ActivityAssets.Logo
+    presenceData.largeImageText = movieName
+    applyVideoState(presenceData, showTime, showPlayState, s.play, s.pause)
+    applyButton(presenceData, showButton, href)
+    return presence.setActivity(presenceData)
+  }
+
+  if (seriesMatch) {
+    const seriesName = schema?.name || cleanTitle(getOgTitle()) || 'Serie'
+    const cover = schema?.image || getOgImage()
+
+    if (brand) {
+      presenceData.details = `Explorando ${seriesName}`
+      presenceData.state = 'Serie'
+    }
+    else {
+      presenceData.name = seriesName
+      presenceData.details = 'Serie'
+    }
+
+    presenceData.largeImageKey = showCover && cover ? cover : ActivityAssets.Logo
+    presenceData.largeImageText = seriesName
+    presenceData.startTimestamp = browsingTimestamp
+    presenceData.smallImageKey = Assets.Search
+    presenceData.smallImageText = s.browse
+    applyButton(presenceData, showButton, href)
+    return presence.setActivity(presenceData)
+  }
+
+  presenceData.details = 'Explorando SoloLatino'
+  presenceData.state = 'Navegando'
+  presenceData.startTimestamp = browsingTimestamp
+  presenceData.smallImageKey = Assets.Search
+  presenceData.smallImageText = s.browse
+
+  if (pathname === '/' || pathname === '') {
+    presenceData.state = 'Página principal'
+  }
+  else if (/^\/(series|peliculas|animes|doramas)\/?$/.test(pathname)) {
+    presenceData.state = prettify(pathname.replace(/\//g, ''))
+  }
+  else if (/^\/genero\/[^/]+/.test(pathname)) {
+    presenceData.state = `Género: ${prettify(pathname.split('/')[2] ?? '')}`
+  }
+  else if (/^\/red\/[^/]+/.test(pathname)) {
+    presenceData.state = `Plataforma: ${prettify(pathname.split('/')[2] ?? '')}`
+  }
+  else if (pathname.startsWith('/buscar')) {
+    const query = new URLSearchParams(search).get('q')
+    presenceData.state = query ? truncate(`Buscando: ${query}`, 80) : 'Buscando contenido'
+  }
+
+  return presence.setActivity(presenceData)
+})

--- a/websites/S/SoloLatino/presence.ts
+++ b/websites/S/SoloLatino/presence.ts
@@ -6,7 +6,7 @@ const presence = new Presence({
 })
 
 enum ActivityAssets {
-  Logo = 'https://i.imgur.com/Rwq5vaF.png',
+  Logo = 'https://i.imgur.com/WTlbzGb.png',
 }
 
 interface VideoData {

--- a/websites/S/SoloLatino/presence.ts
+++ b/websites/S/SoloLatino/presence.ts
@@ -153,9 +153,9 @@ presence.on('UpdateData', async () => {
     largeImageKey: ActivityAssets.Logo,
   }
 
-  const episodeMatch = pathname.match(/^\/serie\/(?:[^/]+)\/temporada-(\d+)\/episodio-(\d+)/)
-  const seriesMatch = pathname.match(/^\/serie\/(?:[^/]+)\/?$/)
-  const movieMatch = pathname.match(/^\/pelicula\/(?:[^/]+)\/?$/)
+  const episodeMatch = pathname.match(/^\/serie\/[^/]+\/temporada-(\d+)\/episodio-(\d+)/)
+  const seriesMatch = pathname.match(/^\/serie\/[^/]+\/?$/)
+  const movieMatch = pathname.match(/^\/pelicula\/[^/]+\/?$/)
 
   if (episodeMatch) {
     const seasonNumber = episodeMatch[1]

--- a/websites/S/SoloLatino/presence.ts
+++ b/websites/S/SoloLatino/presence.ts
@@ -17,10 +17,10 @@ interface VideoData {
 
 interface SchemaNode {
   '@type'?: string | string[]
-  name?: string
-  image?: string
-  partOfSeason?: { seasonNumber?: number }
-  partOfSeries?: { name?: string }
+  'name'?: string
+  'image'?: string
+  'partOfSeason'?: { seasonNumber?: number }
+  'partOfSeries'?: { name?: string }
 }
 
 let video: VideoData = { duration: 0, currentTime: 0, paused: true }
@@ -153,13 +153,13 @@ presence.on('UpdateData', async () => {
     largeImageKey: ActivityAssets.Logo,
   }
 
-  const episodeMatch = pathname.match(/^\/serie\/([^/]+)\/temporada-(\d+)\/episodio-(\d+)/)
-  const seriesMatch = pathname.match(/^\/serie\/([^/]+)\/?$/)
-  const movieMatch = pathname.match(/^\/pelicula\/([^/]+)\/?$/)
+  const episodeMatch = pathname.match(/^\/serie\/(?:[^/]+)\/temporada-(\d+)\/episodio-(\d+)/)
+  const seriesMatch = pathname.match(/^\/serie\/(?:[^/]+)\/?$/)
+  const movieMatch = pathname.match(/^\/pelicula\/(?:[^/]+)\/?$/)
 
   if (episodeMatch) {
-    const seasonNumber = episodeMatch[2]
-    const episodeNumber = episodeMatch[3]
+    const seasonNumber = episodeMatch[1]
+    const episodeNumber = episodeMatch[2]
     const seriesName = schema?.partOfSeries?.name || cleanTitle(getOgTitle()) || 'Serie'
     const episodeTitle = schema?.name || document.querySelector('h1')?.textContent?.trim() || ''
     const cover = getOgImage()
@@ -240,7 +240,7 @@ presence.on('UpdateData', async () => {
   if (pathname === '/' || pathname === '') {
     presenceData.state = 'Página principal'
   }
-  else if (/^\/(series|peliculas|animes|doramas)\/?$/.test(pathname)) {
+  else if (/^\/(?:series|peliculas|animes|doramas)\/?$/.test(pathname)) {
     presenceData.state = prettify(pathname.replace(/\//g, ''))
   }
   else if (/^\/genero\/[^/]+/.test(pathname)) {


### PR DESCRIPTION
## Description
Adds a new Rich Presence activity for **SoloLatino** (https://sololatino.net).
SoloLatino is a streaming service where users can watch movies, TV series, animes, and doramas in Latin Spanish.

Features:
- **TV Series & Anime**: Detects series title, season, episode number, episode name, and cover image.
- **Movies**: Detects movie title, release year, and cover image.
- **Playback & Time**: Syncs current time, remaining duration, and play/pause status using the player iframe and HTML5 video fallback.
- **Browsing**: Detects main page, categories (Series, Películas, Animes, Doramas), genres, and search queries.
- **User Settings**: Options to toggle brand display, season/episode details, remaining time counter, custom cover, play/pause icon, and "Watch now" button.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>

![Watching Episode Proof 1](https://i.imgur.com/fjDbJd4.png)
![Watching Episode Proof 2](https://i.imgur.com/eICGUXS.png)
![Watching Movie Proof 1](https://i.imgur.com/CfZGCzV.png)
![Watching Movie Proof 2](https://i.imgur.com/1y9YT7u.png)

</details>
