### PR TITLE
fix(WeTV): show drama name as activity name.

### DIFF
--- a/websites/W/WeTV/metadata.json
+++ b/websites/W/WeTV/metadata.json
@@ -17,7 +17,7 @@
   },
   "url": "wetv.vip",
   "regExp": "^https?[:][/][/]([a-z0-9-]+[.])*wetv[.]vip[/]",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "logo": "https://cdn.rcd.gg/PreMiD/websites/W/WeTV/assets/logo.png",
   "thumbnail": "https://cdn.rcd.gg/PreMiD/websites/W/WeTV/assets/thumbnail.png",
   "color": "#ffffff",

--- a/websites/W/WeTV/presence.ts
+++ b/websites/W/WeTV/presence.ts
@@ -50,6 +50,10 @@ presence.on('UpdateData', async () => {
         'div.play-sidebar__title',
       )?.textContent
 
+      // Mostra o nome do dorama no lugar do nome da aplicação
+      // (ao lado do ícone da atividade no Discord)
+      presenceData.name = presenceData.details
+
       presenceData.state = episodeNumber
         ? `Episode ${Number.parseInt(episodeNumber.textContent ?? '')}`
         : episodeTitle


### PR DESCRIPTION
## Description
I added the "name" field to presenceData when a video is being watched. This makes Discord show the name of the drama/series being watched in the text next to the activity icon, instead of the fixed "WeTV" label — making it clearer what the person is watching, similar to what other presences (like Netflix's) already do.

I also bumped the version in metadata.json from 2.1.1 to 2.1.2, since this is a small adjustment to presence.ts.

Related #10208

## Acknowledgements
- [x] I read the [Activity Guidelines](https://github.com/PreMiD/Activities/blob/main/.github/CONTRIBUTING.md)
- [x] I linted the code by running `npm run lint`
- [x] The PR title follows the repo's [commit conventions](https://github.com/PreMiD/Activities/blob/main/.github/COMMIT_CONVENTION.md)

## Screenshots
<details>
<summary> Proof showing the creation/modification is working as expected </summary>
<!--
    Screenshots of the activity settings (if applicable) and at least TWO screenshots of the activity displaying correctly
    Including these screenshots will assist the reviewing processes thus speeding up the process of the pull request being merged
-->
<img width="1920" height="1080" alt="Screenshot_115" src="https://github.com/user-attachments/assets/7735e16d-ecde-41bd-83ae-9b2d6b950636" />
<img width="1920" height="1080" alt="Screenshot_116" src="https://github.com/user-attachments/assets/a1bf1d7a-6fc2-47df-84f2-f6f163fa4e5c" />




</details>
