### PR TITLE
feat(Gensokyo Radio): add activity

### DIFF
--- a/websites/G/Gensokyo Radio/metadata.json
+++ b/websites/G/Gensokyo Radio/metadata.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.11",
+  "author": {
+    "name": "nyannoying",
+    "id": "173796735699779585"
+  },
+  "service": "Gensokyo Radio",
+  "description": {
+    "en": "A 24/7 internet radio station playing fan-made Touhou Project music."
+  },
+  "url": ["gensokyoradio.net", "app.gensokyoradio.net", "forum.gensokyoradio.net", "gensokyo.store"],
+  "regExp": "^https?:\\/\\/(app\\.gensokyoradio\\.net|forum\\.gensokyoradio\\.net|(www\\.)?gensokyo\\.store|(www\\.)?gensokyoradio\\.net)\\/.*$",
+  "logo": "https://i.imgur.com/D3eyWs8.png",
+  "thumbnail": "https://i.imgur.com/ooORT0H.png",
+  "color": "#8a2f4a",
+  "tags": ["music", "radio", "touhou", "anime"],
+  "category": "music",
+  "version": "1.0.0"
+}

--- a/websites/G/Gensokyo Radio/metadata.json
+++ b/websites/G/Gensokyo Radio/metadata.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://schemas.premid.app/metadata/1.11",
+  "apiVersion": 1,
   "author": {
     "name": "nyannoying",
     "id": "173796735699779585"
@@ -10,10 +11,10 @@
   },
   "url": ["gensokyoradio.net", "app.gensokyoradio.net", "forum.gensokyoradio.net", "gensokyo.store"],
   "regExp": "^https?:\\/\\/(app\\.gensokyoradio\\.net|forum\\.gensokyoradio\\.net|(www\\.)?gensokyo\\.store|(www\\.)?gensokyoradio\\.net)\\/.*$",
+  "version": "1.0.0",
   "logo": "https://i.imgur.com/D3eyWs8.png",
   "thumbnail": "https://i.imgur.com/ooORT0H.png",
   "color": "#8a2f4a",
-  "tags": ["music", "radio", "touhou", "anime"],
   "category": "music",
-  "version": "1.0.0"
+  "tags": ["music", "radio", "touhou", "anime"]
 }

--- a/websites/G/Gensokyo Radio/presence.ts
+++ b/websites/G/Gensokyo Radio/presence.ts
@@ -1,13 +1,13 @@
-import { ActivityType, Assets, getTimestamps } from "premid";
+import { ActivityType, Assets, getTimestamps } from 'premid'
 
 const presence = new Presence({
-  clientId: "1546592847531217008"
-});
+  clientId: '1546592847531217008',
+})
 
-const browsingTimestamp = Math.floor(Date.now() / 1000);
-const GR_LOGO_URL = "https://i.imgur.com/D3eyWs8.png";
-const GR_WS_URL = "wss://gensokyoradio.net/wss";
-const REFRESH_INTERVAL_MS = 15000;
+const browsingTimestamp = Math.floor(Date.now() / 1000)
+const GR_LOGO_URL = 'https://i.imgur.com/D3eyWs8.png'
+const GR_WS_URL = 'wss://gensokyoradio.net/wss'
+const REFRESH_INTERVAL_MS = 15000
 
 // wss://gensokyoradio.net/wss protocol:
 //   -> {"message":"grInitialConnection"}   (send first, or server stays silent)
@@ -19,144 +19,148 @@ const REFRESH_INTERVAL_MS = 15000;
 //   -> {"message":"grSongDataRequest"} to ask for a fresh songid frame
 
 interface GRSongData {
-  songid: number;
-  title: string;
-  artist: string;
-  album: string;
-  circle: string;
-  duration: number;
-  played: number;
-  remaining: number;
-  albumart: string;
-  albumid: number;
-  year: number;
+  songid: number
+  title: string
+  artist: string
+  album: string
+  circle: string
+  duration: number
+  played: number
+  remaining: number
+  albumart: string
+  albumid: number
+  year: number
 }
 
 interface GRSocketMessage {
-  message?: "grInitialConnection" | "welcome" | "ping" | "pong" | "grSongDataRequest";
-  id?: number;
-  [key: string]: unknown;
+  message?: 'grInitialConnection' | 'welcome' | 'ping' | 'pong' | 'grSongDataRequest'
+  id?: number
+  [key: string]: unknown
 }
 
