### PR TITLE
fix(Jellyfin): Fix cache normalization

### DIFF
--- a/websites/J/Jellyfin/metadata.json
+++ b/websites/J/Jellyfin/metadata.json
@@ -22,7 +22,7 @@
   },
   "url": "jellyfin.org",
   "regExp": "^https?[:][/][/](jellyfin[.]org|.*[/]web[/](index[.]html)?#)[/]",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/J/Jellyfin/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/J/Jellyfin/assets/thumbnail.png",
   "color": "#00698c",

--- a/websites/J/Jellyfin/presence.ts
+++ b/websites/J/Jellyfin/presence.ts
@@ -169,13 +169,13 @@ async function obtainMediaInfo(itemId: string): Promise<MediaInfo | null> {
 }
 
 async function searchMedia(searchTerm: string): Promise<MediaInfo[]> {
-  if (searchMediaCache.has(searchTerm))
-    return searchMediaCache.get(searchTerm)!
-
   if (/- S\d+:E\d+ -/.test(searchTerm))
     searchTerm = searchTerm.split(' - ').pop() ?? ''
 
   searchTerm = searchTerm.replace(/\(\d{4}\)/, '').trim()
+
+  if (searchMediaCache.has(searchTerm))
+    return searchMediaCache.get(searchTerm)!
 
   try {
     const res = await fetch(


### PR DESCRIPTION
## Description
<!-- A clear and detailed description of the changes, referencing issues if applicable -->
Normalize media search terms before checking the cache to avoid cache miss and duplicate requests.
## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->

<img width="469" height="222" alt="Screenshot 2026-09-11 220719" src="https://github.com/user-attachments/assets/771f94ce-8c13-4ae7-8f67-1a235735de2f" />

<img width="1878" height="960" alt="Screenshot 2026-09-11 220943" src="https://github.com/user-attachments/assets/6ec067d9-63b8-453a-b06c-6d5f171c84ef" />

</details>
