### PR TITLE
fix(Peacock): resolve playback presence detection

### DIFF
--- a/websites/P/Peacock/metadata.json
+++ b/websites/P/Peacock/metadata.json
@@ -13,6 +13,10 @@
     {
       "name": "not__bob",
       "id": "1446263635268735151"
+    },
+    {
+      "name": "oncefeltloved",
+      "id": "1454675198598058101"
     }
   ],
   "service": "Peacock",
@@ -25,7 +29,7 @@
     "peacocktv.com"
   ],
   "regExp": "^https?[:][/][/](www[.])?peacocktv[.]com[/]",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/P/Peacock/assets/thumbnail.png",
   "color": "#FCCC12",

--- a/websites/P/Peacock/presence.ts
+++ b/websites/P/Peacock/presence.ts
@@ -20,15 +20,10 @@ function getCoverKey(): string | undefined {
 }
 
 function findWatchingVideo(): HTMLVideoElement | null {
-  const video = document.querySelector<HTMLVideoElement>('#core-video-shaka')
-    || document.querySelector<HTMLVideoElement>('.video-player-component video')
-
   // The detail page autoplays a muted preview clip in the background; that
   // isn't the user deliberately watching something, so it doesn't count.
-  if (video?.closest('[data-gsp-shortform-player]'))
-    return null
-
-  return video
+  const videos = document.querySelectorAll<HTMLVideoElement>('video')
+  return [...videos].find(video => !video.closest('[data-gsp-shortform-player]')) ?? null
 }
 
 presence.on('UpdateData', async () => {
@@ -80,6 +75,7 @@ presence.on('UpdateData', async () => {
       const title = document.querySelector('[data-testid="metadata-title"]')
         || document.querySelector('.playback-header__title')
         || document.querySelector('.playback-metadata__container-title')
+        || document.querySelector('h1')
       const timestamps = getTimestamps(
         Math.floor(video.currentTime),
         Math.floor(video.duration),
@@ -99,7 +95,8 @@ presence.on('UpdateData', async () => {
         delete presenceData.state
       }
       else {
-        let titleText = title?.textContent ?? undefined
+        let titleText = title?.textContent?.trim()
+          || document.title.replace(/\s*[-|]\s*Peacock.*$/i, '').trim()
         if (titleText && path.includes('/watch/playback/playlist'))
           titleText += ' Playlist'
 
@@ -107,6 +104,8 @@ presence.on('UpdateData', async () => {
           presenceData.name = titleText
           if (desc)
             presenceData.details = desc.textContent
+          else
+            presenceData.details = strings.watchingVid
         }
         else {
           if (titleText)
@@ -158,6 +157,24 @@ presence.on('UpdateData', async () => {
         const cover = getCoverKey()
         if (cover)
           presenceData.largeImageKey = cover
+      }
+    }
+    else if (path.includes('/watch/playback')) {
+      isWatching = true
+      ;(presenceData as PresenceData).type = ActivityType.Watching
+
+      const titleText = document.querySelector('h1')?.textContent?.trim()
+        || document.title.replace(/\s*[-|]\s*Peacock.*$/i, '').trim()
+
+      if (privacy) {
+        presenceData.details = strings.watchingVid
+      }
+      else if (usePresenceName && titleText) {
+        presenceData.name = titleText
+        presenceData.details = strings.watchingVid
+      }
+      else if (titleText) {
+        presenceData.details = titleText
       }
     }
   }


### PR DESCRIPTION
﻿## Description

Fix Peacock playback presence detection when the player is not exposed as a page-level `video` element. Playback routes now fall back to the visible title and report a Watching activity instead of remaining on Browsing. Known muted preview videos are ignored when a page-level player is available.

This also includes the existing Peacock settings for privacy, browsing status, timestamps, cover art, title display, and play/pause state.

## Validation

- `npx pmd build Peacock --validate --zip`
- Focused ESLint passed.
- TypeScript diagnostics passed.

## Screenshots

### Before

![Peacock settings](https://raw.githubusercontent.com/hashking710/PreMiD-Plugins/main/docs/peacock/issue%201.png)

![Browsing status](https://raw.githubusercontent.com/hashking710/PreMiD-Plugins/main/docs/peacock/issue%202.png)

### After

![Watching status](https://raw.githubusercontent.com/hashking710/PreMiD-Plugins/main/docs/peacock/resolved%201.png)

![Discord profile activity](https://raw.githubusercontent.com/hashking710/PreMiD-Plugins/main/docs/peacock/resolved%202.png)