-let socket: WebSocket | null = null;
-let welcomeId: number | null = null;
-let nowPlaying: GRSongData | null = null;
-let nowPlayingReceivedAt = 0;
-let refreshInterval: ReturnType<typeof setInterval> | null = null;
+let socket: WebSocket | null = null
+let welcomeId: number | null = null
+let nowPlaying: GRSongData | null = null
+let nowPlayingReceivedAt = 0
+let refreshInterval: ReturnType<typeof setInterval> | null = null
 
 function isSongData(data: GRSocketMessage): data is GRSocketMessage & GRSongData {
-  return typeof data.songid === "number" && typeof data.title === "string";
+  return typeof data.songid === 'number' && typeof data.title === 'string'
 }
 
 function connectSocket() {
   if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
-    return;
+    return
   }
 
-  socket = new WebSocket(GR_WS_URL);
+  socket = new WebSocket(GR_WS_URL)
 
-  socket.addEventListener("open", () => {
-    socket?.send(JSON.stringify({ message: "grInitialConnection" }));
+  socket.addEventListener('open', () => {
+    socket?.send(JSON.stringify({ message: 'grInitialConnection' }))
 
-    if (refreshInterval !== null) clearInterval(refreshInterval);
+    if (refreshInterval !== null)
+      clearInterval(refreshInterval)
     refreshInterval = setInterval(() => {
-      socket?.send(JSON.stringify({ message: "grSongDataRequest" }));
-    }, REFRESH_INTERVAL_MS);
-  });
+      socket?.send(JSON.stringify({ message: 'grSongDataRequest' }))
+    }, REFRESH_INTERVAL_MS)
+  })
 
-  socket.addEventListener("message", (event) => {
-    let data: GRSocketMessage;
+  socket.addEventListener('message', (event) => {
+    let data: GRSocketMessage
     try {
-      data = JSON.parse(event.data);
-    } catch {
-      return;
+      data = JSON.parse(event.data)
+    }
+    catch {
+      return
     }
 
-    if (data.message === "welcome" && typeof data.id === "number") {
-      welcomeId = data.id;
-      return;
+    if (data.message === 'welcome' && typeof data.id === 'number') {
+      welcomeId = data.id
+      return
     }
 
-    if (data.message === "ping") {
-      socket?.send(JSON.stringify({ message: "pong", id: welcomeId ?? data.id }));
-      return;
+    if (data.message === 'ping') {
+      socket?.send(JSON.stringify({ message: 'pong', id: welcomeId ?? data.id }))
+      return
     }
 
     if (isSongData(data)) {
-      nowPlaying = data;
-      nowPlayingReceivedAt = Date.now();
+      nowPlaying = data
+      nowPlayingReceivedAt = Date.now()
     }
-  });
+  })
 
-  socket.addEventListener("close", () => {
-    socket = null;
+  socket.addEventListener('close', () => {
+    socket = null
     if (refreshInterval !== null) {
-      clearInterval(refreshInterval);
-      refreshInterval = null;
+      clearInterval(refreshInterval)
+      refreshInterval = null
     }
-  });
+  })
 
-  socket.addEventListener("error", () => {
-    socket?.close();
-  });
+  socket.addEventListener('error', () => {
+    socket?.close()
+  })
 }
 
 function detectPaused(): boolean {
   // Angular player: <ion-icon name="play"|"stop"> shows the action the button performs
   const stateIcon = document.querySelector<HTMLElement>(
-    'ion-icon[name="stop"], ion-icon[name="play"]'
-  );
+    'ion-icon[name="stop"], ion-icon[name="play"]',
+  )
   if (stateIcon) {
-    return stateIcon.getAttribute("name") === "play";
+    return stateIcon.getAttribute('name') === 'play'
   }
 
   // Classic /playing page has no reliable play/pause signal in the DOM — no <audio>
   // element, and the button's icon is animated via SMIL with no accessible state.
   // Defaulting to "playing" is also just factually true most of the time: the
   // station is always broadcasting regardless of whether you've muted locally.
-  return false;
+  return false
 }
 
