### PR TITLE
feat(AniWorld): overhaul pages, settings and playback detection

### DIFF
--- a/websites/A/AniWorld/functions/animeData.ts
+++ b/websites/A/AniWorld/functions/animeData.ts
@@ -36,10 +36,6 @@ function getCoverFromPage(): string | undefined {
   return new URL(source, document.location.origin).href
 }
 
-/**
- * Reads everything that is available from the page itself. Cheap enough to run
- * on every update, so season and episode never go stale.
- */
 export function getAnimeData(): AnimeData {
   const path = document.location.pathname.toLowerCase()
 
@@ -53,10 +49,6 @@ export function getAnimeData(): AnimeData {
   }
 }
 
-/**
- * Falls back to Kitsu when the page did not ship a cover, e.g. on pages that
- * omit the cover box entirely.
- */
 export async function fetchCover(title: string): Promise<string | undefined> {
   const url = new URL(KITSU_ANIME_API)
   url.searchParams.set('filter[text]', title)
@@ -73,8 +65,7 @@ export async function fetchCover(title: string): Promise<string | undefined> {
     const { data }: KitsuAnimeResponse = await response.json()
     const poster = data?.[0]?.attributes?.posterImage
 
-    //* Discord renders the large image at roughly 300px, so `small` (284x402)
-    //* is already sharp enough.
+    //* Discord renders the large image at roughly 300px, so `small` is enough.
     return poster?.small ?? poster?.medium ?? poster?.original ?? undefined
   }
   catch {

--- a/websites/A/AniWorld/functions/animeData.ts
+++ b/websites/A/AniWorld/functions/animeData.ts
@@ -4,7 +4,6 @@ export interface AnimeData {
   season?: number
   episode?: number
   movie?: number
-  coverImg?: string
 }
 
 interface KitsuAnimeResponse {
@@ -22,20 +21,6 @@ interface KitsuAnimeResponse {
 
 const KITSU_ANIME_API = 'https://kitsu.io/api/edge/anime'
 
-function getCoverFromPage(): string | undefined {
-  const cover = document.querySelector<HTMLImageElement>('.seriesCoverBox img')
-  if (!cover)
-    return undefined
-
-  //* The cover is lazy-loaded: until it enters the viewport `src` only holds a
-  //* 1x1 base64 placeholder and the real file is kept in `data-src`.
-  const source = cover.dataset.src ?? cover.getAttribute('src')
-  if (!source || source.startsWith('data:'))
-    return undefined
-
-  return new URL(source, document.location.origin).href
-}
-
 export function getAnimeData(): AnimeData {
   const path = document.location.pathname.toLowerCase()
 
@@ -45,7 +30,6 @@ export function getAnimeData(): AnimeData {
     season: Number(path.match(/\/staffel-(\d+)/)?.[1]) || undefined,
     episode: Number(path.match(/\/episode-(\d+)/)?.[1]) || undefined,
     movie: Number(path.match(/\/filme\/film-(\d+)/)?.[1]) || undefined,
-    coverImg: getCoverFromPage(),
   }
 }
 

--- a/websites/A/AniWorld/functions/animeData.ts
+++ b/websites/A/AniWorld/functions/animeData.ts
@@ -1,72 +1,83 @@
 export interface AnimeData {
+  slug: string | null
   title: string
   season?: number
   episode?: number
+  movie?: number
   coverImg?: string
 }
 
-export class AnimeDataFetcher {
-  private animeData: AnimeData
-
-  constructor() {
-    const title = document.querySelector<HTMLHeadingElement>('h1')?.textContent?.trim() || 'Anime'
-    const coverImg = document.querySelector<HTMLImageElement>('div.seriesCoverBox img')?.src
-
-    const url = window.location.href.toLowerCase()
-    const seasonMatch = url.match(/staffel-(\d+)/)
-    const episodeMatch = url.match(/episode-(\d+)/)
-
-    this.animeData = {
-      title,
-      season: seasonMatch ? Number(seasonMatch[1]) : undefined,
-      episode: episodeMatch ? Number(episodeMatch[1]) : undefined,
-      coverImg,
+interface KitsuAnimeResponse {
+  data?: {
+    attributes?: {
+      posterImage?: {
+        small?: string
+        medium?: string
+        large?: string
+        original?: string
+      } | null
     }
-  }
+  }[]
+}
 
-  private async fetchCoverFromAniList(title: string): Promise<string | undefined> {
-    const query = `
-      query ($search: String) {
-        Media(search: $search, type: ANIME) {
-          coverImage {
-            large
-          }
-        }
-      }
-    `
-    const variables = { search: title }
+const KITSU_ANIME_API = 'https://kitsu.io/api/edge/anime'
 
-    try {
-      const response = await fetch('https://graphql.anilist.co', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ query, variables }),
-      })
-      const json = await response.json()
-
-      if (json.data?.Media?.coverImage?.large) {
-        return json.data.Media.coverImage.large
-      }
-    }
-    catch (error) {
-      console.error('Fehler bei AniList API:', error)
-    }
+function getCoverFromPage(): string | undefined {
+  const cover = document.querySelector<HTMLImageElement>('.seriesCoverBox img')
+  if (!cover)
     return undefined
+
+  //* The cover is lazy-loaded: until it enters the viewport `src` only holds a
+  //* 1x1 base64 placeholder and the real file is kept in `data-src`.
+  const source = cover.dataset.src ?? cover.getAttribute('src')
+  if (!source || source.startsWith('data:'))
+    return undefined
+
+  return new URL(source, document.location.origin).href
+}
+
+/**
+ * Reads everything that is available from the page itself. Cheap enough to run
+ * on every update, so season and episode never go stale.
+ */
+export function getAnimeData(): AnimeData {
+  const path = document.location.pathname.toLowerCase()
+
+  return {
+    slug: path.match(/^\/anime\/stream\/([^/]+)/)?.[1] ?? null,
+    title: document.querySelector('h1')?.textContent?.trim() || 'AniWorld',
+    season: Number(path.match(/\/staffel-(\d+)/)?.[1]) || undefined,
+    episode: Number(path.match(/\/episode-(\d+)/)?.[1]) || undefined,
+    movie: Number(path.match(/\/filme\/film-(\d+)/)?.[1]) || undefined,
+    coverImg: getCoverFromPage(),
   }
+}
 
-  public async loadAnimeData(): Promise<AnimeData> {
-    if (this.animeData.coverImg) {
-      return this.animeData
-    }
+/**
+ * Falls back to Kitsu when the page did not ship a cover, e.g. on pages that
+ * omit the cover box entirely.
+ */
+export async function fetchCover(title: string): Promise<string | undefined> {
+  const url = new URL(KITSU_ANIME_API)
+  url.searchParams.set('filter[text]', title)
+  url.searchParams.set('page[limit]', '1')
+  url.searchParams.set('fields[anime]', 'posterImage')
 
-    const coverFromApi = await this.fetchCoverFromAniList(this.animeData.title)
-    if (coverFromApi) {
-      this.animeData.coverImg = coverFromApi
-    }
-    return this.animeData
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/vnd.api+json' },
+    })
+    if (!response.ok)
+      return undefined
+
+    const { data }: KitsuAnimeResponse = await response.json()
+    const poster = data?.[0]?.attributes?.posterImage
+
+    //* Discord renders the large image at roughly 300px, so `small` (284x402)
+    //* is already sharp enough.
+    return poster?.small ?? poster?.medium ?? poster?.original ?? undefined
   }
-
-  public getAnimeData(): AnimeData {
-    return this.animeData
+  catch {
+    return undefined
   }
 }

--- a/websites/A/AniWorld/iframe.ts
+++ b/websites/A/AniWorld/iframe.ts
@@ -2,9 +2,11 @@ const iframe = new iFrame()
 
 iframe.on('UpdateData', () => {
   //* AniWorld embeds third-party hosters (VOE, Doodstream, Filemoon, Vidmoly,
-  //* ...) that each ship their own player, so instead of matching a
-  //* hoster-specific selector take the first video that reports a playable
-  //* duration. This also skips the placeholder players some hosters render
+  //* ...) that each ship their own player, and Filemoon nests its player in yet
+  //* another frame. Both the domains and the embed paths rotate, so the frame
+  //* cannot be recognised by its URL - hence the wide iFrameRegExp. Keep this
+  //* handler cheap and only report a video that actually has a playable
+  //* duration, which also skips the placeholder players some hosters render
   //* before the stream is resolved.
   const video = Array.from(document.querySelectorAll('video'))
     .find(({ duration }) => Number.isFinite(duration) && duration > 0)

--- a/websites/A/AniWorld/iframe.ts
+++ b/websites/A/AniWorld/iframe.ts
@@ -1,13 +1,9 @@
 const iframe = new iFrame()
 
 iframe.on('UpdateData', () => {
-  //* AniWorld embeds third-party hosters (VOE, Doodstream, Filemoon, Vidmoly,
-  //* ...) that each ship their own player, and Filemoon nests its player in yet
-  //* another frame. Both the domains and the embed paths rotate, so the frame
-  //* cannot be recognised by its URL - hence the wide iFrameRegExp. Keep this
-  //* handler cheap and only report a video that actually has a playable
-  //* duration, which also skips the placeholder players some hosters render
-  //* before the stream is resolved.
+  //* Every hoster ships its own player, so match on a playable duration rather
+  //* than a selector. This also skips the placeholders rendered before the
+  //* stream resolves.
   const video = Array.from(document.querySelectorAll('video'))
     .find(({ duration }) => Number.isFinite(duration) && duration > 0)
 

--- a/websites/A/AniWorld/iframe.ts
+++ b/websites/A/AniWorld/iframe.ts
@@ -1,15 +1,20 @@
 const iframe = new iFrame()
 
-iframe.on('UpdateData', async () => {
-  const video = document.querySelector('video.jw-video') as HTMLVideoElement | null
-  if (video && !Number.isNaN(video.duration)) {
-    iframe.send({
-      iframe_video: {
-        iFrameVideo: true,
-        currTime: video.currentTime,
-        duration: video.duration,
-        paused: video.paused,
-      },
-    })
-  }
+iframe.on('UpdateData', () => {
+  //* AniWorld embeds third-party hosters (VOE, Doodstream, Filemoon, Vidmoly,
+  //* ...) that each ship their own player, so instead of matching a
+  //* hoster-specific selector take the first video that reports a playable
+  //* duration. This also skips the placeholder players some hosters render
+  //* before the stream is resolved.
+  const video = Array.from(document.querySelectorAll('video'))
+    .find(({ duration }) => Number.isFinite(duration) && duration > 0)
+
+  if (!video)
+    return
+
+  iframe.send({
+    currentTime: video.currentTime,
+    duration: video.duration,
+    paused: video.paused || video.ended,
+  })
 })

--- a/websites/A/AniWorld/metadata.json
+++ b/websites/A/AniWorld/metadata.json
@@ -59,7 +59,6 @@
       "value": 1,
       "values": [
         "AniWorld Logo",
-        "AniWorld Cover",
         "Kitsu Poster"
       ],
       "if": {

--- a/websites/A/AniWorld/metadata.json
+++ b/websites/A/AniWorld/metadata.json
@@ -31,7 +31,7 @@
     "anicloud"
   ],
   "iframe": true,
-  "iFrameRegExp": "^https?:\\/\\/[^\\/]+\\/(?:[ed]\\/[a-zA-Z0-9]{8,}|video\\/[a-zA-Z0-9]{8,}|embed-[a-zA-Z0-9]{8,}\\.html)",
+  "iFrameRegExp": "^https?:\\/\\/[^\\/]+\\/(?:[a-z]{1,6}\\d{0,4}\\/[a-z0-9]{8,16}|embed-[a-z0-9]{8,16}\\.html)",
   "settings": [
     {
       "id": "lang",

--- a/websites/A/AniWorld/metadata.json
+++ b/websites/A/AniWorld/metadata.json
@@ -20,7 +20,7 @@
   },
   "url": "aniworld.to",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*aniworld[.]to[/]",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/thumbnail.png",
   "color": "#637cf9",
@@ -31,7 +31,7 @@
     "anicloud"
   ],
   "iframe": true,
-  "iFrameRegExp": "^https?[:][/][/](jilliandescribecompany[.]com[/]e|loadx[.]ws[/]video)[/][a-zA-Z0-9]+",
+  "iFrameRegExp": "^https?:\\/\\/[^\\/]+\\/(?:[ed]\\/[a-zA-Z0-9]{8,}|video\\/[a-zA-Z0-9]{8,}|embed-[a-zA-Z0-9]{8,}\\.html)",
   "settings": [
     {
       "id": "lang",

--- a/websites/A/AniWorld/metadata.json
+++ b/websites/A/AniWorld/metadata.json
@@ -53,19 +53,64 @@
       }
     },
     {
-      "id": "showCover",
-      "title": "Show Cover Image",
+      "id": "cover",
+      "title": "Cover Image",
       "icon": "fas fa-images",
-      "value": true,
+      "value": 1,
+      "values": [
+        "AniWorld Logo",
+        "AniWorld Cover",
+        "Kitsu Poster"
+      ],
       "if": {
         "privacy": false
       }
+    },
+    {
+      "id": "detailsFormat",
+      "title": "Details Row",
+      "icon": "fas fa-comment-alt-edit",
+      "value": "%anime%",
+      "placeholder": "Use %anime%, %episodeTitle%, %progress%, %season%, %episode%, %movie%",
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "stateFormat",
+      "title": "State Row",
+      "icon": "fas fa-comment-alt-edit",
+      "value": "%episodeTitle%",
+      "placeholder": "Same as the details row, or {0} to remove the row",
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "displayType",
+      "title": "Pick Status Display",
+      "icon": "fad fa-user-edit",
+      "value": 1,
+      "values": [
+        "Activity Name",
+        "Details",
+        "State"
+      ]
     },
     {
       "id": "timestamp",
       "title": "Show Timestamps",
       "icon": "fad fa-stopwatch",
       "value": true,
+      "if": {
+        "privacy": false
+      }
+    },
+    {
+      "id": "hidePaused",
+      "title": "Hide When Paused",
+      "icon": "fad fa-pause-circle",
+      "value": false,
       "if": {
         "privacy": false
       }

--- a/websites/A/AniWorld/presence.ts
+++ b/websites/A/AniWorld/presence.ts
@@ -1,5 +1,5 @@
 import type { AnimeData } from './functions/animeData.js'
-import { ActivityType, Assets, getTimestamps } from 'premid'
+import { ActivityType, Assets, getTimestamps, StatusDisplayType } from 'premid'
 import { fetchCover, getAnimeData } from './functions/animeData.js'
 
 const presence = new Presence({
@@ -8,6 +8,18 @@ const presence = new Presence({
 
 enum ActivityAssets {
   Logo = 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png',
+}
+
+enum CoverMode {
+  Logo = 0,
+  AniWorld = 1,
+  Kitsu = 2,
+}
+
+enum DisplayType {
+  Name = 0,
+  Details = 1,
+  State = 2,
 }
 
 //* The hoster iframe stops sending as soon as it is unloaded (episode switch,
@@ -197,10 +209,8 @@ function getStaticPages(strings: Strings): Record<string, PageInfo> {
   }
 }
 
-/**
- * Pages whose path carries the interesting part. Checked before the static list
- * so that e.g. /support/frage/<slug> is not swallowed by /support.
- */
+//* Checked before the static list so that /support/frage/<slug> is not
+//* swallowed by the /support entry.
 function getDynamicPage(pathname: string, strings: Strings): PageInfo | undefined {
   const profile = pathname.match(/^\/user\/profil\/([^/]+)/)?.[1]
   if (profile) {
@@ -217,9 +227,8 @@ function getDynamicPage(pathname: string, strings: Strings): PageInfo | undefine
   if (letter) {
     return {
       details: strings.catalog,
-      //* Keep the letter in its own field: the string reads as a prefix in
-      //* English ("Viewing animes with") but as a full sentence in other
-      //* locales, so appending to it would not translate.
+      //* Appending would not translate: the string is a prefix in English but a
+      //* full sentence in other locales.
       state: decodeURIComponent(letter),
       smallImageKey: Assets.Search,
       smallImageText: strings.animes,
@@ -251,10 +260,7 @@ function getDynamicPage(pathname: string, strings: Strings): PageInfo | undefine
   return undefined
 }
 
-/**
- * Sub pages such as /account/support/new are only listed by their base path, so
- * fall back to the longest matching prefix.
- */
+//* Sub pages such as /account/support/new are only listed by their base path.
 function findStaticPage(pathname: string, pages: Record<string, PageInfo>): PageInfo | undefined {
   let matched: [string, PageInfo] | undefined
 
@@ -284,20 +290,14 @@ function getVideoData(): IFrameVideoData | null {
   return videoData
 }
 
-let coverSlug: string | null = null
-let coverImg: string | undefined
+let kitsuSlug: string | null = null
+let kitsuCover: string | undefined
 let pendingCover: Promise<string | undefined> | null = null
 
-/**
- * Resolves the cover once per series - it does not change between episodes, so
- * the Kitsu fallback must not be queried again on every episode switch.
- */
-async function getCover(animeData: AnimeData): Promise<string | undefined> {
-  if (animeData.coverImg)
-    return animeData.coverImg
-
-  if (coverSlug === animeData.slug)
-    return coverImg
+//* Cached per series so an episode switch does not re-query Kitsu.
+async function getKitsuCover(animeData: AnimeData): Promise<string | undefined> {
+  if (kitsuSlug === animeData.slug)
+    return kitsuCover
 
   //* UpdateData keeps firing while the lookup is still open, so share it.
   pendingCover ??= fetchCover(animeData.title).finally(() => {
@@ -306,14 +306,26 @@ async function getCover(animeData: AnimeData): Promise<string | undefined> {
 
   const cover = await pendingCover
 
-  //* Discard a result that arrived after the user moved on to another series.
+  //* Discard a result that arrived after the user moved on.
   if (getAnimeData().slug !== animeData.slug)
     return undefined
 
-  coverSlug = animeData.slug
-  coverImg = cover
+  kitsuSlug = animeData.slug
+  kitsuCover = cover
 
   return cover
+}
+
+async function getCover(animeData: AnimeData, mode: CoverMode): Promise<string> {
+  if (mode === CoverMode.Logo)
+    return ActivityAssets.Logo
+
+  //* Either source may come up empty, so fall through to the other one.
+  const cover = mode === CoverMode.Kitsu
+    ? await getKitsuCover(animeData) ?? animeData.coverImg
+    : animeData.coverImg ?? await getKitsuCover(animeData)
+
+  return cover ?? ActivityAssets.Logo
 }
 
 function getEpisodeTitle(): string | undefined {
@@ -321,8 +333,8 @@ function getEpisodeTitle(): string | undefined {
   if (!heading)
     return undefined
 
-  //* The heading carries the localized title plus the English one in a sibling
-  //* <small>, which would otherwise be glued on without a separator.
+  //* The English title sits in a sibling <small> and would otherwise be glued
+  //* on without a separator.
   const title = heading.querySelector('.episodeGermanTitle')?.textContent
     ?? Array.from(heading.childNodes)
       .filter(node => !(node instanceof Element && node.matches('small.episodeEnglishTitle')))
@@ -330,6 +342,33 @@ function getEpisodeTitle(): string | undefined {
       .join('')
 
   return title.trim() || undefined
+}
+
+//* Unlike the raw %season%/%episode% placeholders this stays correct on movie
+//* pages, which have neither.
+function getProgress(animeData: AnimeData): string {
+  if (animeData.movie !== undefined)
+    return `Movie ${animeData.movie}`
+  if (animeData.episode === undefined)
+    return ''
+
+  return animeData.season === undefined
+    ? `E${animeData.episode}`
+    : `S${animeData.season}E${animeData.episode}`
+}
+
+//* Empty placeholders collapse together with their separator, so a missing
+//* episode title cannot leave a dangling dash behind.
+function formatRow(format: string, animeData: AnimeData, episodeTitle: string | undefined): string {
+  return format
+    .replace(/%anime%/g, animeData.title)
+    .replace(/%episodeTitle%/g, episodeTitle ?? '')
+    .replace(/%progress%/g, getProgress(animeData))
+    .replace(/%season%/g, animeData.season?.toString() ?? '')
+    .replace(/%episode%/g, animeData.episode?.toString() ?? '')
+    .replace(/%movie%/g, animeData.movie?.toString() ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/^[\s\-–·|]+|[\s\-–·|]+$/g, '')
 }
 
 let browsingTimestamp = Math.floor(Date.now() / 1000)
@@ -349,12 +388,26 @@ let strings: Strings
 let staticPages: Record<string, PageInfo>
 
 presence.on('UpdateData', async () => {
-  const [lang, privacyMode, showTitleAsPresence, showCover, showTimestamp] = await Promise.all([
+  const [
+    lang,
+    privacyMode,
+    showTitleAsPresence,
+    coverMode,
+    detailsFormat,
+    stateFormat,
+    displayType,
+    showTimestamp,
+    hidePaused,
+  ] = await Promise.all([
     presence.getSetting<string>('lang').catch(() => 'en'),
     presence.getSetting<boolean>('privacy'),
     presence.getSetting<boolean>('showTitleAsPresence'),
-    presence.getSetting<boolean>('showCover'),
+    presence.getSetting<number>('cover'),
+    presence.getSetting<string>('detailsFormat'),
+    presence.getSetting<string>('stateFormat'),
+    presence.getSetting<number>('displayType'),
     presence.getSetting<boolean>('timestamp'),
+    presence.getSetting<boolean>('hidePaused'),
   ])
 
   //* getStrings() is a round trip to the extension, so only refresh the strings
@@ -378,24 +431,31 @@ presence.on('UpdateData', async () => {
     return
   }
 
+  const statusDisplayType = displayType === DisplayType.Name
+    ? StatusDisplayType.Name
+    : displayType === DisplayType.State
+      ? StatusDisplayType.State
+      : StatusDisplayType.Details
+
   if (page.startsWith('/anime/')) {
     const animeData = getAnimeData()
     const isMovie = animeData.movie !== undefined
     const isEpisode = animeData.episode !== undefined
-    const title = showTitleAsPresence ? animeData.title : 'AniWorld'
-    const largeImageKey = (showCover ? await getCover(animeData) : undefined) ?? ActivityAssets.Logo
+    const name = showTitleAsPresence ? animeData.title : 'AniWorld'
+    const largeImageKey = await getCover(animeData, coverMode)
 
     if (!isEpisode && !isMovie) {
       await presence.setActivity({
         type: ActivityType.Watching,
-        name: title,
-        details: title,
+        name,
+        details: name,
         state: strings.episodeList,
         largeImageKey,
         largeImageText: animeData.title,
         smallImageKey: Assets.Reading,
         smallImageText: strings.episodeList,
         startTimestamp: getBrowsingTimestamp(),
+        statusDisplayType,
         buttons: [{ label: strings.buttonWatchAnime, url: document.location.href }],
       })
       return
@@ -404,29 +464,46 @@ presence.on('UpdateData', async () => {
     wasWatching = true
 
     const video = getVideoData()
-    //* Without player data the safest assumption is that nothing is running,
-    //* e.g. while the hoster is still loading.
+    //* No player data yet, e.g. while the hoster loads.
     const paused = video?.paused ?? true
+
+    if (paused && hidePaused) {
+      await presence.clearActivity()
+      return
+    }
+
+    const episodeTitle = getEpisodeTitle()
+    const details = formatRow(detailsFormat, animeData, episodeTitle)
+    const state = formatRow(stateFormat, animeData, episodeTitle)
+
+    const episodeButton = {
+      label: isMovie ? strings.buttonWatchMovie : strings.buttonWatchEpisode,
+      url: document.location.href,
+    }
+    const seriesButton = animeData.slug
+      ? {
+          label: strings.buttonWatchAnime,
+          url: `${document.location.origin}/anime/stream/${animeData.slug}`,
+        }
+      : undefined
 
     const presenceData: PresenceData = {
       type: ActivityType.Watching,
-      name: title,
-      details: title,
+      name,
+      details: details || animeData.title,
       largeImageKey,
       largeImageText: isMovie
         ? `Movie ${animeData.movie}`
         : `Season ${animeData.season ?? 'N/A'}, Episode ${animeData.episode}`,
       smallImageKey: paused ? Assets.Pause : Assets.Play,
       smallImageText: paused ? strings.videoPaused : strings.videoPlaying,
-      buttons: [{
-        label: isMovie ? strings.buttonWatchMovie : strings.buttonWatchEpisode,
-        url: document.location.href,
-      }],
+      statusDisplayType,
+      buttons: seriesButton ? [episodeButton, seriesButton] : [episodeButton],
     }
 
-    const episodeTitle = getEpisodeTitle()
-    if (episodeTitle)
-      presenceData.state = episodeTitle
+    //* "{0}" lets users drop the row entirely.
+    if (state && !stateFormat.includes('{0}'))
+      presenceData.state = state
 
     if (video && !paused && showTimestamp)
       [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(video.currentTime, video.duration)

--- a/websites/A/AniWorld/presence.ts
+++ b/websites/A/AniWorld/presence.ts
@@ -1,9 +1,31 @@
+import type { AnimeData } from './functions/animeData.js'
 import { ActivityType, Assets, getTimestamps } from 'premid'
-import { AnimeDataFetcher } from './functions/animeData.js'
+import { fetchCover, getAnimeData } from './functions/animeData.js'
 
 const presence = new Presence({
   clientId: '1387112561362604104',
 })
+
+enum ActivityAssets {
+  Logo = 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png',
+}
+
+//* The hoster iframe stops sending as soon as it is unloaded (episode switch,
+//* hoster change, closed player), so data that is no longer being refreshed has
+//* to be dropped instead of freezing the presence on the last known position.
+const VIDEO_DATA_TTL = 10_000
+
+interface IFrameVideoData {
+  currentTime: number
+  duration: number
+  paused: boolean
+}
+
+interface PageInfo {
+  details: string
+  smallImageKey?: Assets
+  smallImageText?: string
+}
 
 async function getStrings() {
   return presence.getStrings({
@@ -12,15 +34,14 @@ async function getStrings() {
     buttonWatchAnime: 'general.buttonWatchAnime',
     buttonWatchEpisode: 'general.buttonViewEpisode',
     buttonWatchMovie: 'general.buttonWatchMovie',
-    buttonViewProfile: 'general.buttonViewProfile',
     account: 'general.viewAccount',
     animes: 'aniworld.animes',
+    browsing: 'general.browsing',
     calendar: 'aniworld.calendar',
-    catalogBrowsing: 'aniworld.catalog.browsing',
-    catalogBrowsingState: 'aniworld.catalog.state',
     dmca: 'aniworld.dmca',
     editinfo: 'aniworld.edit.info',
     episodeList: 'aniworld.episodeList',
+    faq: 'aniworld.support.faq',
     guide: 'aniworld.support.guide',
     home: 'general.viewHome',
     login: 'aniworld.login',
@@ -31,60 +52,24 @@ async function getStrings() {
     profile: 'general.viewProfile',
     random: 'aniworld.random',
     registration: 'aniworld.registration',
-    searchLoading: 'aniworld.search.loading',
-    searchQuery: 'aniworld.search.query',
     settings: 'aniworld.settings',
     subscribed: 'aniworld.subscribed',
+    support: 'aniworld.support.help',
     terms: 'general.terms',
     watchlist: 'aniworld.watchlist',
     wishes: 'aniworld.wishes',
-    faq: 'aniworld.support.faq',
-    support: 'aniworld.support.help',
-    supportQuestion: 'aniworld.support.question',
-    supportQuestionState: 'aniworld.support.questionState',
-    supportViewingQuestion: 'aniworld.support.viewingQuestion',
-    browsing: 'general.browsing',
   })
 }
 
-interface StaticPageInfo {
-  details: string
-  smallImageKey?: Assets
-  smallImageText?: string
-  largeImageKey?: string
-  largeImageText?: string
-  state?: string
-  buttons?: { label: string, url: string }[]
-  startTimestamp?: number
-  endTimestamp?: number
-}
+type Strings = Awaited<ReturnType<typeof getStrings>>
 
-let videoData: {
-  currTime?: number
-  duration?: number
-  paused?: boolean
-  title?: string | null
-} | null = null
-
-presence.on('iFrameData', (data: unknown) => {
-  const iframeData = (data as { iframe_video?: any })?.iframe_video
-  if (iframeData) {
-    videoData = {
-      currTime: iframeData.currTime,
-      duration: iframeData.duration,
-      paused: iframeData.paused,
-      title: iframeData.iFrameTitle || null,
-    }
-  }
-})
-
-let oldLang: string | null = null
-let strings: Awaited<ReturnType<typeof getStrings>>
-
-async function getStaticPages(): Promise<{ [key: string]: StaticPageInfo }> {
-  strings = await getStrings()
-
+function getStaticPages(strings: Strings): Record<string, PageInfo> {
   return {
+    '/': {
+      details: strings.home,
+      smallImageKey: Assets.Reading,
+      smallImageText: strings.home,
+    },
     '/animes': {
       details: strings.animes,
       smallImageKey: Assets.Reading,
@@ -200,60 +185,105 @@ async function getStaticPages(): Promise<{ [key: string]: StaticPageInfo }> {
     },
   }
 }
-let lastAnimeKey: string | null = null
-let cachedAnimeData: Awaited<ReturnType<AnimeDataFetcher['loadAnimeData']>> | null = null
-let isLoadingAnimeData = false
-let lastLoadPromise: Promise<Awaited<ReturnType<AnimeDataFetcher['loadAnimeData']>>> | null = null
 
-function getAnimeKeyFromUrl(url: string): string | null {
-  const match = url.match(/\/anime\/stream\/(.+?)\/?$/)
-  return match && typeof match[1] === 'string' ? match[1] : null
+/**
+ * Sub pages such as /user/profil/<name> or /account/support/new are only listed
+ * by their base path, so fall back to the longest matching prefix.
+ */
+function findStaticPage(pathname: string, pages: Record<string, PageInfo>): PageInfo | undefined {
+  let matched: [string, PageInfo] | undefined
+
+  for (const entry of Object.entries(pages)) {
+    if (pathname !== entry[0] && !pathname.startsWith(`${entry[0]}/`))
+      continue
+
+    if (!matched || entry[0].length > matched[0].length)
+      matched = entry
+  }
+
+  return matched?.[1]
 }
 
-async function getCachedAnimeData(): Promise<AnimeDataFetcher['animeData'] | null> {
-  const key = getAnimeKeyFromUrl(document.location.pathname)
-  if (!key) {
-    lastAnimeKey = null
-    cachedAnimeData = null
-    lastLoadPromise = null
-    return null
-  }
+let videoData: IFrameVideoData | null = null
+let videoDataUpdatedAt = 0
 
-  if (cachedAnimeData && lastAnimeKey === key) {
-    return cachedAnimeData
-  }
+presence.on('iFrameData', (data: IFrameVideoData) => {
+  videoData = data
+  videoDataUpdatedAt = Date.now()
+})
 
-  if (isLoadingAnimeData && lastLoadPromise) {
-    const data = await lastLoadPromise
-    if (getAnimeKeyFromUrl(document.location.pathname) === key) {
-      return data
-    }
-    return null
-  }
+function getVideoData(): IFrameVideoData | null {
+  if (videoData && Date.now() - videoDataUpdatedAt > VIDEO_DATA_TTL)
+    videoData = null
 
-  isLoadingAnimeData = true
-  const animeDataFetcher = new AnimeDataFetcher()
-  const loadPromise = animeDataFetcher.loadAnimeData()
-  lastLoadPromise = loadPromise
-
-  try {
-    const data = await loadPromise
-    if (getAnimeKeyFromUrl(document.location.pathname) === key) {
-      cachedAnimeData = data
-      lastAnimeKey = key
-      return data
-    }
-    return null
-  }
-  finally {
-    isLoadingAnimeData = false
-    lastLoadPromise = null
-  }
+  return videoData
 }
+
+let coverSlug: string | null = null
+let coverImg: string | undefined
+let pendingCover: Promise<string | undefined> | null = null
+
+/**
+ * Resolves the cover once per series - it does not change between episodes, so
+ * the Kitsu fallback must not be queried again on every episode switch.
+ */
+async function getCover(animeData: AnimeData): Promise<string | undefined> {
+  if (animeData.coverImg)
+    return animeData.coverImg
+
+  if (coverSlug === animeData.slug)
+    return coverImg
+
+  //* UpdateData keeps firing while the lookup is still open, so share it.
+  pendingCover ??= fetchCover(animeData.title).finally(() => {
+    pendingCover = null
+  })
+
+  const cover = await pendingCover
+
+  //* Discard a result that arrived after the user moved on to another series.
+  if (getAnimeData().slug !== animeData.slug)
+    return undefined
+
+  coverSlug = animeData.slug
+  coverImg = cover
+
+  return cover
+}
+
+function getEpisodeTitle(): string | undefined {
+  const heading = document.querySelector('h2')
+  if (!heading)
+    return undefined
+
+  //* The heading carries the localized title plus the English one in a sibling
+  //* <small>, which would otherwise be glued on without a separator.
+  const title = heading.querySelector('.episodeGermanTitle')?.textContent
+    ?? Array.from(heading.childNodes)
+      .filter(node => !(node instanceof Element && node.matches('small.episodeEnglishTitle')))
+      .map(node => node.textContent ?? '')
+      .join('')
+
+  return title.trim() || undefined
+}
+
+let browsingTimestamp = Math.floor(Date.now() / 1000)
+let wasWatching = false
+
+function getBrowsingTimestamp(): number {
+  if (wasWatching) {
+    browsingTimestamp = Math.floor(Date.now() / 1000)
+    wasWatching = false
+  }
+
+  return browsingTimestamp
+}
+
+let oldLang: string | null = null
+let strings: Strings
+let staticPages: Record<string, PageInfo>
 
 presence.on('UpdateData', async () => {
-  strings = await getStrings()
-
   const [lang, privacyMode, showTitleAsPresence, showCover, showTimestamp] = await Promise.all([
     presence.getSetting<string>('lang').catch(() => 'en'),
     presence.getSetting<boolean>('privacy'),
@@ -262,138 +292,94 @@ presence.on('UpdateData', async () => {
     presence.getSetting<boolean>('timestamp'),
   ])
 
-  if (oldLang !== lang) {
+  //* getStrings() is a round trip to the extension, so only refresh the strings
+  //* when the selected language actually changed.
+  if (!strings || oldLang !== lang) {
     oldLang = lang
     strings = await getStrings()
+    staticPages = getStaticPages(strings)
   }
 
   const page = document.location.pathname
-  const staticPages = await getStaticPages()
 
   if (privacyMode) {
     await presence.setActivity({
       details: strings.browsing,
       smallImageKey: Assets.Reading,
       smallImageText: strings.browsing,
-      largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png',
+      largeImageKey: ActivityAssets.Logo,
+      startTimestamp: getBrowsingTimestamp(),
     })
     return
   }
 
   if (page.startsWith('/anime/')) {
-    const hasEpisode = page.includes('episode-')
+    const animeData = getAnimeData()
+    const isMovie = animeData.movie !== undefined
+    const isEpisode = animeData.episode !== undefined
+    const title = showTitleAsPresence ? animeData.title : 'AniWorld'
+    const largeImageKey = (showCover ? await getCover(animeData) : undefined) ?? ActivityAssets.Logo
 
-    const animeData = await getCachedAnimeData()
-    const detailsText = showTitleAsPresence ? animeData?.title ?? 'AniWorld' : 'AniWorld'
-    const largeImageKey = showCover
-      ? animeData?.coverImg || 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png'
-      : 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png'
-
-    if (!hasEpisode) {
+    if (!isEpisode && !isMovie) {
       await presence.setActivity({
         type: ActivityType.Watching,
-        name: detailsText,
-        details: detailsText,
+        name: title,
+        details: title,
         state: strings.episodeList,
         largeImageKey,
-        largeImageText: animeData?.title ?? 'AniWorld',
+        largeImageText: animeData.title,
         smallImageKey: Assets.Reading,
         smallImageText: strings.episodeList,
+        startTimestamp: getBrowsingTimestamp(),
         buttons: [{ label: strings.buttonWatchAnime, url: document.location.href }],
       })
       return
     }
 
-    const title = document.querySelector('title')?.textContent ?? ''
-    const heading = document.querySelector('h2')
-    const textWithoutSmall = heading
-      ? Array.from(heading.childNodes)
-          .filter(node => !(node.nodeType === Node.ELEMENT_NODE && (node as Element).matches('small.episodeEnglishTitle')))
-          .map(node => node.textContent ?? '')
-          .join('')
-          .trim()
-      : ''
-    const stateText = [title, textWithoutSmall]
-      .map((t) => {
-        const str = typeof t === 'string' ? t : (t && typeof (t as any).textContent === 'string' ? (t as any).textContent ?? '' : '')
-        return str.replace(/Staffel.*|Episode.*|Filme von| \| AniWorld\.to - Animes gratis online ansehen/g, '').trim()
-      })
-      .filter(Boolean)
-      .join(' - ')
-      .replace(/^-\s*/, '')
+    wasWatching = true
 
-    let timestamps: [number, number] = [Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)]
-    if (videoData?.currTime != null && videoData?.duration != null) {
-      timestamps = getTimestamps(videoData.currTime, videoData.duration)
-    }
+    const video = getVideoData()
+    //* Without player data the safest assumption is that nothing is running,
+    //* e.g. while the hoster is still loading.
+    const paused = video?.paused ?? true
 
-    if (videoData?.paused || !videoData) {
-      await presence.setActivity({
-        type: ActivityType.Watching,
-        name: detailsText,
-        details: detailsText,
-        state: stateText,
-        largeImageKey,
-        largeImageText: `Season ${animeData?.season ?? 'N/A'}, Episode ${animeData?.episode ?? 'N/A'}`,
-        smallImageKey: Assets.Pause,
-        smallImageText: strings.videoPaused,
-        buttons: [{ label: strings.buttonWatchAnime, url: document.location.href }],
-      })
-      return
-    }
-
-    await presence.setActivity({
+    const presenceData: PresenceData = {
       type: ActivityType.Watching,
-      name: detailsText,
-      details: detailsText,
-      state: stateText,
+      name: title,
+      details: title,
       largeImageKey,
-      largeImageText: `Season ${animeData?.season ?? 'N/A'}, Episode ${animeData?.episode ?? 'N/A'}`,
-      smallImageKey: Assets.Play,
-      smallImageText: strings.videoPlaying,
-      startTimestamp: showTimestamp ? timestamps[0] : undefined,
-      endTimestamp: showTimestamp ? timestamps[1] : undefined,
-      buttons: [{ label: strings.buttonWatchAnime, url: document.location.href }],
-    })
-    return
-  }
-
-  if (page === '/') {
-    await presence.setActivity({
-      details: strings.home,
-      smallImageKey: Assets.Reading,
-      smallImageText: strings.home,
-      largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png',
-    })
-    return
-  }
-
-  if (page in staticPages) {
-    const info = staticPages[page]
-    if (info) {
-      const { largeImageText, buttons, ...restPageInfo } = info
-      const activityData: Record<string, unknown> = {
-        ...restPageInfo,
-        largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png',
-      }
-
-      if (buttons && buttons.length > 0) {
-        activityData.buttons = buttons.slice(0, 2) as [typeof buttons[0], typeof buttons[1]?]
-      }
-
-      if (largeImageText) {
-        activityData.largeImageText = largeImageText
-      }
-
-      await presence.setActivity(activityData)
-      return
+      largeImageText: isMovie
+        ? `Movie ${animeData.movie}`
+        : `Season ${animeData.season ?? 'N/A'}, Episode ${animeData.episode}`,
+      smallImageKey: paused ? Assets.Pause : Assets.Play,
+      smallImageText: paused ? strings.videoPaused : strings.videoPlaying,
+      buttons: [{
+        label: isMovie ? strings.buttonWatchMovie : strings.buttonWatchEpisode,
+        url: document.location.href,
+      }],
     }
+
+    const episodeTitle = getEpisodeTitle()
+    if (episodeTitle)
+      presenceData.state = episodeTitle
+
+    if (video && !paused && showTimestamp)
+      [presenceData.startTimestamp, presenceData.endTimestamp] = getTimestamps(video.currentTime, video.duration)
+
+    await presence.setActivity(presenceData)
+    return
   }
+
+  const pageInfo = findStaticPage(page, staticPages)
+    ?? {
+      details: strings.browsing,
+      smallImageKey: Assets.Reading,
+      smallImageText: strings.browsing,
+    }
 
   await presence.setActivity({
-    details: strings.browsing,
-    smallImageKey: Assets.Reading,
-    smallImageText: strings.browsing,
-    largeImageKey: 'https://cdn.rcd.gg/PreMiD/websites/A/AniWorld/assets/logo.png',
+    ...pageInfo,
+    largeImageKey: ActivityAssets.Logo,
+    startTimestamp: getBrowsingTimestamp(),
   })
 })

--- a/websites/A/AniWorld/presence.ts
+++ b/websites/A/AniWorld/presence.ts
@@ -216,7 +216,11 @@ function getDynamicPage(pathname: string, strings: Strings): PageInfo | undefine
   const letter = pathname.match(/^\/katalog\/([^/]+)/)?.[1]
   if (letter) {
     return {
-      details: `${strings.catalog} ${decodeURIComponent(letter)}`,
+      details: strings.catalog,
+      //* Keep the letter in its own field: the string reads as a prefix in
+      //* English ("Viewing animes with") but as a full sentence in other
+      //* locales, so appending to it would not translate.
+      state: decodeURIComponent(letter),
       smallImageKey: Assets.Search,
       smallImageText: strings.animes,
     }

--- a/websites/A/AniWorld/presence.ts
+++ b/websites/A/AniWorld/presence.ts
@@ -12,8 +12,7 @@ enum ActivityAssets {
 
 enum CoverMode {
   Logo = 0,
-  AniWorld = 1,
-  Kitsu = 2,
+  Kitsu = 1,
 }
 
 enum DisplayType {
@@ -316,16 +315,13 @@ async function getKitsuCover(animeData: AnimeData): Promise<string | undefined> 
   return cover
 }
 
+//* Covers hosted on aniworld.to are not an option: Discord never resolves them
+//* into an external asset and falls back to a blank image.
 async function getCover(animeData: AnimeData, mode: CoverMode): Promise<string> {
   if (mode === CoverMode.Logo)
     return ActivityAssets.Logo
 
-  //* Either source may come up empty, so fall through to the other one.
-  const cover = mode === CoverMode.Kitsu
-    ? await getKitsuCover(animeData) ?? animeData.coverImg
-    : animeData.coverImg ?? await getKitsuCover(animeData)
-
-  return cover ?? ActivityAssets.Logo
+  return await getKitsuCover(animeData) ?? ActivityAssets.Logo
 }
 
 function getEpisodeTitle(): string | undefined {

--- a/websites/A/AniWorld/presence.ts
+++ b/websites/A/AniWorld/presence.ts
@@ -23,6 +23,7 @@ interface IFrameVideoData {
 
 interface PageInfo {
   details: string
+  state?: string
   smallImageKey?: Assets
   smallImageText?: string
 }
@@ -38,6 +39,7 @@ async function getStrings() {
     animes: 'aniworld.animes',
     browsing: 'general.browsing',
     calendar: 'aniworld.calendar',
+    catalog: 'aniworld.catalog.browsing',
     dmca: 'aniworld.dmca',
     editinfo: 'aniworld.edit.info',
     episodeList: 'aniworld.episodeList',
@@ -52,9 +54,13 @@ async function getStrings() {
     profile: 'general.viewProfile',
     random: 'aniworld.random',
     registration: 'aniworld.registration',
+    searchLoading: 'aniworld.search.loading',
+    searchQuery: 'aniworld.search.query',
     settings: 'aniworld.settings',
     subscribed: 'aniworld.subscribed',
     support: 'aniworld.support.help',
+    supportQuestion: 'aniworld.support.question',
+    supportQuestionState: 'aniworld.support.questionState',
     terms: 'general.terms',
     watchlist: 'aniworld.watchlist',
     wishes: 'aniworld.wishes',
@@ -99,6 +105,11 @@ function getStaticPages(strings: Strings): Record<string, PageInfo> {
       smallImageText: strings.random,
     },
     '/neu': {
+      details: strings.new,
+      smallImageKey: Assets.Search,
+      smallImageText: strings.new,
+    },
+    '/neue-episoden': {
       details: strings.new,
       smallImageKey: Assets.Search,
       smallImageText: strings.new,
@@ -187,8 +198,58 @@ function getStaticPages(strings: Strings): Record<string, PageInfo> {
 }
 
 /**
- * Sub pages such as /user/profil/<name> or /account/support/new are only listed
- * by their base path, so fall back to the longest matching prefix.
+ * Pages whose path carries the interesting part. Checked before the static list
+ * so that e.g. /support/frage/<slug> is not swallowed by /support.
+ */
+function getDynamicPage(pathname: string, strings: Strings): PageInfo | undefined {
+  const profile = pathname.match(/^\/user\/profil\/([^/]+)/)?.[1]
+  if (profile) {
+    return {
+      details: strings.profile,
+      //* "general.viewProfile" ends with a colon and expects the name next to it.
+      state: document.querySelector('h1')?.textContent?.trim() || decodeURIComponent(profile),
+      smallImageKey: Assets.Reading,
+      smallImageText: strings.profile,
+    }
+  }
+
+  const letter = pathname.match(/^\/katalog\/([^/]+)/)?.[1]
+  if (letter) {
+    return {
+      details: `${strings.catalog} ${decodeURIComponent(letter)}`,
+      smallImageKey: Assets.Search,
+      smallImageText: strings.animes,
+    }
+  }
+
+  if (/^\/support\/frage\//.test(pathname)) {
+    return {
+      details: strings.supportQuestion,
+      smallImageKey: Assets.Question,
+      smallImageText: strings.supportQuestionState,
+    }
+  }
+
+  if (pathname === '/search') {
+    const query = document.querySelector<HTMLInputElement>('#search')?.value.trim()
+    const info: PageInfo = {
+      details: query ? strings.searchQuery : strings.searchLoading,
+      smallImageKey: Assets.Search,
+      smallImageText: strings.searchLoading,
+    }
+
+    if (query)
+      info.state = query
+
+    return info
+  }
+
+  return undefined
+}
+
+/**
+ * Sub pages such as /account/support/new are only listed by their base path, so
+ * fall back to the longest matching prefix.
  */
 function findStaticPage(pathname: string, pages: Record<string, PageInfo>): PageInfo | undefined {
   let matched: [string, PageInfo] | undefined
@@ -370,7 +431,8 @@ presence.on('UpdateData', async () => {
     return
   }
 
-  const pageInfo = findStaticPage(page, staticPages)
+  const pageInfo = getDynamicPage(page, strings)
+    ?? findStaticPage(page, staticPages)
     ?? {
       details: strings.browsing,
       smallImageKey: Assets.Reading,


### PR DESCRIPTION
## Description
The activity is currently broken on `main`: `iFrameRegExp` still points at `jilliandescribecompany.com`, a VOE domain that has since rotated, so the iframe script is never injected and no timestamps ever arrive. The cover is read from the cover box `src`, which AniWorld now fills with a 1x1 base64 placeholder until the image is scrolled into view.

**Playback**
- Match the embed path shapes the hosters use instead of chasing individual domains, and follow the nested frame Filemoon renders its player in. Checked against VOE, Doodstream, Filemoon and Vidmoly over both their entry and final domains, while the Facebook, Twitter, YouTube and DoubleClick frames on the page stay excluded.
- Pick the player by taking the first video element that reports a playable duration - every hoster ships its own player, and `video.jw-video` only ever matched VOE.
- Treat movie pages (`/anime/stream/<slug>/filme/film-<n>`) as playback; they previously fell through to the episode list branch.
- Drop iframe data that is no longer being refreshed, so switching episodes or closing the player no longer freezes the presence on the last position.

**Pages**
`/katalog/<letter>`, `/search`, `/support/frage/<slug>`, `/user/profil/<name>` and `/neue-episoden` had translated strings that were never used and showed the generic browsing status. `/support/frage/<slug>` was also swallowed by the `/support` entry, and `general.viewProfile` was left with its dangling colon.

**Settings**
- `detailsFormat` / `stateFormat` build both rows from `%anime%`, `%episodeTitle%`, `%progress%`, `%season%`, `%episode%` and `%movie%`. Placeholders without a value collapse together with their separator, and `%progress%` stays correct on movie pages. `{0}` drops the state row.
- `cover` picks between the logo and the Kitsu poster, cached per series slug. Covers hosted on aniworld.to are not offered: the URL the activity builds is correct and publicly reachable, but Discord leaves the large image blank instead of showing them.
- `displayType` sets `statusDisplayType`, `hidePaused` clears the activity instead of showing a paused presence.

While an episode is running the series page is offered as a second button; Discord allows two and only one was used.

Version 2.1.0 -> 2.4.0.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<img width="505" height="190" alt="image" src="https://github.com/user-attachments/assets/48af9fa5-5dff-4a00-89c8-af5e06f5b9cb" />
<img width="483" height="231" alt="image" src="https://github.com/user-attachments/assets/111828ff-028d-44fa-8601-5cd5d74e43bf" />
</details>
