### PR TITLE
feat(ClubDoDorama): add presence

### DIFF
--- a/websites/C/ClubDoDorama/metadata.json
+++ b/websites/C/ClubDoDorama/metadata.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schemas.premid.app/metadata/1.17",
+  "apiVersion": 1,
+  "author": {
+    "id": "582396294715408436",
+    "name": "lucas.mro"
+  },
+  "service": "ClubDoDorama",
+  "description": {
+    "en": "Show on Discord which drama you are watching on ClubDoDorama.",
+    "pt": "Mostre no Discord qual dorama você está assistindo no ClubDoDorama."
+  },
+  "url": "clubdodorama.com",
+  "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*clubdodorama[.]com[/]",
+  "version": "1.0.0",
+  "logo": "https://clubdodorama.com/wp-content/uploads/2025/04/CLUBDODORAMA.png",
+  "thumbnail": "https://clubdodorama.com/wp-content/uploads/2025/04/CLUBDODORAMA.png",
+  "color": "#000000",
+  "category": "videos",
+  "tags": [
+    "streaming",
+    "doramas",
+    "series",
+    "tv"
+  ]
+}

--- a/websites/C/ClubDoDorama/metadata.json
+++ b/websites/C/ClubDoDorama/metadata.json
@@ -13,8 +13,8 @@
   "url": "clubdodorama.com",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*clubdodorama[.]com[/]",
   "version": "1.0.0",