-function readPageTimer(): { played: number; duration: number } | null {
-  const el = document.querySelector<HTMLElement>("#playerCounter");
-  const text = el?.textContent?.trim();
-  if (!text) return null;
+function readPageTimer(): { played: number, duration: number } | null {
+  const el = document.querySelector<HTMLElement>('#playerCounter')
+  const text = el?.textContent?.trim()
+  if (!text)
+    return null
 
-  const match = text.match(/^(\d+):(\d{2})\s*\/\s*(\d+):(\d{2})$/);
-  if (!match) return null;
+  const match = text.match(/^(\d+):(\d{2})\s*\/\s*(\d+):(\d{2})$/)
+  if (!match)
+    return null
 
-  const [, elapsedMin, elapsedSec, totalMin, totalSec] = match;
+  const [, elapsedMin, elapsedSec, totalMin, totalSec] = match
   return {
     played: Number(elapsedMin) * 60 + Number(elapsedSec),
-    duration: Number(totalMin) * 60 + Number(totalSec)
-  };
+    duration: Number(totalMin) * 60 + Number(totalSec),
+  }
 }
 
-presence.on("UpdateData", async () => {
-  const { pathname, href } = document.location;
+presence.on('UpdateData', async () => {
+  const { pathname, href } = document.location
   let presenceData: PresenceData = {
     largeImageKey: GR_LOGO_URL,
-    startTimestamp: browsingTimestamp
-  };
+    startTimestamp: browsingTimestamp,
+  }
 
-  const onPlayerPage =
-    href.includes("app.gensokyoradio.net/player") ||
-    pathname.includes("/playing") ||
-    (location.hostname === "app.gensokyoradio.net" && document.querySelector("audio") !== null);
-  const onStorePage = href.includes("gensokyo.store");
-  const onForumPage = href.includes("forum.gensokyoradio.net");
+  const onPlayerPage
+    = href.includes('app.gensokyoradio.net/player')
+      || pathname.includes('/playing')
+      || (location.hostname === 'app.gensokyoradio.net' && document.querySelector('audio') !== null)
+  const onStorePage = href.includes('gensokyo.store')
+  const onForumPage = href.includes('forum.gensokyoradio.net')
 
   if (onPlayerPage) {
-    connectSocket();
+    connectSocket()
 
     if (nowPlaying) {
-      const paused = detectPaused();
-      const details = `\u25B6 ${nowPlaying.title}`;
+      const paused = detectPaused()
+      const details = `\u25B6 ${nowPlaying.title}`
       const state = nowPlaying.circle
         ? `${nowPlaying.artist} \u2014 ${nowPlaying.circle}`
-        : nowPlaying.artist;
-      const largeImageKey = nowPlaying.albumart || GR_LOGO_URL;
-      const largeImageText = nowPlaying.album;
+        : nowPlaying.artist
+      const largeImageKey = nowPlaying.albumart || GR_LOGO_URL
+      const largeImageText = nowPlaying.album
 
       if (paused) {
         presenceData = {
@@ -166,23 +170,25 @@ presence.on("UpdateData", async () => {
           largeImageKey,
           largeImageText,
           smallImageKey: Assets.Pause,
-          smallImageText: "Paused"
-        };
-      } else {
-        const pageTimer = readPageTimer();
-        let playedSeconds: number;
-        let durationSeconds: number;
+          smallImageText: 'Paused',
+        }
+      }
+      else {
+        const pageTimer = readPageTimer()
+        let playedSeconds: number
+        let durationSeconds: number
 
         if (pageTimer) {
-          playedSeconds = pageTimer.played;
-          durationSeconds = pageTimer.duration;
-        } else {
-          const elapsedSinceMessage = (Date.now() - nowPlayingReceivedAt) / 1000;
-          playedSeconds = Math.min(nowPlaying.played + elapsedSinceMessage, nowPlaying.duration);
-          durationSeconds = nowPlaying.duration;
+          playedSeconds = pageTimer.played
+          durationSeconds = pageTimer.duration
+        }
+        else {
+          const elapsedSinceMessage = (Date.now() - nowPlayingReceivedAt) / 1000
+          playedSeconds = Math.min(nowPlaying.played + elapsedSinceMessage, nowPlaying.duration)
+          durationSeconds = nowPlaying.duration
         }
 
-        const [start, end] = getTimestamps(Math.floor(playedSeconds), durationSeconds);
+        const [start, end] = getTimestamps(Math.floor(playedSeconds), durationSeconds)
 
         presenceData = {
           type: ActivityType.Listening,
@@ -191,81 +197,92 @@ presence.on("UpdateData", async () => {
           largeImageKey,
           largeImageText,
           smallImageKey: Assets.Play,
-          smallImageText: "Playing",
+          smallImageText: 'Playing',
           startTimestamp: start,
-          endTimestamp: end
-        };
+          endTimestamp: end,
+        }
       }
-    } else {
-      presenceData.details = "Connecting to Gensokyo Radio\u2026";
-      presenceData.state = "100% fan-made Touhou Project music";
     }
-  } else if (onStorePage) {
-    presenceData.details = "Browsing the Gensokyo Store";
-    presenceData.state = "Merch & music";
-    presenceData.smallImageKey = Assets.Search;
-  } else if (onForumPage) {
+    else {
+      presenceData.details = 'Connecting to Gensokyo Radio\u2026'
+      presenceData.state = '100% fan-made Touhou Project music'
+    }
+  }
+  else if (onStorePage) {
+    presenceData.details = 'Browsing the Gensokyo Store'
+    presenceData.state = 'Merch & music'
+    presenceData.smallImageKey = Assets.Search
+  }
+  else if (onForumPage) {
     // Discourse titles: "Topic - Category - Gensokyo Radio" or "Category - Gensokyo Radio"
-    const suffix = " - Gensokyo Radio";
+    const suffix = ' - Gensokyo Radio'
 
     if (document.title.endsWith(suffix)) {
-      const withoutSuffix = document.title.slice(0, -suffix.length);
-      const lastDashIndex = withoutSuffix.lastIndexOf(" - ");
+      const withoutSuffix = document.title.slice(0, -suffix.length)
+      const lastDashIndex = withoutSuffix.lastIndexOf(' - ')
 
-      if (pathname.startsWith("/t/") && lastDashIndex !== -1) {
-        const topicTitle = withoutSuffix.slice(0, lastDashIndex);
-        const category = withoutSuffix.slice(lastDashIndex + 3);
-        presenceData.details = "Reading a forum topic";
-        presenceData.state = `"${topicTitle}" in ${category}`;
-      } else if (pathname.startsWith("/c/")) {
-        presenceData.details = `Browsing the ${withoutSuffix} forum`;
-      } else {
-        presenceData.details = "Browsing the Forums";
+      if (pathname.startsWith('/t/') && lastDashIndex !== -1) {
+        const topicTitle = withoutSuffix.slice(0, lastDashIndex)
+        const category = withoutSuffix.slice(lastDashIndex + 3)
+        presenceData.details = 'Reading a forum topic'
+        presenceData.state = `"${topicTitle}" in ${category}`
       }
-    } else {
-      presenceData.details = "Browsing the Forums";
+      else if (pathname.startsWith('/c/')) {
+        presenceData.details = `Browsing the ${withoutSuffix} forum`
+      }
+      else {
+        presenceData.details = 'Browsing the Forums'
+      }
     }
-  } else {
+    else {
+      presenceData.details = 'Browsing the Forums'
+    }
+  }
+  else {
     const articleMatch = document.title.match(
-      /^(.+?)\s\((News|Reviews?)\)\s\|\s*Gensokyo Radio$/i
-    );
+      /^(.+?)\s\((News|Reviews?)\)\s\|\s*Gensokyo Radio$/i,
+    )
 
     if (articleMatch) {
-      const [, articleTitle, articleType] = articleMatch;
-      presenceData.details =
-        (articleType ?? "").toLowerCase() === "news" ? "Reading through news" : "Reading a review";
-      presenceData.state = articleTitle;
-    } else if (pathname.startsWith("/news")) {
-      presenceData.details = "Browsing News";
-    } else if (pathname.startsWith("/reviews")) {
-      presenceData.details = "Browsing Reviews";
-    } else {
+      const [, articleTitle, articleType] = articleMatch
+      presenceData.details
+        = (articleType ?? '').toLowerCase() === 'news' ? 'Reading through news' : 'Reading a review'
+      presenceData.state = articleTitle
+    }
+    else if (pathname.startsWith('/news')) {
+      presenceData.details = 'Browsing News'
+    }
+    else if (pathname.startsWith('/reviews')) {
+      presenceData.details = 'Browsing Reviews'
+    }
+    else {
       // URL-based labels — their title doesn't always update on client-side nav
       const pathLabels: Array<[RegExp, string]> = [
-        [/^\/music\/circle\/[^/]+\/?$/, "Browsing a Circle"],
-        [/^\/music\/circle\/?$/, "Browsing Circles"],
-        [/^\/music\/artist\/[^/]+\/?$/, "Browsing an Artist"],
-        [/^\/music\/artist\/?$/, "Browsing Artists"],
-        [/^\/music\/album\/\d+\/?$/, "Browsing an Album"],
-        [/^\/music\/?$/, "Browsing Music"],
-        [/^\/shows\/?$/, "Browsing Podcasts"],
-        [/^\/search\/?$/, "Searching Gensokyo Radio"],
-        [/^\/faq\/?$/, "Reading the FAQ"],
-        [/^\/about\/?$/, "Learning About Gensokyo Radio"],
-        [/^\/account/, "Managing their Account"]
-      ];
-      const pathMatch = pathLabels.find(([re]) => re.test(pathname));
+        [/^\/music\/circle\/[^/]+\/?$/, 'Browsing a Circle'],
+        [/^\/music\/circle\/?$/, 'Browsing Circles'],
+        [/^\/music\/artist\/[^/]+\/?$/, 'Browsing an Artist'],
+        [/^\/music\/artist\/?$/, 'Browsing Artists'],
+        [/^\/music\/album\/\d+\/?$/, 'Browsing an Album'],
+        [/^\/music\/?$/, 'Browsing Music'],
+        [/^\/shows\/?$/, 'Browsing Podcasts'],
+        [/^\/search\/?$/, 'Searching Gensokyo Radio'],
+        [/^\/faq\/?$/, 'Reading the FAQ'],
+        [/^\/about\/?$/, 'Learning About Gensokyo Radio'],
+        [/^\/account/, 'Managing their Account'],
+      ]
+      const pathMatch = pathLabels.find(([re]) => re.test(pathname))
 
       if (pathMatch) {
-        presenceData.details = pathMatch[1];
-      } else {
-        const genericMatch = document.title.match(/^(.+?)\s\|\s*Gensokyo Radio$/i);
+        presenceData.details = pathMatch[1]
+      }
+      else {
+        const genericMatch = document.title.match(/^(.+?)\s\|\s*Gensokyo Radio$/i)
         presenceData.details = genericMatch
           ? `Browsing ${genericMatch[1]}`
-          : "Browsing Gensokyo Radio";
+          : 'Browsing Gensokyo Radio'
       }
     }
   }
 
-  presence.setActivity(presenceData);
-});
+  presence.setActivity(presenceData)
+})

