### PR TITLE
feat(RNGdle): add activity

### DIFF
--- a/websites/R/RNGdle/metadata.json
+++ b/websites/R/RNGdle/metadata.json
@@ -10,9 +10,10 @@
     "en": "RNGdle is a daily number-rolling game. Earn badges and EP from the patterns in your roll and compete on the leaderboard."
   },
   "url": "www.rngdle.com",
+  "regExp": "^https?://(www\\.)?rngdle\\.com/",
   "version": "1.0.0",
-  "logo": "https://www.rngdle.com/favicon/web-app-manifest-512x512.png",
-  "thumbnail": "https://www.rngdle.com/favicon/web-app-manifest-512x512.png",
+  "logo": "https://github.com/user-attachments/assets/a456896f-d063-46ee-94e6-cad07feb0f12",
+  "thumbnail": "https://github.com/user-attachments/assets/b32d3b39-8959-49cd-97a1-e02b546fa0db",
   "color": "#FFFFFF",
   "category": "games",
   "tags": [

--- a/websites/R/RNGdle/metadata.json
+++ b/websites/R/RNGdle/metadata.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.16",
+  "apiVersion": 1,
+  "author": {
+    "name": "developedbyalex",
+    "id": "626130640768729088"
+  },
+  "service": "RNGdle",
+  "description": {
+    "en": "RNGdle is a daily number-rolling game. Earn badges and EP from the patterns in your roll and compete on the leaderboard."
+  },
+  "url": "www.rngdle.com",
+  "version": "1.0.0",
+  "logo": "https://www.rngdle.com/favicon/web-app-manifest-512x512.png",
+  "thumbnail": "https://www.rngdle.com/favicon/web-app-manifest-512x512.png",
+  "color": "#FFFFFF",
+  "category": "games",
+  "tags": [
+    "rng",
+    "daily",
+    "numbers",
+    "badges"
+  ],
+  "settings": [
+    {
+      "id": "showNames",
+      "title": "Show usernames",
+      "icon": "fas fa-user",
+      "value": true
+    }
+  ]
+}

--- a/websites/R/RNGdle/presence.ts
+++ b/websites/R/RNGdle/presence.ts
@@ -7,7 +7,7 @@ presence.on('UpdateData', async () => {
   const showNames = await presence.getSetting<boolean>('showNames')
   const { pathname } = document.location
   const presenceData: PresenceData = {
-    largeImageKey: 'https://www.rngdle.com/favicon/web-app-manifest-512x512.png',
+    largeImageKey: 'https://github.com/user-attachments/assets/a456896f-d063-46ee-94e6-cad07feb0f12',
     startTimestamp: browsingTimestamp,
     details: 'Browsing RNGdle',
   }

--- a/websites/R/RNGdle/presence.ts
+++ b/websites/R/RNGdle/presence.ts
@@ -1,0 +1,81 @@
+const presence = new Presence({
+  clientId: '1546333183132565535',
+})
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+
+presence.on('UpdateData', async () => {
+  const showNames = await presence.getSetting<boolean>('showNames')
+  const { pathname } = document.location
+  const presenceData: PresenceData = {
+    largeImageKey: 'https://www.rngdle.com/favicon/web-app-manifest-512x512.png',
+    startTimestamp: browsingTimestamp,
+    details: 'Browsing RNGdle',
+  }
+
+  if (pathname === '/') {
+    const profileLink = document.querySelector('header a[href="/profile"]')
+    const username = profileLink?.querySelector('span')?.textContent?.trim()
+    const score = document.querySelector('main div.type-data.inline-flex')?.textContent?.trim()
+    const lifetimeLabel = [...document.querySelectorAll('main .type-meta')]
+      .find(element => element.textContent?.trim() === 'Your lifetime EP')
+    const lifetime = lifetimeLabel?.parentElement?.querySelector('.type-data')?.textContent?.trim()
+    const completed = [...document.querySelectorAll('main .type-meta')]
+      .some(element => element.textContent?.trim() === 'Next roll in')
+
+    presenceData.details = showNames && username && username !== 'Profile'
+      ? `Playing as ${username}`
+      : 'Playing the daily roll'
+
+    const scores: string[] = []
+    // The score animates while badges are revealed; only publish the final total.
+    if (completed && score && /^[\d,]+ EP$/.test(score))
+      scores.push(`Today: ${score}`)
+    if (lifetime && /^[\d,]+ EP$/.test(lifetime))
+      scores.push(`Lifetime: ${lifetime}`)
+
+    if (scores.length)
+      presenceData.state = scores.join(' | ')
+  }
+  else if (pathname === '/leaderboard') {
+    presenceData.details = 'Browsing the leaderboard'
+    const period = document.querySelector('main button.border-prose')?.textContent?.trim()
+    if (period)
+      presenceData.state = period
+  }
+  else if (/^\/u\/[^/]+\/?$/.test(pathname)) {
+    const username = document.querySelector('main h1')?.textContent?.trim()
+    const scoreLabel = [...document.querySelectorAll('main .type-label')]
+      .find(element => element.textContent?.trim() === 'Total EP')
+    const score = scoreLabel?.nextElementSibling?.textContent?.trim()
+
+    presenceData.details = 'Viewing a player profile'
+    if (showNames && username)
+      presenceData.details = `Viewing ${username}'s profile`
+    if (score && /^[\d,]+$/.test(score))
+      presenceData.state = `Lifetime: ${score} EP`
+  }
+  else if (/^\/u\/[^/]+\/roll\/\d+\/?$/.test(pathname)) {
+    presenceData.details = 'Viewing a roll'
+    const score = document.querySelector('main .type-data')?.textContent?.trim()
+    if (score && /^[\d,]+ EP$/.test(score))
+      presenceData.state = `Score: ${score}`
+  }
+  else if (/^\/u\/[^/]+\/badges\/[^/]+\/?$/.test(pathname)) {
+    presenceData.details = 'Viewing a badge collection'
+  }
+  else if (pathname === '/about') {
+    presenceData.details = 'Reading about RNGdle'
+  }
+  else if (pathname === '/profile') {
+    presenceData.details = 'Viewing their profile'
+  }
+  else if (pathname === '/friends') {
+    presenceData.details = 'Viewing friends'
+  }
+  else {
+    presence.clearActivity()
+    return
+  }
+
+  presence.setActivity(presenceData)
+})


### PR DESCRIPTION
## Description

Adds RNGdle support for #11103. The daily-roll activity shows the signed-in player name, completed daily EP and lifetime EP. It distinguishes leaderboards, public profiles, individual rolls and badge collections, and includes a setting to hide usernames. Loading and animation states do not publish partial daily scores; unsupported routes clear the activity.

Closes #11103.

## Validation

- PreMiD type checking, metadata/application/image validation and compilation passed.
- 20 behavior assertions passed, covering score extraction, zero values, animation, username privacy, page transitions and stale-state clearing.
- Full repository lint is being checked. Live Discord screenshots and final GitHub-hosted assets are being added before this draft is marked ready.

## Acknowledgements

- [x] I read the Activity Guidelines.
- [x] I ran `npm run lint`.
- [x] The PR title follows the repository's commit conventions.

## Screenshots

Live Discord and extension-settings evidence is pending.

## Assets

Images will be uploaded directly to GitHub at the contributor's request. Imgur is unavailable in the contributor's region. The draft currently uses the official RNGdle logo for local testing; maintainer acceptance of GitHub asset hosting is needed.