-  "logo": "https://clubdodorama.com/wp-content/uploads/2025/04/CLUBDODORAMA.png",
-  "thumbnail": "https://clubdodorama.com/wp-content/uploads/2025/04/CLUBDODORAMA.png",
+  "logo": "https://i.imgur.com/NG3A7fd.png",
+  "thumbnail": "https://i.imgur.com/NG3A7fd.png",
   "color": "#000000",
   "category": "videos",
   "tags": [

--- a/websites/C/ClubDoDorama/presence.ts
+++ b/websites/C/ClubDoDorama/presence.ts
@@ -21,7 +21,7 @@ presence.on('UpdateData', async () => {
 
   const presenceData: PresenceData = {
     type: ActivityType.Watching,
-    largeImageKey: 'https://i.imgur.com/uItlPhx.jpeg',
+    largeImageKey: 'https://i.imgur.com/NG3A7fd.png',
     largeImageText: 'ClubDoDorama',
     startTimestamp: browsingTimestamp,
   }
@@ -90,14 +90,14 @@ presence.on('UpdateData', async () => {
     presenceData.details = rawTitle
     presenceData.state = 'Vendo detalhes do dorama'
     presenceData.smallImageKey
-      = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f50d.png'
+      = 'https://i.imgur.com/eeVRVDN.png'
     presenceData.smallImageText = 'Navegando'
   }
   else {
     presenceData.details = 'Navegando no site'
     presenceData.state = 'Procurando o que assistir'
     presenceData.smallImageKey
-      = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f50d.png'
+      = 'https://i.imgur.com/eeVRVDN.png'
     presenceData.smallImageText = 'Navegando'
   }
 

--- a/websites/C/ClubDoDorama/presence.ts
+++ b/websites/C/ClubDoDorama/presence.ts
@@ -1,0 +1,105 @@
+import { ActivityType, Assets } from 'premid'
+
+const presence = new Presence({
+  clientId: '1534760108268064938',
+})
+
+// Guarda o momento em que começamos a "assistir" essa página,
+// já que o player é um iframe de terceiros (fsst.online) e não
+// dá pra ler o tempo real do vídeo por causa de CORS.
+let browsingTimestamp = Math.floor(Date.now() / 1000)
+let lastPath = ''
+
+presence.on('UpdateData', async () => {
+  const { pathname } = document.location
+
+  // Reseta o cronômetro sempre que troca de página/episódio
+  if (pathname !== lastPath) {
+    browsingTimestamp = Math.floor(Date.now() / 1000)
+    lastPath = pathname
+  }
+
+  const presenceData: PresenceData = {
+    type: ActivityType.Watching,
+    largeImageKey: 'https://i.imgur.com/uItlPhx.jpeg',
+    largeImageText: 'ClubDoDorama',
+    startTimestamp: browsingTimestamp,
+  }
+
+  const isEpisodePage = pathname.startsWith('/episodios/')
+  const isSeriesPage = pathname.startsWith('/series-de-tv/')
+  const isMoviePage = pathname.startsWith('/filmes/')
+
+  if (isEpisodePage) {
+    // Ex: "The Shadow Sovereign: 1x16"
+    const titleEl = document.querySelector('h1')
+    const rawTitle = titleEl?.textContent?.trim() ?? 'Dorama desconhecido'
+
+    // Busca "NxN" no final do título, evitando regex com backtracking ambíguo
+    const episodeMatch = rawTitle.match(/(\d+)x(\d+)\s*$/)
+
+    const poster = document.querySelector<HTMLImageElement>(
+      'img[src*="image.tmdb.org"]',
+    )?.src
+
+    if (episodeMatch) {
+      const season = episodeMatch[1]
+      const episode = episodeMatch[2]
+      const showName = rawTitle.slice(0, episodeMatch.index).replace(/:\s*$/, '').trim() || rawTitle
+      presenceData.name = showName
+      presenceData.details = `Assistindo: ${showName}`
+      presenceData.state = `Temporada ${season}, Episódio ${episode}`
+    }
+    else {
+      presenceData.name = rawTitle
+      presenceData.details = `Assistindo: ${rawTitle}`
+      presenceData.state = 'Episódio'
+    }
+
+    presenceData.smallImageKey = Assets.Play
+    presenceData.smallImageText = 'Assistindo'
+
+    if (poster) {
+      presenceData.largeImageKey = poster
+      presenceData.largeImageText = presenceData.details
+    }
+  }
+  else if (isMoviePage) {
+    const titleEl = document.querySelector('h1')
+    const rawTitle = titleEl?.textContent?.trim() ?? 'Filme desconhecido'
+
+    const poster = document.querySelector<HTMLImageElement>(
+      'img[src*="image.tmdb.org"]',
+    )?.src
+
+    presenceData.name = rawTitle
+    presenceData.details = `Assistindo: ${rawTitle}`
+    presenceData.state = 'Filme'
+    presenceData.smallImageKey = Assets.Play
+    presenceData.smallImageText = 'Assistindo'
+
+    if (poster) {
+      presenceData.largeImageKey = poster
+      presenceData.largeImageText = rawTitle
+    }
+  }
+  else if (isSeriesPage) {
+    const titleEl = document.querySelector('h1')
+    const rawTitle = titleEl?.textContent?.trim() ?? 'Dorama desconhecido'
+
+    presenceData.details = rawTitle
+    presenceData.state = 'Vendo detalhes do dorama'
+    presenceData.smallImageKey
+      = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f50d.png'
+    presenceData.smallImageText = 'Navegando'
+  }
+  else {
+    presenceData.details = 'Navegando no site'
+    presenceData.state = 'Procurando o que assistir'
+    presenceData.smallImageKey
+      = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f50d.png'
+    presenceData.smallImageText = 'Navegando'
+  }
+
+  presence.setActivity(presenceData)
+})

--- a/websites/C/ClubDoDorama/tsconfig.json
+++ b/websites/C/ClubDoDorama/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  }
+}


### PR DESCRIPTION
## Description
Adds Rich Presence support for ClubDoDorama (clubdodorama.com), a Korean/Asian drama streaming site.

The presence detects three types of pages:
- Episode pages: shows "Watching: Drama Name" with the current season and episode
- Movie pages: shows "Watching: Movie Name"
- Series detail pages: shows that the person is viewing that drama's details
- General browsing: shows a generic "browsing the site" message

When available, it uses the drama/movie poster (via TMDB) as the large image. The drama/movie name is also used in the "name" field, so it shows up next to the activity icon on Discord instead of the application name.

Note: the site's video player is a third-party iframe, so it isn't possible to read the exact video progress (play/pause/time) due to browser CORS restrictions. Because of that, the timestamp shown is based on when the person opened the page, not the actual video playback time.

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="1920" height="1080" alt="Screenshot_112" src="https://github.com/user-attachments/assets/8cd24dd8-38d5-48cb-987f-85948c0756b9" />
<img width="1920" height="1080" alt="Screenshot_113" src="https://github.com/user-attachments/assets/29a37869-40d1-4dc1-912a-3506d5206fe2" />
<img width="1920" height="1080" alt="Screenshot_114" src="https://github.com/user-attachments/assets/47697d3c-dfc3-4024-a6a3-8f15334c4544" />




</details>