--- a/websites/G/Gensokyo Radio/presence.ts
+++ b/websites/G/Gensokyo Radio/presence.ts
@@ -1,0 +1,277 @@
+import { ActivityType, Assets, getTimestamps } from "premid";
+
+const presence = new Presence({
+  clientId: "1546592847531217008"
+});
+
+const browsingTimestamp = Math.floor(Date.now() / 1000);
+const GR_LOGO_URL = "https://i.imgur.com/D3eyWs8.png";
+const GR_WS_URL = "wss://gensokyoradio.net/wss";
+const REFRESH_INTERVAL_MS = 15000;
+
+// wss://gensokyoradio.net/wss protocol:
+//   -> {"message":"grInitialConnection"}   (send first, or server stays silent)
+//   <- {"message":"welcome","id":123}
+//   <- {"songid":1,"title":"...","artist":"...","album":"...","circle":"...",
+//       "duration":244,"played":56,"remaining":188,"albumart":"https://...",
+//       "albumid":1,"year":2011}
+//   <- {"message":"ping"} -> reply {"message":"pong","id":123}
+//   -> {"message":"grSongDataRequest"} to ask for a fresh songid frame
+
+interface GRSongData {
+  songid: number;
+  title: string;
+  artist: string;
+  album: string;
+  circle: string;
+  duration: number;
+  played: number;
+  remaining: number;
+  albumart: string;
+  albumid: number;
+  year: number;
+}
+
+interface GRSocketMessage {
+  message?: "grInitialConnection" | "welcome" | "ping" | "pong" | "grSongDataRequest";
+  id?: number;
+  [key: string]: unknown;
+}
+
+let socket: WebSocket | null = null;
+let welcomeId: number | null = null;
+let nowPlaying: GRSongData | null = null;
+let nowPlayingReceivedAt = 0;
+let refreshInterval: ReturnType<typeof setInterval> | null = null;
+
+function isSongData(data: GRSocketMessage): data is GRSocketMessage & GRSongData {
+  return typeof data.songid === "number" && typeof data.title === "string";
+}
+
+function connectSocket() {
+  if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
+    return;
+  }
+
+  socket = new WebSocket(GR_WS_URL);
+
+  socket.addEventListener("open", () => {
+    socket?.send(JSON.stringify({ message: "grInitialConnection" }));
+
+    if (refreshInterval !== null) clearInterval(refreshInterval);
+    refreshInterval = setInterval(() => {
+      socket?.send(JSON.stringify({ message: "grSongDataRequest" }));
+    }, REFRESH_INTERVAL_MS);
+  });
+
+  socket.addEventListener("message", (event) => {
+    let data: GRSocketMessage;
+    try {
+      data = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+
+    if (data.message === "welcome" && typeof data.id === "number") {
+      welcomeId = data.id;
+      return;
+    }
+
+    if (data.message === "ping") {
+      socket?.send(JSON.stringify({ message: "pong", id: welcomeId ?? data.id }));
+      return;
+    }
+
+    if (isSongData(data)) {
+      nowPlaying = data;
+      nowPlayingReceivedAt = Date.now();
+    }
+  });
+
+  socket.addEventListener("close", () => {
+    socket = null;
+    if (refreshInterval !== null) {
+      clearInterval(refreshInterval);
+      refreshInterval = null;
+    }
+  });
+
+  socket.addEventListener("error", () => {
+    socket?.close();
+  });
+}
+
+function detectPaused(): boolean {
+  // Angular player: <ion-icon name="play"|"stop"> shows the action the button performs
+  const stateIcon = document.querySelector<HTMLElement>(
+    'ion-icon[name="stop"], ion-icon[name="play"]'
+  );
+  if (stateIcon) {
+    return stateIcon.getAttribute("name") === "play";
+  }
+
+  // Classic /playing page: #playStopBtn polygon morphs between a play triangle and stop square
+  const shape = document.querySelector<SVGPolygonElement>(
+    "#playStopBtn polygon#shape, #playStopBtn polygon"
+  );
+  if (shape) {
+    const points = shape.getAttribute("points") ?? "";
+    const looksLikeStopSquare = points.includes("45,45") && points.includes("95,95");
+    return !looksLikeStopSquare;
+  }
+
+  return false;
+}
+
+function readPageTimer(): { played: number; duration: number } | null {
+  const el = document.querySelector<HTMLElement>("#playerCounter");
+  const text = el?.textContent?.trim();
+  if (!text) return null;
+
+  const match = text.match(/^(\d+):(\d{2})\s*\/\s*(\d+):(\d{2})$/);
+  if (!match) return null;
+
+  const [, elapsedMin, elapsedSec, totalMin, totalSec] = match;
+  return {
+    played: Number(elapsedMin) * 60 + Number(elapsedSec),
+    duration: Number(totalMin) * 60 + Number(totalSec)
+  };
+}
+
+presence.on("UpdateData", async () => {
+  const { pathname, href } = document.location;
+  let presenceData: PresenceData = {
+    largeImageKey: GR_LOGO_URL,
+    startTimestamp: browsingTimestamp
+  };
+
+  const onPlayerPage =
+    href.includes("app.gensokyoradio.net/player") ||
+    pathname.includes("/playing") ||
+    (location.hostname === "app.gensokyoradio.net" && document.querySelector("audio") !== null);
+  const onStorePage = href.includes("gensokyo.store");
+  const onForumPage = href.includes("forum.gensokyoradio.net");
+
+  if (onPlayerPage) {
+    connectSocket();
+
+    if (nowPlaying) {
+      const paused = detectPaused();
+      const details = `\u25B6 ${nowPlaying.title}`;
+      const state = nowPlaying.circle
+        ? `${nowPlaying.artist} \u2014 ${nowPlaying.circle}`
+        : nowPlaying.artist;
+      const largeImageKey = nowPlaying.albumart || GR_LOGO_URL;
+      const largeImageText = nowPlaying.album;
+
+      if (paused) {
+        presenceData = {
+          type: ActivityType.Listening,
+          details,
+          state,
+          largeImageKey,
+          largeImageText,
+          smallImageKey: Assets.Pause,
+          smallImageText: "Paused"
+        };
+      } else {
+        const pageTimer = readPageTimer();
+        let playedSeconds: number;
+        let durationSeconds: number;
+
+        if (pageTimer) {
+          playedSeconds = pageTimer.played;
+          durationSeconds = pageTimer.duration;
+        } else {
+          const elapsedSinceMessage = (Date.now() - nowPlayingReceivedAt) / 1000;
+          playedSeconds = Math.min(nowPlaying.played + elapsedSinceMessage, nowPlaying.duration);
+          durationSeconds = nowPlaying.duration;
+        }
+
+        const [start, end] = getTimestamps(Math.floor(playedSeconds), durationSeconds);
+
+        presenceData = {
+          type: ActivityType.Listening,
+          details,
+          state,
+          largeImageKey,
+          largeImageText,
+          smallImageKey: Assets.Play,
+          smallImageText: "Playing",
+          startTimestamp: start,
+          endTimestamp: end
+        };
+      }
+    } else {
+      presenceData.details = "Connecting to Gensokyo Radio\u2026";
+      presenceData.state = "100% fan-made Touhou Project music";
+    }
+  } else if (onStorePage) {
+    presenceData.details = "Browsing the Gensokyo Store";
+    presenceData.state = "Merch & music";
+    presenceData.smallImageKey = Assets.Search;
+  } else if (onForumPage) {
+    // Discourse titles: "Topic - Category - Gensokyo Radio" or "Category - Gensokyo Radio"
+    const suffix = " - Gensokyo Radio";
+
+    if (document.title.endsWith(suffix)) {
+      const withoutSuffix = document.title.slice(0, -suffix.length);
+      const lastDashIndex = withoutSuffix.lastIndexOf(" - ");
+
+      if (pathname.startsWith("/t/") && lastDashIndex !== -1) {
+        const topicTitle = withoutSuffix.slice(0, lastDashIndex);
+        const category = withoutSuffix.slice(lastDashIndex + 3);
+        presenceData.details = "Reading a forum topic";
+        presenceData.state = `"${topicTitle}" in ${category}`;
+      } else if (pathname.startsWith("/c/")) {
+        presenceData.details = `Browsing the ${withoutSuffix} forum`;
+      } else {
+        presenceData.details = "Browsing the Forums";
+      }
+    } else {
+      presenceData.details = "Browsing the Forums";
+    }
+  } else {
+    const articleMatch = document.title.match(
+      /^(.+?)\s\((News|Reviews?)\)\s\|\s*Gensokyo Radio$/i
+    );
+
+    if (articleMatch) {
+      const [, articleTitle, articleType] = articleMatch;
+      presenceData.details =
+        (articleType ?? "").toLowerCase() === "news" ? "Reading through news" : "Reading a review";
+      presenceData.state = articleTitle;
+    } else if (pathname.startsWith("/news")) {
+      presenceData.details = "Browsing News";
+    } else if (pathname.startsWith("/reviews")) {
+      presenceData.details = "Browsing Reviews";
+    } else {
+      // URL-based labels — their title doesn't always update on client-side nav
+      const pathLabels: Array<[RegExp, string]> = [
+        [/^\/music\/circle\/[^/]+\/?$/, "Browsing a Circle"],
+        [/^\/music\/circle\/?$/, "Browsing Circles"],
+        [/^\/music\/artist\/[^/]+\/?$/, "Browsing an Artist"],
+        [/^\/music\/artist\/?$/, "Browsing Artists"],
+        [/^\/music\/album\/\d+\/?$/, "Browsing an Album"],
+        [/^\/music\/?$/, "Browsing Music"],
+        [/^\/shows\/?$/, "Browsing Podcasts"],
+        [/^\/search\/?$/, "Searching Gensokyo Radio"],
+        [/^\/faq\/?$/, "Reading the FAQ"],
+        [/^\/about\/?$/, "Learning About Gensokyo Radio"],
+        [/^\/account/, "Managing their Account"]
+      ];
+      const pathMatch = pathLabels.find(([re]) => re.test(pathname));
+
+      if (pathMatch) {
+        presenceData.details = pathMatch[1];
+      } else {
+        const genericMatch = document.title.match(/^(.+?)\s\|\s*Gensokyo Radio$/i);
+        presenceData.details = genericMatch
+          ? `Browsing ${genericMatch[1]}`
+          : "Browsing Gensokyo Radio";
+      }
+    }
+  }
+
+  presence.setActivity(presenceData);
+});


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->

## Acknowledgements
- [X] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [X] I linted the code by running `npm run lint`
- [X] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="277" height="130" alt="image" src="https://github.com/user-attachments/assets/45cc9c3d-d0bc-4c8a-b9a1-e0b1d19565cf" />
<img width="269" height="129" alt="image" src="https://github.com/user-attachments/assets/23bc9444-bb8f-46c6-b0c5-31354bf9dc1b" />
<img width="272" height="129" alt="image" src="https://github.com/user-attachments/assets/2fd04774-ebf3-42e9-89d0-5dbf3dd37986" />
<img width="271" height="113" alt="image" src="https://github.com/user-attachments/assets/e99f74d4-50c4-431c-84dd-c5d05f87f716" />
<img width="268" height="112" alt="image" src="https://github.com/user-attachments/assets/c266f2be-4590-4730-9b19-5ff29c476804" />
<img width="277" height="117" alt="image" src="https://github.com/user-attachments/assets/2c95bb11-9a21-4a8a-a4f5-8ceccb1b3bbd" />
<img width="279" height="122" alt="image" src="https://github.com/user-attachments/assets/d0fb226e-f1b7-48e3-bc91-b416ab67fe63" />
<img width="270" height="130" alt="image" src="https://github.com/user-attachments/assets/5035b8e0-4f25-4558-8b4b-cbca3208ccd1" />
<img width="273" height="129" alt="image" src="https://github.com/user-attachments/assets/4e51c0fd-c217-432b-aeba-c800e3c6af29" />
<img width="272" height="127" alt="image" src="https://github.com/user-attachments/assets/5f6db753-1d55-471e-8f03-85bc85039d65" />
<img width="273" height="119" alt="image" src="https://github.com/user-attachments/assets/2363b6f3-e6e6-4a29-b33a-1439c0ee172b" />
<img width="280" height="122" alt="image" src="https://github.com/user-attachments/assets/c258d626-36e9-42e7-9ae0-b5691a565ccf" />
<img width="267" height="122" alt="image" src="https://github.com/user-attachments/assets/7a79ec78-5ba4-42d2-95ac-3e4f25d0faad" />



</details>

Here's every status this presence can show, by page type:

Player (app.gensokyoradio.net/player, gensokyoradio.net/playing/)

No data yet: Connecting to Gensokyo Radio… / 100% fan-made Touhou Project music
Playing: ▶ {title} / {artist} — {circle} — with progress bar, "Playing" badge
Paused: same text, "Paused" badge, no progress bar
Store (gensokyo.store)

Browsing the Gensokyo Store / Merch & music
Forum (forum.gensokyoradio.net)

Topic page: Reading a forum topic / "{topic title}" in {category}
Category page: Browsing the {category} forum
Anything else on the forum: Browsing the Forums
News & Reviews articles (title contains (News) or (Reviews))

Reading through news or Reading a review / {article title}
Listing pages (no specific article): Browsing News / Browsing Reviews
Classic site, everything else (path-based, ignores their sometimes-stale tab title)

/music/circle/<name>/ → Browsing a Circle
/music/circle/ → Browsing Circles
/music/artist/<name>/ → Browsing an Artist
/music/artist/ → Browsing Artists
/music/album/<id>/ → Browsing an Album
/music/ → Browsing Music
/shows/ → Browsing Podcasts
/search/ → Searching Gensokyo Radio
/faq → Reading the FAQ
/about → Learning About Gensokyo Radio
/account* → Managing their Account
Anything unmapped → Browsing {Page Name} (parsed from their title), or Browsing Gensokyo Radio as last resort


Known limitation: On the classic gensokyoradio.net/playing/ page, the play/pause state always shows "Playing." That page has no <audio> element and its stop/play icon is driven by a SMIL animation with no state reliably readable from JS. The Angular app.gensokyoradio.net/player page has a proper icon-based indicator and correctly reflects Play/Pause there.

